### PR TITLE
unquote variable for use in dplyr::gather

### DIFF
--- a/R/plotting.R
+++ b/R/plotting.R
@@ -1131,7 +1131,7 @@ FeatureHeatmap <- function(
   data.plot$ident <- as.character(x = object@ident)
   data.plot$cell <- rownames(x = data.plot)
   features.plot <- gsub('-', '\\.', features.plot)
-  data.plot  %>% gather(gene, expression, features.plot, -dim1, -dim2, -ident, -cell) -> data.plot
+  data.plot  %>% gather(gene, expression, !!features.plot, -dim1, -dim2, -ident, -cell) -> data.plot
   if (sep.scale) {
     data.plot %>% group_by(ident, gene) %>% mutate(scaled.expression = scale(expression)) -> data.plot
   } else {


### PR DESCRIPTION
Ran into this error when running FeatureHeatmap:

```r
dat <- readRDS("aligned.Rdata")
FeatureHeatmap(dat, features.plot = "XCP1")
Error in FUN(X[[i]], ...) : object 'features.plot' not found
```

Simple 2 character fix, unquoting `features.plot` in the `FeatureHeatmap` function.

Although, this function was working for me previously and I haven't been able to work out what changed in Seurat to produce the error, so someone may want to verify they get the same error when running FeatureHeatmap before merging.
