### PR TITLE
Fast residual

### DIFF
--- a/R/preprocessing_internal.R
+++ b/R/preprocessing_internal.R
@@ -108,6 +108,7 @@ RegressOutResid <- function(
   data.resid <- foreach(i = 1:max.bin, .combine = "c", .options.snow = opts) %dopar% {
     genes.bin.regress <- rownames(x = data.use)[bin.ind == i]
     gene.expr <- as.matrix(x = data.use[genes.bin.regress, , drop = FALSE])
+    empty_char = character(length = dim(gene.expr)[1]) # Empty vector to reuse
     new.data <- sapply(
       X = genes.bin.regress,
       FUN = function(x) {
@@ -136,7 +137,7 @@ RegressOutResid <- function(
           ) 
         }
         if (!is.list(x = resid)) {
-          resid <- list('resid' = resid, 'mode' = character(length = length(x = resid)))
+          resid <- list('resid' = resid, 'mode' = empty_char)
         }
         return(resid)
       }

--- a/R/preprocessing_internal.R
+++ b/R/preprocessing_internal.R
@@ -100,8 +100,7 @@ RegressOutResid <- function(
     regression.mat <- cbind(latent.data, data.use[1,])
     colnames(regression.mat) <- reg.mat.colnames
     qr = lm(fmla, data = regression.mat, qr=TRUE)$qr
-    rm(regression.mat) # Ensure memory isn't held by fastResiduals closure
-    fastResiduals <- function(y) {qr.resid(qr, y)}
+    rm(regression.mat)
   }
   
   
@@ -114,7 +113,7 @@ RegressOutResid <- function(
       FUN = function(x) {
         # Fast path for std. linear models
         if(model.use=="linear") {
-          resid <- fastResiduals(gene.expr[x,])
+          resid <- qr.resid(qr, gene.expr[x,])
         } else {
           regression.mat <- cbind(latent.data, gene.expr[x,])
           colnames(x = regression.mat) <- reg.mat.colnames

--- a/R/preprocessing_internal.R
+++ b/R/preprocessing_internal.R
@@ -137,9 +137,8 @@ RegressOutResid <- function(
       }
     )
     new.data.resid <- new.data[seq.int(from = 1, to = length(x = new.data), by = 2)]
-    new.data.resid <- as.data.frame(x = new.data.resid)
+    new.data.resid = matrix(unlist(new.data.resid), nrow = length(new.data.resid[[1]]))
     colnames(x = new.data.resid) <- genes.bin.regress
-    new.data.resid <- as.matrix(x = new.data.resid)
     new.data.mode <- unlist(x = new.data[seq.int(from = 2, to = length(x = new.data), by = 2)])
     names(x = new.data.mode) <- genes.bin.regress
     new.data <- list('resid' = new.data.resid, 'mode' = new.data.mode)

--- a/R/preprocessing_internal.R
+++ b/R/preprocessing_internal.R
@@ -84,13 +84,7 @@ RegressOutResid <- function(
     time_elapsed <- Sys.time()
   }
   reg.mat.colnames <- c(colnames(x = latent.data), "GENE")
-  fmla <- as.formula(
-    object = paste0(
-      "GENE ",
-      " ~ ",
-      paste(vars.to.regress, collapse = "+")
-    )
-  )
+  fmla_str = paste0("GENE ", " ~ ", paste(vars.to.regress, collapse = "+"))
   if(model.use == "linear") {
     # In this code, we'll repeatedly regress different Y against the same X
     # (latent.data) in order to calculate residuals.  Rather that repeatedly
@@ -99,7 +93,7 @@ RegressOutResid <- function(
     # storing it in a fastResiduals function.
     regression.mat <- cbind(latent.data, data.use[1,])
     colnames(regression.mat) <- reg.mat.colnames
-    qr = lm(fmla, data = regression.mat, qr=TRUE)$qr
+    qr = lm(as.formula(fmla_str), data = regression.mat, qr=TRUE)$qr
     rm(regression.mat)
   }
   
@@ -117,6 +111,7 @@ RegressOutResid <- function(
         } else {
           regression.mat <- cbind(latent.data, gene.expr[x,])
           colnames(x = regression.mat) <- reg.mat.colnames
+          fmla = as.formula(fmla_str)
           resid <- switch(
             EXPR = model.use,
             'poisson' = residuals(


### PR DESCRIPTION
While profiling some analysis, I noticed that a lot of time was being spent in this function, and put some optimizations into it.  For a test case where this results in the ScaleData function only taking half as much time when called to regress on 2 variables using 2 cores for a dataset with 7.3K cells and 20K genes.  The speed improvements come from two main changes:

1 – **Avoids allocating several large empty character vectors in the inner loop.** Instead, it creates one empty_char vector and repeatedly reuses it, avoiding a lot of memory allocation overhead.

2 -- **Reuses the QR Decomposition** - Rather than recompute the QR decomposition for each regression, it reuses one calculated once.

After these first two commits, some other minor changes are included which were flagged in profiling.

I confirmed the ScaleData command returned the same values with these changes in place as it did originally.
