### PR TITLE
TCC-LRDE

### DIFF
--- a/R/tcc.R
+++ b/R/tcc.R
@@ -19,9 +19,9 @@ AddTCC <- function(object, tcc.counts, tx.counts, ec.map, gene.map,
   if (display.progress) {
     cat("Reading files\n", file = stderr())
   }
-  tcc.mat <- read.table(file = tcc.counts, sep = "\t", header = TRUE,
-                        row.names = 1)
-  tcc.mat <- as(as.matrix(tcc.mat), "dgCMatrix")
+  tcc.mat <- read.table(file = tcc.counts)
+  tcc.mat <- sparseMatrix(i = tcc.mat$V2 + 1, j = tcc.mat$V1 +1, x = tcc.mat$V3)
+  tcc.mat <- as(tcc.mat, "dgCMatrix")
   tx.mat <- readRDS(file = tx.counts)
   tx.mat <- as(as.matrix(tx.mat$counts), "dgCMatrix")
   ec.map <- as.matrix(read.table(file = ec.map, stringsAsFactors = FALSE,

--- a/R/tcc.R
+++ b/R/tcc.R
@@ -14,16 +14,24 @@
 #' @importFrom Matrix rowSums
 #' @export
 #'
-AddTCC <- function(object, tcc.counts, tx.counts, ec.map, gene.map,
+
+#should modularize the reading of TCCs and transcripts
+AddTCC <- function(object, sample.names, tcc.counts, tx.counts = NULL, ec.map, gene.map,
                    min.ec.filter = 0, display.progress = TRUE){
   if (display.progress) {
     cat("Reading files\n", file = stderr())
   }
   tcc.mat <- read.table(file = tcc.counts)
-  tcc.mat <- sparseMatrix(i = tcc.mat$V2 + 1, j = tcc.mat$V1 +1, x = tcc.mat$V3)
+  tcc.mat <- sparseMatrix(i = tcc.mat$V1 + 1, j = tcc.mat$V2 +1, x = tcc.mat$V3)
   tcc.mat <- as(tcc.mat, "dgCMatrix")
-  tx.mat <- readRDS(file = tx.counts)
-  tx.mat <- as(as.matrix(tx.mat$counts), "dgCMatrix")
+  rownames(tcc.mat) = 0:(nrow(tcc.mat)-1)
+  colnames(tcc.mat) = sample.names
+  
+  #probably should not be readRDS
+  if (!is.null(tx.counts)) {
+	tx.mat <- readRDS(file = tx.counts)
+  	tx.mat <- as(as.matrix(tx.mat$counts), "dgCMatrix")
+  }
   ec.map <- as.matrix(read.table(file = ec.map, stringsAsFactors = FALSE,
                                  sep = "\t", row.names = 1))
   gene.map <- read.table(file = gene.map, stringsAsFactors = FALSE)
@@ -84,7 +92,7 @@ AddTCC <- function(object, tcc.counts, tx.counts, ec.map, gene.map,
   tcc <- new(
     Class = "tcc",
     tcc.raw = tcc.mat,
-    tx.raw = tx.mat,
+    #tx.raw = tx.mat,
     ec.to.tx.map = ec.to.tx.ht,
     tx.to.ec.map = tx.to.ec.ht,
     tx.to.gene.map = tx.to.gene.ht,


### PR DESCRIPTION
Changes / issues to work on:

1. We updated kallisto with a new format for the TCCs in sparse matrix format, so I updated Seurat’s AddTCC to reflect that.  I apologize for this, since I provided the example dataset that would’ve worked perfectly with this code.  I impressed upon the kallisto team (@Pall) that Seurat will depend on the formatting of kallisto’s TCC outputs, and that we will be very mindful of this in the future.

2. We generally do not do transcript quantifications for 10x.  Theoretically, the reading of TCCs and transcript quantifications should be modular, since there may be tx quantifications for SMART-Seq but not for 10x, and vice versa for TCCs.  AddTCC required both tx and TCCs, so I made some changes to allow for TCC-only reading, but Andrew you should decide the most rigorous way of coding this.  I think it might make sense to have a separate AddTranscript function.
	2b. The reading of transcripts right now is through a .RDS file, which is not the general kallisto output (which is .h5 and .tsv, per sample). I apologize that I provided initially the .RDS as an example to just transmit the data efficiently.

3. Lastly, I modified the code to test genes only — in that, our method is not meant to provide p-values for TCCs or for transcripts and we haven’t tested logistic regression on those independently. (I believe this feature is a fossil from the start of our collaboration, when Fisher’s method was implemented, but we prefer logistic regression over that method for single cell RNA-seq)

4. Suggestions for error messages: instead of using gene names from the assay data matrix, it seems to make sense to use the genes used in the tx.to.gene map, or to test that these genes overlap. Also, some additional error messages for when the gene.to.ec mapping fails, i.e. gene not found, would be useful. This actually happened to me a lot, when I was changing code and CD45 would not have any TCCs and I didn’t get a useful error message.
