### PR TITLE
Update JackStrawPlot to return Seurat object instead of plot

### DIFF
--- a/R/plotting.R
+++ b/R/plotting.R
@@ -1544,7 +1544,9 @@ globalVariables(names = 'Value', package = 'Seurat', add = TRUE)
 #' @param plot.x.lim X-axis maximum on each QQ plot.
 #' @param plot.y.lim Y-axis maximum on each QQ plot.
 #'
-#' @return A ggplot object
+#' @return Returns a Seurat object where object@@dr$pca@@jackstraw@@overall.p.values
+#' represents p-values for each PC and object@@dr$pca@@misc$jackstraw.plot 
+#' stores the ggplot2 plot.
 #'
 #' @author Thanks to Omri Wurtzel for integrating with ggplot
 #'
@@ -1569,7 +1571,7 @@ JackStrawPlot <- function(
   pAll <- pAll[, PCs, drop = FALSE]
   pAll <- as.data.frame(pAll)
   pAll$Contig <- rownames(x = pAll)
-  pAll.l <- melt(data = pAll, id.vars = "Contig")
+  pAll.l <- reshape2::melt(data = pAll, id.vars = "Contig")
   colnames(x = pAll.l) <- c("Contig", "PC", "Value")
   qq.df <- NULL
   score.df <- NULL
@@ -1620,7 +1622,11 @@ JackStrawPlot <- function(
     coord_flip() +
     geom_abline(intercept = 0, slope = 1, linetype = "dashed", na.rm = TRUE) +
     theme_bw()
-  return(gp)
+  
+  object@dr$pca@misc[["jackstraw.plot"]] <- gp
+  print(gp)
+  
+  return(object)
 }
 
 globalVariables(names = c('x', 'y'), package = 'Seurat', add = TRUE)


### PR DESCRIPTION
Hi,

Related to PR #392. However, the fix in #392 did not return a `Seurat` object. In this case, `Seurat::JackStrawPlot()` returns a `Seurat` object, with `object@dr$pca@jackstraw@overall.p.values` representing PC p-values and `object@dr$pca@misc$jackstraw.plot` storing the `ggplot2` plot.

Please do make sure also to update the vignette on your webpage!

Best,
Leon