### PR TITLE
Fix subscript out of bounds in FindAllMarkers

### DIFF
--- a/R/seurat.R
+++ b/R/seurat.R
@@ -713,8 +713,8 @@ setMethod("FindAllMarkersNode","seurat",
                       }
                       gde.all=data.frame()
                       for(i in ((tree.use$Nnode+2):max(tree.use$edge))) {
+                        if (is.null(unlist(genes.de[i]))) next;
                         gde=genes.de[[i]]
-                        if (is.null(gde)) next;
                         if (nrow(gde)>0) {
                           if (test.use=="roc") gde=subset(gde,(myAUC>return.thresh|myAUC<(1-return.thresh)))
                           if ((test.use=="bimod")||(test.use=="t")) {
@@ -2074,8 +2074,8 @@ FindAllMarkers <- function(object, genes.use = NULL, thresh.use = 0.25, test.use
             }
             gde.all=data.frame()
             for(i in 1:length(idents.all)) {
+              if (is.null(unlist(genes.de[i]))) next;
               gde=genes.de[[i]]
-              if (is.null(gde)) next;
               if (nrow(gde)>0) {
                 if (test.use=="roc") {
                   gde=subset(gde,(myAUC>return.thresh|myAUC<(1-return.thresh)))


### PR DESCRIPTION
Hi, I noticed this error when running FindAllMarkers:

```
Error in genes.de[[i]] : subscript out of bounds
Calls: FindAllMarkers
Execution halted
```

This is due to FindAllMarkers checking if each each entry is null before trying to do something with it, but if the final cluster is null, then nothing gets added to the `genes.de` list. Here's an example:


```r
my_list <- list()
my_list[[1]] <- 1
my_list[[2]] <- NULL
my_list[[3]] <- 3
print(my_list)
```

```
## [[1]]
## [1] 1
## 
## [[2]]
## NULL
## 
## [[3]]
## [1] 3
```

All fine. Now, if the last entry is null:


```r
my_list[[4]] <- NULL
print(my_list)
```

```
## [[1]]
## [1] 1
## 
## [[2]]
## NULL
## 
## [[3]]
## [1] 3
```

There's no `my_list[[4]]`, so the later check (`is.null(gde.gene[[i]])`) gives subscript out of bounds, not `TRUE` as expected.

If you use `my_list[4]` instead, you don't get this error:


```r
is.null(unlist(my_list[4]))
```

```
## [1] TRUE
```

This seemed like the simplest solution.

Tim