### PR TITLE
fix for issue #188

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -587,7 +587,7 @@ AverageExpression <- function(
       }
       if (length(x = temp.cells) >1 ) {
         data.temp <- apply(
-          X = data.use[genes.assay, temp.cells],
+          X = data.use[genes.assay, temp.cells, drop = F],
           MARGIN = 1,
           FUN = fxn.average
         )

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -587,7 +587,7 @@ AverageExpression <- function(
       }
       if (length(x = temp.cells) >1 ) {
         data.temp <- apply(
-          X = data.use[genes.assay, temp.cells, drop = F],
+          X = data.use[genes.assay, temp.cells, drop = FALSE],
           MARGIN = 1,
           FUN = fxn.average
         )


### PR DESCRIPTION
Allows AverageExpression() to work even when only one gene is provided. By adding "drop = F" the matrix structure of data.temp is maintained even though it only has one row (default would be for its structure to change from a matrix to a vector), allowing data.temp to be successfully passed as an argument to the apply function.