### PR TITLE
Plot gradient legends in SplitDotPlotGG()

### DIFF
--- a/R/plotting.R
+++ b/R/plotting.R
@@ -862,8 +862,8 @@ SplitDotPlotGG <- function(
     levels = rev(x = sub(pattern = "-", replacement = ".", x = genes.plot))
   )
   data.to.plot$pct.exp[data.to.plot$pct.exp < dot.min] <- NA
-  palette.1 <- CustomPalette(low = "grey", high = "blue", k = 20)
-  palette.2 <- CustomPalette(low = "grey", high = "red", k = 20)
+  palette.1 <- CustomPalette(low = "grey", high = cols.use[1], k = 20)
+  palette.2 <- CustomPalette(low = "grey", high = cols.use[2], k = 20)
   data.to.plot$ptcolor <- "grey"
   data.to.plot[vals.1, "ptcolor"] <- palette.1[as.matrix(
     x = data.to.plot[vals.1, "avg.exp.scale"]
@@ -895,11 +895,22 @@ SplitDotPlotGG <- function(
         strip.placement = "outside"
       )
   }
-  if (! plot.legend) {
-    p <- p + theme(legend.position = "none")
-  }
   if (x.lab.rot) {
     p <- p + theme(axis.text.x = element_text(angle = 90, vjust = 0.5))
+  }
+  if (! plot.legend) {
+    p <- p + theme(legend.position = "none")
+  } else if (plot.legend) {
+  # Get legend from plot
+  plot.legend <- cowplot::get_legend(plot = p)
+  # Get gradient legends from both palettes
+  gradient.legends <- mapply(FUN = GetGradientLegend, palette = list(palette.1, palette.2), g = list(1,2), SIMPLIFY = F, USE.NAMES = F)
+  # Remove legend from p
+  p <- p + theme(legend.position = "none")
+  # Arrange legends using plot_grid
+  legends <- cowplot::plot_grid(gradient.legends[[1]], gradient.legends[[2]], plot.legend, ncol = 1, nrow = 3, rel_heights = c(0.5, 0.5, 1), scale = c(0.5, 0.5, 0.5), align = "hv")
+  # Arrange plot and legends using plot_grid
+  p <- cowplot::plot_grid(p, legends, ncol = 2, rel_widths = c(1, 0.3), scale = c(1, 0.8))
   }
   suppressWarnings(print(p))
   if (do.return) {

--- a/R/plotting.R
+++ b/R/plotting.R
@@ -904,7 +904,7 @@ SplitDotPlotGG <- function(
   # Get legend from plot
   plot.legend <- cowplot::get_legend(plot = p)
   # Get gradient legends from both palettes
-  gradient.legends <- mapply(FUN = GetGradientLegend, palette = list(palette.1, palette.2), g = list(1,2), SIMPLIFY = F, USE.NAMES = F)
+  gradient.legends <- mapply(FUN = GetGradientLegend, palette = list(palette.1, palette.2), g = list(unique(grouping.data)), SIMPLIFY = F, USE.NAMES = F)
   # Remove legend from p
   p <- p + theme(legend.position = "none")
   # Arrange legends using plot_grid

--- a/R/plotting.R
+++ b/R/plotting.R
@@ -904,7 +904,7 @@ SplitDotPlotGG <- function(
   # Get legend from plot
   plot.legend <- cowplot::get_legend(plot = p)
   # Get gradient legends from both palettes
-  gradient.legends <- mapply(FUN = GetGradientLegend, palette = list(palette.1, palette.2), g = list(unique(grouping.data)), SIMPLIFY = F, USE.NAMES = F)
+  gradient.legends <- mapply(FUN = GetGradientLegend, palette = list(palette.1, palette.2), g = as.list(unique(grouping.data)), SIMPLIFY = F, USE.NAMES = F)
   # Remove legend from p
   p <- p + theme(legend.position = "none")
   # Arrange legends using plot_grid

--- a/R/plotting.R
+++ b/R/plotting.R
@@ -904,7 +904,7 @@ SplitDotPlotGG <- function(
   # Get legend from plot
   plot.legend <- cowplot::get_legend(plot = p)
   # Get gradient legends from both palettes
-  gradient.legends <- mapply(FUN = GetGradientLegend, palette = list(palette.1, palette.2), g = as.list(unique(grouping.data)), SIMPLIFY = F, USE.NAMES = F)
+  gradient.legends <- mapply(FUN = GetGradientLegend, palette = list(palette.1, palette.2), group = as.list(unique(grouping.data)), SIMPLIFY = F, USE.NAMES = F)
   # Remove legend from p
   p <- p + theme(legend.position = "none")
   # Arrange legends using plot_grid


### PR DESCRIPTION
Hi again,

I updated the `SplitDotPlotGG()` function, such that now one can plot gradient legends for each of the 2 conditions, hence bypassing the need to pass by Adobe Illustrator to generate such gradient legends. This pull request is linked to [#306](https://github.com/satijalab/seurat/pull/306). 

Along the way, I also found that the `cols.use` argument was not passed to the function. The function previously produced gradient colours from grey to blue for the first condition, and from grey to red for the second condition. This is now fixed in the new version of the function. 

Best,
Leon