### PR TITLE
Preserve dimnames when downsampling UMIs.

### DIFF
--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -672,8 +672,8 @@ SampleUMI <- function(
     upsample = upsample,
     display_progress = progress.bar
   )
-  dimnames(new_data) = dimnames(data)
-  return( new_data ) 
+  dimnames(new_data) <- dimnames(data)
+  return(new_data) 
 }
 
 #' Identify variable genes

--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -666,14 +666,14 @@ SampleUMI <- function(
   } else if (length(x = max.umi) != ncol(x = data)) {
     stop("max.umi vector not equal to number of cells")
   }
-  return(
-    RunUMISamplingPerCell(
-      data = data,
-      sample_val = max.umi,
-      upsample = upsample,
-      display_progress = progress.bar
-    )
+  new_data = RunUMISamplingPerCell(
+    data = data,
+    sample_val = max.umi,
+    upsample = upsample,
+    display_progress = progress.bar
   )
+  dimnames(new_data) = dimnames(data)
+  return( new_data ) 
 }
 
 #' Identify variable genes


### PR DESCRIPTION
This fixes #425 .