### PR TITLE
pch.use not passed to ggplot in FeatureHeatmap

### DIFF
--- a/R/plotting.R
+++ b/R/plotting.R
@@ -1215,7 +1215,7 @@ FeatureHeatmap <- function(
     key.title.pos <- "left"
   }
   p <- ggplot(data = data.plot, mapping = aes(x = dim1, y = dim2)) +
-    geom_point(mapping = aes(colour = scaled.expression), size = pt.size)
+    geom_point(mapping = aes(colour = scaled.expression), size = pt.size, shape = pch.use)
   if (rotate.key) {
     p <- p + scale_colour_gradient(
       low = cols.use[1],


### PR DESCRIPTION
Shape of points argument is not passed to ggplot in FeatureHeatmap.