### PR TITLE
Update to FindMarkers

### DIFF
--- a/R/seurat.R
+++ b/R/seurat.R
@@ -1947,20 +1947,24 @@ setMethod("FindMarkers", "seurat",
             genes.use=set.ifnull(genes.use, rownames(object@data))
             
             if (max.cells.per.ident < Inf) object=SubsetData(object,max.cells.per.ident = max.cells.per.ident,random.seed = random.seed)
-            cells.1=WhichCells(object,ident.1)
             # in case the user passed in cells instead of identity classes
             if (length(as.vector(ident.1) > 1) && any(as.character(ident.1) %in% object@cell.names)) {
               cells.1=ainb(ident.1,object@cell.names)
+            } else {
+            cells.1=WhichCells(object,ident.1)
             }
+              
+            
             # if NULL for ident.2, use all other cells
-            if (is.null(ident.2)) {
-              cells.2=object@cell.names
-            }
-            else {
-              cells.2=WhichCells(object, ident = ident.2)
-            }
             if (length(as.vector(ident.2) > 1) && any(as.character(ident.2) %in% object@cell.names)) {
               cells.2=ainb(ident.2,object@cell.names)
+            } else {
+              if (is.null(ident.2)) {
+               cells.2=object@cell.names
+              }
+             else {
+               cells.2=WhichCells(object, ident = ident.2)
+             }
             }
             cells.2=anotinb(cells.2,cells.1)
 


### PR DESCRIPTION
The FindMarkers code has a useful line that allows a user to pass cell names, instead of an identity class, to the "ident.1" and "ident.2" parameters. As the code is currently written, if a user passes cell names, an error will be thrown because of "cells.1=WhichCells(object,ident.1)" before that useful line of code is ever reached. I have changed the order of the two lines and added an if/else to fix the bug.