### PR TITLE
include lfa dependency via bioconductor

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,5 +8,6 @@ Maintainer: Satija Lab <seuratpackage@gmail.com>
 URL: http://www.satijalab.org/seurat
 Depends: R (>= 3.1.0), ggplot2, reshape2, useful, gridExtra, gplots, gdata
 Imports: ROCR, stringr, mixtools, lars, fastICA, tsne, Rtsne, fpc, ape, VGAM, jackstraw, XLConnect
+biocViews: lfa
 License: GPL 3.0
 


### PR DESCRIPTION
Will require the user to first run `source("https://bioconductor.org/biocLite.R")` in order to get the current BiocInstaller. 