### PR TITLE
Transform `data` also for single cells in AverageExpression

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -592,6 +592,10 @@ AverageExpression <- function(
       genes.assay <- unique(x = intersect(x = genes.assay, y = rownames(x = data.use)))
       if (length(x = temp.cells) == 1) {
         data.temp <- (data.use[genes.assay, temp.cells])
+        # transform data if needed (alternative: apply fxn.average to single value above)
+        if(!(use.scale | use.raw)) { # equivalent: slot.use == "data"
+          data.temp <- expm1(data.temp)
+        }
       }
       if (length(x = temp.cells) >1 ) {
         data.temp <- apply(


### PR DESCRIPTION
This fixes a discrepancy in AverageExpression:
When `use.scale` and `use.raw` are both FALSE (default), identities with
several cells were transformed back (exp(x) - 1) before averaging while single
cell identities were neither averaged (no need) nor transformed (discrepancy).
This commit fixes this by transforming the data data conditionally in the
scenario described above.
It uses `if(!(use.scale | use.raw))` assuming this would be faster to evaluate
than `if(use.slot == "data")` or applying `mean` to a single value to safe the
conditional altogether. This performance assumption, however, was not tested.

fixes #571