### PR TITLE
Updating AddModuleScore function

### DIFF
--- a/R/scoring.R
+++ b/R/scoring.R
@@ -13,6 +13,7 @@
 #' @param ctrl.size Number of control genes selected from the same bin per analyzed gene
 #' @param use.k Use gene clusters returned from DoKMeans()
 #' @param enrich.name Name for the expression programs
+#' @param random.seed Set a random seed
 #'
 #' @return Returns a Seurat object with module scores added to object@meta.data
 #'

--- a/R/scoring.R
+++ b/R/scoring.R
@@ -56,8 +56,10 @@ AddModuleScore <- function(
   seed.use = 1,
   ctrl.size = 100,
   use.k = FALSE,
-  enrich.name = "Cluster"
+  enrich.name = "Cluster",
+  random.seed = 1
 ) {
+  set.seed(seed = random.seed) 
   genes.old <- genes.list
   if (use.k) {
     genes.list <- list()
@@ -100,7 +102,7 @@ AddModuleScore <- function(
   }
   data.avg <- apply(X = object@data[genes.pool,], MARGIN = 1, FUN = mean)
   data.avg <- data.avg[order(data.avg)]
-  data.cut <- as.numeric(x = cut2(
+  data.cut <- as.numeric(x = Hmisc::cut2(
     x = data.avg,
     m = round(x = length(x = data.avg) / n.bin)
   ))
@@ -131,9 +133,14 @@ AddModuleScore <- function(
   genes.scores <- c()
   for (i in 1:cluster.length) {
     genes.use <- genes.list[[i]]
+    if (length(genes.use) == 1) {
+      data.use <- t(as.matrix(object@data[genes.use, ]))
+    } else {
+      data.use <- object@data[genes.use, ]
+    }
     genes.scores <- rbind(
       genes.scores,
-      apply(X = object@data[genes.use, ], MARGIN = 2, FUN = mean)
+      apply(X = data.use, MARGIN = 2, FUN = mean)
     )
   }
 


### PR DESCRIPTION
Hello,

An [issue](https://github.com/satijalab/seurat/issues/248) was raised several days ago related to the `AddModuleScore()` function. I have checked the script, and found that for `genes.scores` ( see [lines 133 to 137](https://github.com/satijalab/seurat/blob/cec7cb95c73fd6d605723e9af9a1f96eda5635de/R/scoring.R#L133-L137)), the `apply()` function was being applied on the columns of a numeric vector, therefore throwing the following error:

```
Error in apply(X = object@data[genes.use, ], MARGIN = 2, FUN = mean) : 
  dim(X) must have a positive length
```

I have therefore specified that if `genes.use` is formed of a single element, the data to be used on which the function should be applied is a transposition of a matrix of the subsetted data. Otherwise, the subsetted data is used:

```
if (length(genes.use) == 1) {
  data.use <- t(as.matrix(object@data[genes.use, ]))
} else {
  data.use <- object@data[genes.use, ]
}
genes.scores <- rbind(
  genes.scores,
  apply(X = data.use, MARGIN = 2, FUN = mean)
)
```

I have also modified two things:

1. I have explicitly specified the package `Hmisc` for the `cut2()` function, as this was throwing me an error while troubleshooting. I know that this is handled when the function is executed through Seurat, but this modification does not make any difference to the normal execution of the function.
2. Provided that the `sample()` function is used to sample `ctrl.use` (see [lines 112 to 119](url)), I have specified a seed value (`random.seed` argument) as input to the function. This way, we can ensure reproducibility, and people who are willing to try other seed values can do so. 

Best,
Leon