### PR TITLE
Warn on NA data being used for regression

### DIFF
--- a/R/preprocessing_internal.R
+++ b/R/preprocessing_internal.R
@@ -61,6 +61,11 @@ RegressOutResid <- function(
   if (use.umi) {
     data.use <- object@raw.data[genes.regress, object@cell.names, drop = FALSE]
   }
+  
+  if(anyNA(latent.data) | anyNA(data.use)) {
+    stop("Data used in regression cannot contain NA values.")
+  }
+  
   # input checking for parallel options
   if (do.par) {
     if (num.cores == 1) {


### PR DESCRIPTION
If the data used for the regression contains NA values, this will lead to errors downstream.  For example, if one row contains an NA value, it will be removed and create a size mismatch when a data.frame is later constructed using the residuals of all rows, or if a linear model is used, it will create a problem when the QR decomposition has different rows than the value being regressed against.  This notifies the user of the underlying issue before a harder to debug error message appears.

Motivated by:
https://github.com/satijalab/seurat/issues/618