### PR TITLE
Updating PrintTSNEParams

### DIFF
--- a/R/printing_utilities.R
+++ b/R/printing_utilities.R
@@ -199,7 +199,6 @@ PrintTSNEParams <- function(object, raw = FALSE){
                             parameter = "time"),
                "\n"))
     cat("=============================================================================\n")
-    
     if(is.null(GetCalcParam(object = object,
                             calculation = "RunTSNE",
                             parameter = "genes.use"))) {

--- a/R/printing_utilities.R
+++ b/R/printing_utilities.R
@@ -192,15 +192,14 @@ PrintTSNEParams <- function(object, raw = FALSE){
   }
   if (raw){
     print(object@calc.params$RunTSNE)
-  }
-  else{
+  } else{
     cat(paste0("Parameters used in latest TSNE calculation run on: ",
                GetCalcParam(object = object,
                             calculation = "RunTSNE",
                             parameter = "time"),
                "\n"))
     cat("=============================================================================\n")
-
+    
     if(is.null(GetCalcParam(object = object,
                             calculation = "RunTSNE",
                             parameter = "genes.use"))) {
@@ -223,18 +222,18 @@ PrintTSNEParams <- function(object, raw = FALSE){
                                    calculation = "RunTSNE",
                                    parameter = "genes.use"))
     }
-    do.fast <- GetCalcParam(object = object,
+    tsne.method <- GetCalcParam(object = object,
                             calculation = "RunTSNE",
-                            parameter = "do.fast")
+                            parameter = "tsne.method")
     dim.embed <- GetCalcParam(object = object,
                               calculation = "RunTSNE",
                               parameter = "dim.embed")
-    cat(paste0("Reduction use          do.fast          dim.embed\n"))
+    cat(paste0("Reduction use          tsne.method          dim.embed\n"))
     cat(paste0("     ",
                reduction,
-               FillWhiteSpace(n = 19 - nchar(reduction)),
-               do.fast,
-               FillWhiteSpace(n = 20 - nchar(do.fast)),
+               FillWhiteSpace(n = 21 - nchar(reduction)),
+               tsne.method,
+               FillWhiteSpace(n = 22 - nchar(tsne.method)),
                dim.embed,
                "\n"))
     cat("-----------------------------------------------------------------------------\n")

--- a/R/printing_utilities.R
+++ b/R/printing_utilities.R
@@ -184,6 +184,7 @@ PrintICAParams <- function(object, raw = FALSE){
 #' @export
 #'
 #' @examples
+#' pbmc_small <- RunTSNE(pbmc_small, perplexity = 10)
 #' PrintTSNEParams(object = pbmc_small)
 #'
 PrintTSNEParams <- function(object, raw = FALSE){

--- a/man/PrintTSNEParams.Rd
+++ b/man/PrintTSNEParams.Rd
@@ -19,6 +19,7 @@ No return value. Only prints to console.
 Print the parameters chosen for the latest stored TSNE calculation.
 }
 \examples{
+pbmc_small <- RunTSNE(pbmc_small, perplexity = 10)
 PrintTSNEParams(object = pbmc_small)
 
 }


### PR DESCRIPTION
Hello,

I have updated the `Seurat::PrintTSNEParams()` function to support the new argument of the `Seurat::RunTSNE()` function. Briefly, the `do.fast` argument has been replaced by `tsne.method`, which led to the following error:

```R
> Seurat::PrintTSNEParams(object = object, raw = FALSE) # print tSNE calculation parameters
Parameters used in latest TSNE calculation run on: 2018-03-27 23:20:53
=============================================================================
Reduction use          do.fast          dim.embed
Error in if (n <= 0) { : argument is of length zero
```

Now, the function prints the expected output:

```R
> PrintTSNEParams(object = object, raw = FALSE) # print tSNE calculation parameters
Parameters used in latest TSNE calculation run on: 2018-03-27 23:20:53
=============================================================================
Reduction use          tsne.method          dim.embed
     pca                  Rtsne                 2
-----------------------------------------------------------------------------
Dims used in calculation
=============================================================================
1 2 3 4 5 6 7 9 11 12 13 14 15 16 19 20 22 23 25 28 34 35 37 44 48 51 55 56 60
61 65 
```

Best,
Leon