### PR TITLE
Fixing compatibility of RegressOutNBreg for input of class 'data.frame'

### DIFF
--- a/R/preprocessing_internal.R
+++ b/R/preprocessing_internal.R
@@ -346,7 +346,8 @@ RegressOutNBreg <- function(
       }
     )
     # Print message to keep track of the genes for which glm failed to converge
-    message(paste(unlist(x = lapply(X = bin.pr.lst, FUN = function(l) { return(l$message) }), use.names = FALSE), collapse = "\n"))
+    message <- unlist(x = lapply(X = bin.pr.lst, FUN = function(l) { return(l$message) }), use.names = FALSE)
+    if(!is.null(x = message)) { message(paste(message, collapse = "\n")) }
     bin.pr.lst <- lapply(X = bin.pr.lst, FUN = function(l) { return(l$res) })
     pr <- rbind(pr, do.call(rbind, bin.pr.lst))
     setTxtProgressBar(pb, i)


### PR DESCRIPTION
Hi,

I have slightly changed the code of `Seurat::RegressOutNBreg()` in such a way to make it compatible with `object@raw.data` of class `'data.frame'`. 

Briefly, when `MASS::theta.ml()`, `stats::glm()` or `base::scale()` were being computed on `cm[j,]`, if `object@raw.data` was of class `'data.frame'`, `cm[j,]` was also a data frame, which returned either an error (for `MASS::theta.ml()` or `stats::glm()`) or `NA` (for `base::scale()`, because scaling was being computed on columns with a single value). 

Also, provided that the code uses parallel processing (through `parallel::mclapply()`), the warning message that is thrown for genes for which model convergence failed (namely, `'glm and family=negative.binomial(theta=%f) failed for gene %s; falling back to scale(log10(y+1))'`) was omitted. With a slight tweaking, now the function returns this message. 

Best,
Leon