### PR TITLE
Output numeric prop.test p-values from JackStrawPlot()

### DIFF
--- a/R/jackstraw_internal.R
+++ b/R/jackstraw_internal.R
@@ -4,7 +4,8 @@ jackstraw.data <- setClass(
   slots = list(
     emperical.p.value = "matrix",
     fake.pc.scores = "matrix",
-    emperical.p.value.full = "matrix"
+    emperical.p.value.full = "matrix",
+    overall.p.values = "matrix"
   )
 )
 

--- a/R/plotting.R
+++ b/R/plotting.R
@@ -1533,6 +1533,10 @@ JackStrawPlot <- function(
     x = pAll.l$PC.Score,
     levels = paste0(score.df$PC, " ", sprintf("%1.3g", score.df$Score))
   )
+  pAll.l$p.val <- rep(
+    x = score.df$Score,
+    each = length(x = unique(x = pAll.l$Contig))
+  )
   gp <- ggplot(data = pAll.l, mapping = aes(sample=Value)) +
     stat_qq(distribution = qunif) +
     facet_wrap("PC.Score", ncol = nCol) +

--- a/R/plotting.R
+++ b/R/plotting.R
@@ -1533,10 +1533,11 @@ JackStrawPlot <- function(
     x = pAll.l$PC.Score,
     levels = paste0(score.df$PC, " ", sprintf("%1.3g", score.df$Score))
   )
-  pAll.l$p.val <- rep(
-    x = score.df$Score,
-    each = length(x = unique(x = pAll.l$Contig))
-  )
+
+  score.df$PC <- PCs
+  score.df <- as.matrix(score.df)
+  object@dr$pca@jackstraw@overall.p.values <- score.df
+
   gp <- ggplot(data = pAll.l, mapping = aes(sample=Value)) +
     stat_qq(distribution = qunif) +
     facet_wrap("PC.Score", ncol = nCol) +


### PR DESCRIPTION
Hi,

This fix outputs in the `data` slot from the `ggplot2` object the numeric p-values from the `prop.test` performed by `Seurat::JackStrawPlot()`. This facilitates the indexing of PCs for downstream analysis using automated code lines.

Best,
Leon