### PR TITLE
change x-axis label rot to 45 degree

### DIFF
--- a/R/plotting_internal.R
+++ b/R/plotting_internal.R
@@ -683,7 +683,7 @@ SingleVlnPlot <- function(
     plot <- plot + scale_fill_manual(values = cols.use)
   }
   if (x.lab.rot) {
-    plot <- plot + theme(axis.text.x = element_text(angle = 90, vjust = 0.5))
+    plot <- plot + theme(axis.text.x = element_text(angle = 45, hjust = 1))
   }
   if (y.lab.rot) {
     plot <- plot + theme(axis.text.x = element_text(angle = 90))


### PR DESCRIPTION
For the x-axis labels in VlnPlot: ability to rotate labels is important for making them fit, but my personal opinion is that a 45 degree rotation is more legible than the 90 degree rotation (which requires viewers to tilt their heads to read)