### PR TITLE
Warn when increasing num.cores

### DIFF
--- a/R/jackstraw.R
+++ b/R/jackstraw.R
@@ -93,6 +93,7 @@ JackStraw <- function(
   if (do.par) {
     if (num.cores == 1) {
       num.cores <- detectCores() / 2
+      warning(paste0("do.par set to TRUE but num.cores set to 1. Setting num.cores to ", num.cores, "."))
     } else {
       if (num.cores > detectCores()) {
         num.cores <- detectCores() - 1

--- a/R/jackstraw.R
+++ b/R/jackstraw.R
@@ -94,17 +94,13 @@ JackStraw <- function(
     if (num.cores == 1) {
       num.cores <- detectCores() / 2
       warning(paste0("do.par set to TRUE but num.cores set to 1. Setting num.cores to ", num.cores, "."))
-    } else {
-      if (num.cores > detectCores()) {
-        num.cores <- detectCores() - 1
-        warning(paste0("num.cores set greater than number of available cores(", detectCores(), "). Setting num.cores to ", num.cores, "."))
-      }
+    } else if (num.cores > detectCores()) {
+      num.cores <- detectCores() - 1
+      warning(paste0("num.cores set greater than number of available cores(", detectCores(), "). Setting num.cores to ", num.cores, "."))
     }
-  } else {
-    if (num.cores != 1) {
+  } else if (num.cores != 1) {
       num.cores <- 1
       warning("For parallel processing, please set do.par to TRUE.")
-    }
   }
 
   cl <- parallel::makeCluster(num.cores)

--- a/R/jackstraw.R
+++ b/R/jackstraw.R
@@ -16,6 +16,8 @@
 #' If set to TRUE, will use half of the machines available cores (FALSE by default)
 #' @param num.cores If do.par = TRUE, specify the number of cores to use.
 #' Note that for higher number of cores, larger free memory is needed.
+#' If \code{num.cores = 1} and \code{do.par = TRUE}, \code{num.cores} will be set to half
+#' of all available cores on the machine.
 #' @param maxit maximum number of iterations to be performed by the irlba function of RunPCA
 #'
 #' @return Returns a Seurat object where object@@dr$pca@@jackstraw@@emperical.p.value

--- a/man/JackStraw.Rd
+++ b/man/JackStraw.Rd
@@ -24,7 +24,9 @@ that have been processed.}
 If set to TRUE, will use half of the machines available cores (FALSE by default)}
 
 \item{num.cores}{If do.par = TRUE, specify the number of cores to use.
-Note that for higher number of cores, larger free memory is needed.}
+Note that for higher number of cores, larger free memory is needed.
+If \code{num.cores = 1} and \code{do.par = TRUE}, \code{num.cores} will be set to half
+of all available cores on the machine.}
 
 \item{maxit}{maximum number of iterations to be performed by the irlba function of RunPCA}
 }


### PR DESCRIPTION
When setting `do.par = TRUE` but `num.cores = 1`, `JackStraw` interprets this to use half of the available cores.
While this seems to be intended it is not documented and might cause confusion, so I figured a warning would be fair.
The same is already done when specifying more cores than available, so this also increases consistency.