### PR TITLE
Performance Optimization of Sparse Matrix Access and RNG Generation

### DIFF
--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -651,7 +651,7 @@ SampleUMI <- function(
   data,
   max.umi = 1000,
   upsample = FALSE,
-  progress.bar = TRUE
+  progress.bar = FALSE
 ) {
   data <- as(data, "dgCMatrix")
   if (length(x = max.umi) == 1) {

--- a/man/SampleUMI.Rd
+++ b/man/SampleUMI.Rd
@@ -4,7 +4,7 @@
 \alias{SampleUMI}
 \title{Sample UMI}
 \usage{
-SampleUMI(data, max.umi = 1000, upsample = FALSE, progress.bar = TRUE)
+SampleUMI(data, max.umi = 1000, upsample = FALSE, progress.bar = FALSE)
 }
 \arguments{
 \item{data}{Matrix with the raw count data}

--- a/src/data_manipulation.cpp
+++ b/src/data_manipulation.cpp
@@ -22,7 +22,7 @@ Eigen::SparseMatrix<double> RunUMISampling(Eigen::SparseMatrix<double> data, int
         if( (upsample) || (colSums[k] > sample_val)){
           entry = entry * double(sample_val) / colSums[k];
           if (fmod(entry, 1) != 0){
-            double rn = runif(1)[0];
+            double rn = R::runif(0,1);
             if(fmod(entry, 1) <= rn){
               it.valueRef() = floor(entry);
             }
@@ -50,7 +50,7 @@ Eigen::SparseMatrix<double> RunUMISamplingPerCell(Eigen::SparseMatrix<double> da
       if( (upsample) || (colSums[k] > sample_val[k])){
         entry = entry * double(sample_val[k]) / colSums[k];
         if (fmod(entry, 1) != 0){
-          double rn = runif(1)[0];
+          double rn = R::runif(0,1);
           if(fmod(entry, 1) <= rn){
             it.valueRef() = floor(entry);
           }

--- a/src/data_manipulation.cpp
+++ b/src/data_manipulation.cpp
@@ -24,14 +24,14 @@ Eigen::SparseMatrix<double> RunUMISampling(Eigen::SparseMatrix<double> data, int
           if (fmod(entry, 1) != 0){
             double rn = runif(1)[0];
             if(fmod(entry, 1) <= rn){
-              data.coeffRef(it.row(), it.col()) = floor(entry);
+              it.valueRef() = floor(entry);
             }
             else{
-              data.coeffRef(it.row(), it.col()) = ceil(entry);
+              it.valueRef() = ceil(entry);
             }
           }
           else{
-            data.coeffRef(it.row(), it.col()) = entry;
+            it.valueRef() = entry;
           }
         }
       }
@@ -52,14 +52,14 @@ Eigen::SparseMatrix<double> RunUMISamplingPerCell(Eigen::SparseMatrix<double> da
         if (fmod(entry, 1) != 0){
           double rn = runif(1)[0];
           if(fmod(entry, 1) <= rn){
-            data.coeffRef(it.row(), it.col()) = floor(entry);
+            it.valueRef() = floor(entry);
           }
           else{
-            data.coeffRef(it.row(), it.col()) = ceil(entry);
+            it.valueRef() = ceil(entry);
           }
         }
         else{
-          data.coeffRef(it.row(), it.col()) = entry;
+          it.valueRef() = entry;
         }
       }
     }
@@ -117,7 +117,7 @@ Eigen::SparseMatrix<double> LogNorm(Eigen::SparseMatrix<double> data, int scale_
   for (int k=0; k < data.outerSize(); ++k){
     p.increment();
     for (Eigen::SparseMatrix<double>::InnerIterator it(data, k); it; ++it){
-      data.coeffRef(it.row(), it.col()) = log1p(double(it.value()) / colSums[k] * scale_factor);
+      it.valueRef() = log1p(double(it.value()) / colSums[k] * scale_factor);
     }
   }
   return data;


### PR DESCRIPTION
Some changes to speed up the `LogNormalize` and `SampleUMI` functions.  These changes for SampleUMI changed the execution time from 24 seconds down to 0.4 seconds. The two changes are:

**Use scalar runif** Calling runif to return one value is expensive, as the underlying code must generate an R NumericVector, populate the vector, then access the scalar value in this vector, which involves a lot of R allocator overhead.

Rcpp provides a much lighter interface where you can just generate a single double value, rather than a whole vector (see: http://gallery.rcpp.org/articles/random-number-generation/).

Since the code now runs an example 7K cells and 20K gene dataset in less than half a second, it also seemed sensible not to display a progress bar by default.

**coeffRef(it.row(), it.col()) -> it.valueRef()** 

Performance optimization.  In a few of the edited places, the code is iterating over the elements of a sparse matrix using an iterator.  However, when it came time to update the sparsematrix at the given position, rather then directly assign the value, the code called `coeffRef` to assign it.

This is inefficient because `coeffRef` involves an expensive binary search to find position `i,j` in the sparse matrix, even though the memory location of `i,j` is already known to the iterator on the stack.  To directly use the known value, we can just call `.valueRef()` on the iterator instead of looking for the position again.

A discussion of this difference is given in the `Iterating over the nonzero coefficients` section of this tutorial: https://eigen.tuxfamily.org/dox/group__TutorialSparse.html

Benchmarking showed this shaved 13% off the time for NormalizeData, and dropped the time for `SampleUMI` from 0.8 seconds to 0.4 seconds after the change listed above was implemented.