### PR TITLE
Add as() method for seurat <-> SCE conversions

### DIFF
--- a/R/conversion.R
+++ b/R/conversion.R
@@ -218,6 +218,8 @@ Convert.seurat <- function(
   return(object.to)
 }
 
+setAs("seurat", "SingleCellExperiment", function(from) Convert(from, "sce"))
+
 #' @param raw.data.slot name of the SingleCellExperiment assay to slot into @@raw.data
 #' @param data.slot name of the SingleCellExperiment assay to slot into @@data
 #'
@@ -267,3 +269,5 @@ Convert.SingleCellExperiment <- function(
   )
   return(object.to)
 }
+
+setAs("SingleCellExperiment", "seurat", function(from) Convert(from, "seurat"))


### PR DESCRIPTION
Makes for a slightly more R/Bioconductor-flavoured conversion method

``` r
library(seurat)
data("pbmc_small")
sce <- as(pbmc_small, "SingleCellExperiment")
sce
#> class: SingleCellExperiment 
#> dim: 230 80 
#> metadata(0):
#> assays(2): counts logcounts
#> rownames(230): MS4A1 CD79B ... SPON2 S100B
#> rowData names(4): gene gene.mean gene.dispersion
#>   gene.dispersion.scaled
#> colnames(80): ATGCCAGAACGACT CATGGCCTGTGCAT ... GGAACACTTCAGAC
#>   CTTGATTGATCTTC
#> colData names(6): nGene nUMI ... res.1 ident
#> reducedDimNames(2): PCA TSNE
#> spikeNames(0):
as(sce, "seurat")
#> An object of class seurat in project SeuratProject 
#>  230 genes across 80 samples.
```

Created on 2018-04-26 by the [reprex package](http://reprex.tidyverse.org) (v0.2.0).