### PR TITLE
Use custom gene names and cells names

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -110,7 +110,7 @@ Collate:
     'utilities_generics.R'
     'utilities_internal.R'
     'zfRenderSeurat.R'
-RoxygenNote: 6.0.1
+RoxygenNote: 6.1.0
 Suggests:
     testthat,
     S4Vectors,

--- a/R/conversion.R
+++ b/R/conversion.R
@@ -55,6 +55,9 @@ Convert.seurat <- function(
       if (!'loomR' %in% rownames(x = installed.packages())) {
         stop("Please install loomR from GitHub before converting to a loom object")
       }
+      # loomR::create needs chunk.dims = NULL in order to automatically estimate it
+      # Passing a string to chunk.dims will make it NA
+      chunk.dims <- NULL
       cell.order <- from@cell.names
       gene.order <- rownames(x = from@data)
       loomfile <- loomR::create(

--- a/R/dimensional_reduction.R
+++ b/R/dimensional_reduction.R
@@ -212,7 +212,7 @@ RunPCA.loom <- function(
         cat("Smaller number of cells than required for online PCA\n")
         cat("Running standard PCA instead\n")
       }
-      pca.results <- irlba(A = t(x = data), nv = pcs.compute, ...)
+      pca.results <- irlba(A = data, nv = pcs.compute, ...)
       gene.loadings <- pca.results$u
       cell.embeddings <- pca.results$v
       sdev <- pca.results$d / sqrt(x = max(1, ncol(x = data) - 1))
@@ -547,8 +547,10 @@ RunTSNE.seurat <- function(
   return(object)
 }
 
+#' @param gene.names Dataset name for gene names in loom object
+#' @param cell.names Dataset name for cell names in loom object
 #' @param overwrite Overwrite existing data? Used only for loom objects
-#'
+#' 
 #' @describeIn RunTSNE Run TSNE on a loom file
 #' @export
 #' @method RunTSNE loom
@@ -566,6 +568,8 @@ RunTSNE.loom <- function(
   distance.matrix = NULL,
   reduction.name = "tsne",
   reduction.key = "tSNE_",
+  gene.names = "row_attrs/gene_names",
+  cell.names = "col_attrs/cell_names",
   overwrite = FALSE,
   ...
 ) {
@@ -583,6 +587,8 @@ RunTSNE.loom <- function(
     reduction.name = reduction.name,
     reduction.key = reduction.key,
     overwrite = overwrite,
+    gene.names = gene.names,
+    cell.names = cell.names,
     ...
   )
   invisible(x = object)

--- a/R/dimensional_reduction.R
+++ b/R/dimensional_reduction.R
@@ -125,6 +125,7 @@ RunPCA.seurat <- function(
 #' @param gene.means Path to gene means dataset
 #' @param gene.variance Path to gene variance dataset
 #' @param scale.data Path to scaled data matrix
+#' @param cell.names Path to cell names dataset
 #' @param ngene Number of variable genes to use
 #' @param overwrite Overwrite preexisting results
 #' @param display.progress Show progress bars
@@ -156,6 +157,7 @@ RunPCA.loom <- function(
   gene.variance = 'row_attrs/gene_dispersion',
   var.genes = 'row_attrs/var_genes',
   scale.data = 'layers/scale_data',
+  cell.names = 'col_attrs/cell_names',
   ngene = NULL,
   overwrite = FALSE,
   display.progress = TRUE,
@@ -200,7 +202,9 @@ RunPCA.loom <- function(
       genes.use = pc.genes,
       chunk.size = cells.initial,
       do.sparse = FALSE,
-      display.progress = display.progress
+      display.progress = display.progress,
+      cell.names = cell.names,
+      gene.names = gene.names
     )
     if (cells.use <= cells.initial) {
       # Small number of cells, just use irlba
@@ -295,7 +299,9 @@ RunPCA.loom <- function(
           genes.use = pc.genes,
           chunk.size = chunk.size,
           do.sparse = FALSE,
-          display.progress = display.progress
+          display.progress = display.progress,
+          cell.names = cell.names,
+          gene.names = gene.names
         )
         data <- object[[scale.data]][chunk.indices, pc.genes]
         cell.embeddings[chunk.indices, ] <- data %*% pca$vectors
@@ -363,7 +369,7 @@ RunPCA.loom <- function(
       }
     }
     colnames(x = pc.values) <- paste0("PC", 1:ncol(x = pc.values))
-    rownames(pc.values) <- object[['col_attrs/cell_names']][]
+    rownames(pc.values) <- object[[cell.names]][]
     pc.values <- pc.values[, 1:pcs.compute]
     gene.loadings <- pc.eigs$vectors[, 1:pcs.compute]
     rownames(gene.loadings) <- rownames(covariance.mat)

--- a/R/dimensional_reduction_internal.R
+++ b/R/dimensional_reduction_internal.R
@@ -112,6 +112,8 @@ DoTSNE <- function(
   distance.matrix = NULL,
   reduction.name = "tsne",
   reduction.key = "tSNE_",
+  gene.names = "row_attrs/gene_names",
+  cell.names = "col_attrs/cell_names",
   overwrite = FALSE,
   ...
 ) {
@@ -123,7 +125,9 @@ DoTSNE <- function(
     data.use <- GetDimReduction(
       object = object,
       reduction.type = reduction.use,
-      slot = "cell.embeddings"
+      slot = "cell.embeddings",
+      gene.names = gene.names,
+      cell.names = cell.names
     )[, dims.use]
   } else {
     data.use <- t(x = PrepDR(

--- a/R/dimensional_reduction_utilities.R
+++ b/R/dimensional_reduction_utilities.R
@@ -7,7 +7,9 @@
 GetDimReduction.seurat <- function(
   object,
   reduction.type = "pca",
-  slot = "gene.loadings"
+  slot = "gene.loadings",
+  gene.names = 'row_attrs/gene_names', # I added this so when it won't throw an error
+  cell.names = 'col_attrs/cell_names'  # when a Seurat object is passed in DoTSNE; these arguments won't be evaluated
 ) {
   if (!(reduction.type %in% names(object@dr))) {
     stop(paste(reduction.type, " dimensional reduction has not been computed"))

--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -339,12 +339,14 @@ NormalizeData.loom <- function(
     dtype = dtype,
     chunk.dims = chunk.dims
   )
+  # Store parameters
   parameters.to.store <- as.list(x = environment(), all = TRUE)[names(formals())]
   SetCalcParams(
     object = object,
     dataset.use = "layers/norm_data",
     ... = parameters.to.store
   )
+  # Clean up
   gc(verbose = FALSE)
   invisible(x = object)
 }
@@ -839,7 +841,7 @@ FindVariableGenes.seurat <- function(
   display.progress = TRUE,
   ...
 ) {
-  parameters.to.store <- as.list(environment(), all = TRUE)[names(formals("FindVariableGenes"))]
+  parameters.to.store <- as.list(environment(), all = TRUE)[names(formals())]
   parameters.to.store$mean.function <- as.character(substitute(mean.function))
   parameters.to.store$dispersion.function <- as.character(substitute(dispersion.function))
   object <- SetCalcParams(
@@ -1054,6 +1056,14 @@ FindVariableGenes.loom <- function(
       'var_genes' = var.genes
     )
   )
+  # Store parameters
+  parameters.to.store <- as.list(environment(), all = TRUE)[names(formals())]
+  SetCalcParams(
+    object = object,
+    dataset.use = "row_attrs/var_genes",
+    ... = parameters.to.store
+  )
+  # Clean up
   gc(verbose = FALSE)
   invisible(x = object)
 }

--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -1062,11 +1062,11 @@ FindVariableGenes.loom <- function(
 #' @export
 #' @method GetVariableGenes loom
 #'
-GetVariableGenes.loom <- function(object) {
+GetVariableGenes.loom <- function(object, row.names = "gene_names") {
   hvg.info <- object$get.attribute.df(
     MARGIN = 1,
     attribute.names = c('gene_means', 'gene_dispersion', 'gene_dispersion_scaled'),
-    row.names = 'gene_names'
+    row.names = row.names
   )
   hvg.info$index <- 1:nrow(x = hvg.info)
   colnames(x = hvg.info) <- gsub(

--- a/R/preprocessing_generics.R
+++ b/R/preprocessing_generics.R
@@ -122,6 +122,7 @@ ScaleData <- function(object, ...) {
 #' Get the variable genes dataframe
 #'
 #' @param object An object
+#' @param row.names Name of dataset for gene names in loom objects. Default to "gene_names". Duplicates are not allowed.
 #'
 #' @return A dataframe with four columns
 #' \item{gene.means}{Gene means}

--- a/R/utilities_internal.R
+++ b/R/utilities_internal.R
@@ -271,6 +271,7 @@ setMethod(
     to.store <- list(...)
     to.store$...$object <- NULL
     to.store$...$object2 <- NULL
+    to.store$...$... <- NULL
     names.to.store <- names(to.store$...)
     to.store <- as.character(unlist(to.store))
     if(time) {

--- a/man/AddImputedScore.Rd
+++ b/man/AddImputedScore.Rd
@@ -4,8 +4,8 @@
 \alias{AddImputedScore}
 \title{Calculate imputed expression values}
 \usage{
-AddImputedScore(object, genes.use = NULL, genes.fit = NULL, s.use = 20,
-  do.print = FALSE, gram = TRUE)
+AddImputedScore(object, genes.use = NULL, genes.fit = NULL,
+  s.use = 20, do.print = FALSE, gram = TRUE)
 }
 \arguments{
 \item{object}{Seurat object}

--- a/man/AddModuleScore.Rd
+++ b/man/AddModuleScore.Rd
@@ -4,9 +4,9 @@
 \alias{AddModuleScore}
 \title{Calculate module scores for gene expression programs in single cells}
 \usage{
-AddModuleScore(object, genes.list = NULL, genes.pool = NULL, n.bin = 25,
-  seed.use = 1, ctrl.size = 100, use.k = FALSE, enrich.name = "Cluster",
-  random.seed = 1)
+AddModuleScore(object, genes.list = NULL, genes.pool = NULL,
+  n.bin = 25, seed.use = 1, ctrl.size = 100, use.k = FALSE,
+  enrich.name = "Cluster", random.seed = 1)
 }
 \arguments{
 \item{object}{Seurat object}

--- a/man/AddSamples.Rd
+++ b/man/AddSamples.Rd
@@ -4,10 +4,11 @@
 \alias{AddSamples}
 \title{Add samples into existing Seurat object.}
 \usage{
-AddSamples(object, new.data, project = NULL, min.cells = 0, min.genes = 0,
-  is.expr = 0, do.normalize = TRUE, scale.factor = 10000,
-  do.scale = FALSE, do.center = FALSE, names.field = 1,
-  names.delim = "_", meta.data = NULL, add.cell.id = NULL)
+AddSamples(object, new.data, project = NULL, min.cells = 0,
+  min.genes = 0, is.expr = 0, do.normalize = TRUE,
+  scale.factor = 10000, do.scale = FALSE, do.center = FALSE,
+  names.field = 1, names.delim = "_", meta.data = NULL,
+  add.cell.id = NULL)
 }
 \arguments{
 \item{object}{Seurat object}

--- a/man/AssessNodes.Rd
+++ b/man/AssessNodes.Rd
@@ -4,7 +4,8 @@
 \alias{AssessNodes}
 \title{Assess Internal Nodes}
 \usage{
-AssessNodes(object, node.list, all.below = FALSE, genes.training = NULL)
+AssessNodes(object, node.list, all.below = FALSE,
+  genes.training = NULL)
 }
 \arguments{
 \item{object}{Seurat object}

--- a/man/BuildClusterTree.Rd
+++ b/man/BuildClusterTree.Rd
@@ -4,9 +4,9 @@
 \alias{BuildClusterTree}
 \title{Phylogenetic Analysis of Identity Classes}
 \usage{
-BuildClusterTree(object, genes.use = NULL, pcs.use = NULL, SNN.use = NULL,
-  do.plot = TRUE, do.reorder = FALSE, reorder.numeric = FALSE,
-  show.progress = TRUE)
+BuildClusterTree(object, genes.use = NULL, pcs.use = NULL,
+  SNN.use = NULL, do.plot = TRUE, do.reorder = FALSE,
+  reorder.numeric = FALSE, show.progress = TRUE)
 }
 \arguments{
 \item{object}{Seurat object}

--- a/man/BuildRFClassifier.Rd
+++ b/man/BuildRFClassifier.Rd
@@ -4,8 +4,8 @@
 \alias{BuildRFClassifier}
 \title{Build Random Forest Classifier}
 \usage{
-BuildRFClassifier(object, training.genes = NULL, training.classes = NULL,
-  verbose = TRUE, ...)
+BuildRFClassifier(object, training.genes = NULL,
+  training.classes = NULL, verbose = TRUE, ...)
 }
 \arguments{
 \item{object}{Seurat object on which to train the classifier}

--- a/man/BuildSNN.Rd
+++ b/man/BuildSNN.Rd
@@ -8,15 +8,17 @@
 \usage{
 BuildSNN(object, ...)
 
-\method{BuildSNN}{seurat}(object, genes.use = NULL, reduction.type = "pca",
-  dims.use = NULL, k.param = 10, plot.SNN = FALSE, prune.SNN = 1/15,
-  print.output = TRUE, distance.matrix = NULL, force.recalc = FALSE,
-  filename = NULL, save.SNN = TRUE, nn.eps = 0)
+\method{BuildSNN}{seurat}(object, genes.use = NULL,
+  reduction.type = "pca", dims.use = NULL, k.param = 10,
+  plot.SNN = FALSE, prune.SNN = 1/15, print.output = TRUE,
+  distance.matrix = NULL, force.recalc = FALSE, filename = NULL,
+  save.SNN = TRUE, nn.eps = 0)
 
-\method{BuildSNN}{loom}(object, genes.use = NULL, reduction.type = "pca",
-  dims.use = NULL, k.param = 10, k.scale = 10, prune.SNN = 1/15,
-  print.output = TRUE, distance.matrix = NULL, filename = NULL,
-  save.SNN = TRUE, nn.eps = 0, overwrite = FALSE)
+\method{BuildSNN}{loom}(object, genes.use = NULL,
+  reduction.type = "pca", dims.use = NULL, k.param = 10,
+  k.scale = 10, prune.SNN = 1/15, print.output = TRUE,
+  distance.matrix = NULL, filename = NULL, save.SNN = TRUE,
+  nn.eps = 0, overwrite = FALSE)
 }
 \arguments{
 \item{object}{Seurat object}

--- a/man/CellPlot.Rd
+++ b/man/CellPlot.Rd
@@ -5,8 +5,8 @@
 \title{Cell-cell scatter plot}
 \usage{
 CellPlot(object, cell1, cell2, gene.ids = NULL, col.use = "black",
-  nrpoints.use = Inf, pch.use = 16, cex.use = 0.5, do.hover = FALSE,
-  do.identify = FALSE, ...)
+  nrpoints.use = Inf, pch.use = 16, cex.use = 0.5,
+  do.hover = FALSE, do.identify = FALSE, ...)
 }
 \arguments{
 \item{object}{Seurat object}

--- a/man/Convert.Rd
+++ b/man/Convert.Rd
@@ -18,16 +18,16 @@ Convert(from, ...)
   chunk.size = 1000, overwrite = FALSE, display.progress = TRUE,
   anndata.raw = "raw.data", anndata.X = "data", ...)
 
-\method{Convert}{SingleCellExperiment}(from, to, raw.data.slot = "counts",
-  data.slot = "logcounts", ...)
+\method{Convert}{SingleCellExperiment}(from, to,
+  raw.data.slot = "counts", data.slot = "logcounts", ...)
 
 \method{Convert}{anndata.base.AnnData}(from, to, X.slot = "scale.data",
   raw.slot = "data", ...)
 
 \method{Convert}{loom}(from, to, raw.data = "matrix",
-  gene.names = "row_attrs/gene_names", cell.names = "col_attrs/cell_names",
-  norm.data = "layers/norm_data", scale.data = "layers/scale_data",
-  gene.means = "row_attrs/gene.mean",
+  gene.names = "row_attrs/gene_names",
+  cell.names = "col_attrs/cell_names", norm.data = "layers/norm_data",
+  scale.data = "layers/scale_data", gene.means = "row_attrs/gene.mean",
   gene.dispersion = "row_attrs/gene.dispersion",
   gene.scaled = "row_attrs/gene.dispersion.scaled",
   var.genes = "row_attrs/var_genes")

--- a/man/DBClustDimension.Rd
+++ b/man/DBClustDimension.Rd
@@ -4,8 +4,9 @@
 \alias{DBClustDimension}
 \title{Perform spectral density clustering on single cells}
 \usage{
-DBClustDimension(object, dim.1 = 1, dim.2 = 2, reduction.use = "tsne",
-  G.use = NULL, set.ident = TRUE, seed.use = 1, ...)
+DBClustDimension(object, dim.1 = 1, dim.2 = 2,
+  reduction.use = "tsne", G.use = NULL, set.ident = TRUE,
+  seed.use = 1, ...)
 }
 \arguments{
 \item{object}{Seurat object}

--- a/man/DESeq2DETest.Rd
+++ b/man/DESeq2DETest.Rd
@@ -4,8 +4,8 @@
 \alias{DESeq2DETest}
 \title{Differential expression using DESeq2}
 \usage{
-DESeq2DETest(object, cells.1, cells.2, genes.use = NULL, assay.type = "RNA",
-  ...)
+DESeq2DETest(object, cells.1, cells.2, genes.use = NULL,
+  assay.type = "RNA", ...)
 }
 \arguments{
 \item{object}{Seurat object}

--- a/man/DiffExpTest.Rd
+++ b/man/DiffExpTest.Rd
@@ -4,8 +4,8 @@
 \alias{DiffExpTest}
 \title{Likelihood ratio test for zero-inflated data}
 \usage{
-DiffExpTest(object, cells.1, cells.2, assay.type = "RNA", genes.use = NULL,
-  print.bar = TRUE)
+DiffExpTest(object, cells.1, cells.2, assay.type = "RNA",
+  genes.use = NULL, print.bar = TRUE)
 }
 \arguments{
 \item{object}{Seurat object}

--- a/man/DimElbowPlot.Rd
+++ b/man/DimElbowPlot.Rd
@@ -4,8 +4,8 @@
 \alias{DimElbowPlot}
 \title{Quickly Pick Relevant Dimensions}
 \usage{
-DimElbowPlot(object, reduction.type = "pca", dims.plot = 20, xlab = "",
-  ylab = "", title = "")
+DimElbowPlot(object, reduction.type = "pca", dims.plot = 20,
+  xlab = "", ylab = "", title = "")
 }
 \arguments{
 \item{object}{Seurat object}

--- a/man/DimHeatmap.Rd
+++ b/man/DimHeatmap.Rd
@@ -4,11 +4,11 @@
 \alias{DimHeatmap}
 \title{Dimensional reduction heatmap}
 \usage{
-DimHeatmap(object, assay.use = "RNA", reduction.type = "pca", dim.use = 1,
-  cells.use = NULL, num.genes = 30, use.full = FALSE, disp.min = -2.5,
-  disp.max = 2.5, do.return = FALSE, col.use = PurpleAndYellow(),
-  use.scale = TRUE, do.balanced = FALSE, remove.key = FALSE,
-  label.columns = NULL, check.plot = TRUE, ...)
+DimHeatmap(object, assay.use = "RNA", reduction.type = "pca",
+  dim.use = 1, cells.use = NULL, num.genes = 30, use.full = FALSE,
+  disp.min = -2.5, disp.max = 2.5, do.return = FALSE,
+  col.use = PurpleAndYellow(), use.scale = TRUE, do.balanced = FALSE,
+  remove.key = FALSE, label.columns = NULL, check.plot = TRUE, ...)
 }
 \arguments{
 \item{object}{Seurat object.}

--- a/man/DimPlot.Rd
+++ b/man/DimPlot.Rd
@@ -10,18 +10,19 @@ DimPlot(object, ...)
 
 \method{DimPlot}{seurat}(object, reduction.use = "pca", dim.1 = 1,
   dim.2 = 2, cells.use = NULL, pt.size = 1, do.return = FALSE,
-  do.bare = FALSE, cols.use = NULL, group.by = "ident", pt.shape = NULL,
-  do.hover = FALSE, data.hover = "ident", do.identify = FALSE,
-  do.label = FALSE, label.size = 4, no.legend = FALSE, no.axes = FALSE,
-  dark.theme = FALSE, plot.order = NULL, cells.highlight = NULL,
-  cols.highlight = "red", sizes.highlight = 1, plot.title = NULL,
-  vector.friendly = FALSE, png.file = NULL, png.arguments = c(10, 10,
-  100), ...)
+  do.bare = FALSE, cols.use = NULL, group.by = "ident",
+  pt.shape = NULL, do.hover = FALSE, data.hover = "ident",
+  do.identify = FALSE, do.label = FALSE, label.size = 4,
+  no.legend = FALSE, no.axes = FALSE, dark.theme = FALSE,
+  plot.order = NULL, cells.highlight = NULL, cols.highlight = "red",
+  sizes.highlight = 1, plot.title = NULL, vector.friendly = FALSE,
+  png.file = NULL, png.arguments = c(10, 10, 100), ...)
 
-\method{DimPlot}{loom}(object, reduction.use = "pca", dataset.use = NULL,
-  ident.use = NULL, dim.1 = 1, dim.2 = 2, cells.use = NULL,
-  pt.size = 1, do.return = FALSE, do.bare = FALSE, cols.use = NULL,
-  do.label = FALSE, label.size = 4, no.legend = FALSE, no.axes = FALSE,
+\method{DimPlot}{loom}(object, reduction.use = "pca",
+  dataset.use = NULL, ident.use = NULL, dim.1 = 1, dim.2 = 2,
+  cells.use = NULL, pt.size = 1, do.return = FALSE,
+  do.bare = FALSE, cols.use = NULL, do.label = FALSE,
+  label.size = 4, no.legend = FALSE, no.axes = FALSE,
   dark.theme = FALSE, vector.friendly = FALSE, png.file = NULL,
   png.arguments = c(10, 10, 100), ...)
 }

--- a/man/DimTopCells.Rd
+++ b/man/DimTopCells.Rd
@@ -4,8 +4,8 @@
 \alias{DimTopCells}
 \title{Find cells with highest scores for a given dimensional reduction technique}
 \usage{
-DimTopCells(object, dim.use = 1, reduction.type = "pca", num.cells = NULL,
-  do.balanced = FALSE)
+DimTopCells(object, dim.use = 1, reduction.type = "pca",
+  num.cells = NULL, do.balanced = FALSE)
 }
 \arguments{
 \item{object}{An object}

--- a/man/DimTopGenes.Rd
+++ b/man/DimTopGenes.Rd
@@ -4,8 +4,8 @@
 \alias{DimTopGenes}
 \title{Find genes with highest scores for a given dimensional reduction technique}
 \usage{
-DimTopGenes(object, dim.use = 1, reduction.type = "pca", num.genes = 30,
-  use.full = FALSE, do.balanced = FALSE)
+DimTopGenes(object, dim.use = 1, reduction.type = "pca",
+  num.genes = 30, use.full = FALSE, do.balanced = FALSE)
 }
 \arguments{
 \item{object}{An object}

--- a/man/DoHeatmap.Rd
+++ b/man/DoHeatmap.Rd
@@ -4,12 +4,13 @@
 \alias{DoHeatmap}
 \title{Gene expression heatmap}
 \usage{
-DoHeatmap(object, data.use = NULL, use.scaled = TRUE, cells.use = NULL,
-  genes.use = NULL, disp.min = -2.5, disp.max = 2.5, group.by = "ident",
-  group.order = NULL, draw.line = TRUE, col.low = "#FF00FF",
-  col.mid = "#000000", col.high = "#FFFF00", slim.col.label = FALSE,
-  remove.key = FALSE, rotate.key = FALSE, title = NULL, cex.col = 10,
-  cex.row = 10, group.label.loc = "bottom", group.label.rot = FALSE,
+DoHeatmap(object, data.use = NULL, use.scaled = TRUE,
+  cells.use = NULL, genes.use = NULL, disp.min = -2.5,
+  disp.max = 2.5, group.by = "ident", group.order = NULL,
+  draw.line = TRUE, col.low = "#FF00FF", col.mid = "#000000",
+  col.high = "#FFFF00", slim.col.label = FALSE, remove.key = FALSE,
+  rotate.key = FALSE, title = NULL, cex.col = 10, cex.row = 10,
+  group.label.loc = "bottom", group.label.rot = FALSE,
   group.cex = 15, group.spacing = 0.15, assay.type = "RNA",
   do.plot = TRUE)
 }

--- a/man/DoKMeans.Rd
+++ b/man/DoKMeans.Rd
@@ -6,8 +6,8 @@
 \usage{
 DoKMeans(object, genes.use = NULL, k.genes = NULL, k.cells = 0,
   k.seed = 1, do.plot = FALSE, data.cut = 2.5,
-  k.cols = PurpleAndYellow(), set.ident = TRUE, do.constrained = FALSE,
-  assay.type = "RNA", ...)
+  k.cols = PurpleAndYellow(), set.ident = TRUE,
+  do.constrained = FALSE, assay.type = "RNA", ...)
 }
 \arguments{
 \item{object}{Seurat object}

--- a/man/FeatureHeatmap.Rd
+++ b/man/FeatureHeatmap.Rd
@@ -8,8 +8,8 @@ FeatureHeatmap(object, features.plot, dim.1 = 1, dim.2 = 2,
   idents.use = NULL, pt.size = 2, cols.use = c("grey", "red"),
   pch.use = 16, reduction.use = "tsne", group.by = NULL,
   data.use = "data", sep.scale = FALSE, do.return = FALSE,
-  min.exp = -Inf, max.exp = Inf, rotate.key = FALSE, plot.horiz = FALSE,
-  key.position = "right")
+  min.exp = -Inf, max.exp = Inf, rotate.key = FALSE,
+  plot.horiz = FALSE, key.position = "right")
 }
 \arguments{
 \item{object}{Seurat object}

--- a/man/FindMarkersNode.Rd
+++ b/man/FindMarkersNode.Rd
@@ -5,7 +5,8 @@
 \title{Gene expression markers of identity classes defined by a phylogenetic clade}
 \usage{
 FindMarkersNode(object, node, tree.use = NULL, genes.use = NULL,
-  logfc.threshold = 0.25, test.use = "wilcox", assay.type = "RNA", ...)
+  logfc.threshold = 0.25, test.use = "wilcox", assay.type = "RNA",
+  ...)
 }
 \arguments{
 \item{object}{Seurat object}

--- a/man/FindVariableGenes.Rd
+++ b/man/FindVariableGenes.Rd
@@ -16,9 +16,10 @@ FindVariableGenes(object, ...)
   display.progress = TRUE, ...)
 
 \method{FindVariableGenes}{loom}(object, x.low.cutoff = 0.1,
-  x.high.cutoff = 8, y.cutoff = 1, y.high.cutoff = Inf, num.bin = 20,
-  chunk.size = 1000, normalized.data = "layers/norm_data",
-  overwrite = FALSE, display.progress = TRUE, ...)
+  x.high.cutoff = 8, y.cutoff = 1, y.high.cutoff = Inf,
+  num.bin = 20, chunk.size = 1000,
+  normalized.data = "layers/norm_data", overwrite = FALSE,
+  display.progress = TRUE, ...)
 }
 \arguments{
 \item{object}{An object}

--- a/man/GenePlot.Rd
+++ b/man/GenePlot.Rd
@@ -5,10 +5,10 @@
 \title{Scatter plot of single cell data}
 \usage{
 GenePlot(object, gene1, gene2, cell.ids = NULL, col.use = NULL,
-  pch.use = 16, cex.use = 1.5, use.imputed = FALSE, use.scaled = FALSE,
-  use.raw = FALSE, do.hover = FALSE, data.hover = "ident",
-  do.identify = FALSE, dark.theme = FALSE, do.spline = FALSE,
-  spline.span = 0.75, ...)
+  pch.use = 16, cex.use = 1.5, use.imputed = FALSE,
+  use.scaled = FALSE, use.raw = FALSE, do.hover = FALSE,
+  data.hover = "ident", do.identify = FALSE, dark.theme = FALSE,
+  do.spline = FALSE, spline.span = 0.75, ...)
 }
 \arguments{
 \item{object}{Seurat object}

--- a/man/GetAssayData.Rd
+++ b/man/GetAssayData.Rd
@@ -8,8 +8,8 @@
 \usage{
 GetAssayData(object, ...)
 
-\method{GetAssayData}{seurat}(object, assay.type = "RNA", slot = "data",
-  ...)
+\method{GetAssayData}{seurat}(object, assay.type = "RNA",
+  slot = "data", ...)
 
 \method{GetAssayData}{loom}(object, slot = "data", cells.use = NULL,
   genes.use = NULL, cell.names = "col_attrs/cell_names",

--- a/man/GetDimReduction.Rd
+++ b/man/GetDimReduction.Rd
@@ -14,7 +14,8 @@ GetDimReduction(object, ...)
 
 \method{GetDimReduction}{loom}(object, reduction.type = "pca",
   slot = "gene_loadings", dataset.use = NULL,
-  gene.names = "row_attrs/gene_names", cell.names = "col_attrs/cell_names")
+  gene.names = "row_attrs/gene_names",
+  cell.names = "col_attrs/cell_names")
 }
 \arguments{
 \item{object}{An object}

--- a/man/GetVariableGenes.Rd
+++ b/man/GetVariableGenes.Rd
@@ -7,10 +7,12 @@
 \usage{
 GetVariableGenes(object, ...)
 
-\method{GetVariableGenes}{loom}(object)
+\method{GetVariableGenes}{loom}(object, row.names = "gene_names")
 }
 \arguments{
 \item{object}{An object}
+
+\item{row.names}{Name of dataset for gene names in loom objects. Default to "gene_names". Duplicates are not allowed.}
 }
 \value{
 A dataframe with four columns

--- a/man/HTODemux.Rd
+++ b/man/HTODemux.Rd
@@ -6,7 +6,8 @@
 \usage{
 HTODemux(object, percent_cutoff = 0.999, init_centers = NULL,
   cluster_nstarts = 100, k_function = "kmeans", nsamples = 100,
-  print.output = TRUE, assay.type = "HTO", confidence_threshold = 0.05)
+  print.output = TRUE, assay.type = "HTO",
+  confidence_threshold = 0.05)
 }
 \arguments{
 \item{object}{Seurat object. Assumes that the hash tag oligo (HTO) data has been added and normalized in the HTO slot.}

--- a/man/HoverLocator.Rd
+++ b/man/HoverLocator.Rd
@@ -4,7 +4,8 @@
 \alias{HoverLocator}
 \title{Hover Locator}
 \usage{
-HoverLocator(plot, data.plot, features.info = NULL, dark.theme = FALSE, ...)
+HoverLocator(plot, data.plot, features.info = NULL, dark.theme = FALSE,
+  ...)
 }
 \arguments{
 \item{plot}{A ggplot2 plot}

--- a/man/JackStraw.Rd
+++ b/man/JackStraw.Rd
@@ -5,7 +5,8 @@
 \title{Determine statistical significance of PCA scores.}
 \usage{
 JackStraw(object, num.pc = 20, num.replicate = 100, prop.freq = 0.01,
-  display.progress = TRUE, do.par = FALSE, num.cores = 1, maxit = 1000)
+  display.progress = TRUE, do.par = FALSE, num.cores = 1,
+  maxit = 1000)
 }
 \arguments{
 \item{object}{Seurat object}

--- a/man/KMeansHeatmap.Rd
+++ b/man/KMeansHeatmap.Rd
@@ -4,9 +4,9 @@
 \alias{KMeansHeatmap}
 \title{Plot k-means clusters}
 \usage{
-KMeansHeatmap(object, cells.use = object@cell.names, genes.cluster = NULL,
-  max.genes = 1e+06, slim.col.label = TRUE, remove.key = TRUE,
-  row.lines = TRUE, ...)
+KMeansHeatmap(object, cells.use = object@cell.names,
+  genes.cluster = NULL, max.genes = 1e+06, slim.col.label = TRUE,
+  remove.key = TRUE, row.lines = TRUE, ...)
 }
 \arguments{
 \item{object}{A Seurat object}

--- a/man/MASTDETest.Rd
+++ b/man/MASTDETest.Rd
@@ -4,8 +4,8 @@
 \alias{MASTDETest}
 \title{Differential expression using MAST}
 \usage{
-MASTDETest(object, cells.1, cells.2, genes.use = NULL, latent.vars = NULL,
-  assay.type = "RNA", ...)
+MASTDETest(object, cells.1, cells.2, genes.use = NULL,
+  latent.vars = NULL, assay.type = "RNA", ...)
 }
 \arguments{
 \item{object}{Seurat object}

--- a/man/MarkerTest.Rd
+++ b/man/MarkerTest.Rd
@@ -4,8 +4,8 @@
 \alias{MarkerTest}
 \title{ROC-based marker discovery}
 \usage{
-MarkerTest(object, cells.1, cells.2, genes.use = NULL, print.bar = TRUE,
-  assay.type = "RNA")
+MarkerTest(object, cells.1, cells.2, genes.use = NULL,
+  print.bar = TRUE, assay.type = "RNA")
 }
 \arguments{
 \item{object}{Seurat object}

--- a/man/MergeSeurat.Rd
+++ b/man/MergeSeurat.Rd
@@ -5,9 +5,10 @@
 \title{Merge Seurat Objects}
 \usage{
 MergeSeurat(object1, object2, project = NULL, min.cells = 0,
-  min.genes = 0, is.expr = 0, do.normalize = TRUE, scale.factor = 10000,
-  do.scale = FALSE, do.center = FALSE, names.field = 1,
-  names.delim = "_", add.cell.id1 = NULL, add.cell.id2 = NULL)
+  min.genes = 0, is.expr = 0, do.normalize = TRUE,
+  scale.factor = 10000, do.scale = FALSE, do.center = FALSE,
+  names.field = 1, names.delim = "_", add.cell.id1 = NULL,
+  add.cell.id2 = NULL)
 }
 \arguments{
 \item{object1}{First Seurat object to merge}

--- a/man/MetageneBicorPlot.Rd
+++ b/man/MetageneBicorPlot.Rd
@@ -4,9 +4,9 @@
 \alias{MetageneBicorPlot}
 \title{Plot CC bicor saturation plot}
 \usage{
-MetageneBicorPlot(object, bicor.data, grouping.var, dims.eval, gene.num = 30,
-  num.possible.genes = 2000, return.mat = FALSE, smooth = TRUE,
-  display.progress = TRUE)
+MetageneBicorPlot(object, bicor.data, grouping.var, dims.eval,
+  gene.num = 30, num.possible.genes = 2000, return.mat = FALSE,
+  smooth = TRUE, display.progress = TRUE)
 }
 \arguments{
 \item{object}{A Seurat object}

--- a/man/OldDoHeatmap.Rd
+++ b/man/OldDoHeatmap.Rd
@@ -4,11 +4,12 @@
 \alias{OldDoHeatmap}
 \title{Gene expression heatmap}
 \usage{
-OldDoHeatmap(object, cells.use = NULL, genes.use = NULL, disp.min = NULL,
-  disp.max = NULL, draw.line = TRUE, do.return = FALSE,
-  order.by.ident = TRUE, col.use = PurpleAndYellow(),
-  slim.col.label = FALSE, group.by = NULL, remove.key = FALSE,
-  cex.col = NULL, do.scale = TRUE, ...)
+OldDoHeatmap(object, cells.use = NULL, genes.use = NULL,
+  disp.min = NULL, disp.max = NULL, draw.line = TRUE,
+  do.return = FALSE, order.by.ident = TRUE,
+  col.use = PurpleAndYellow(), slim.col.label = FALSE,
+  group.by = NULL, remove.key = FALSE, cex.col = NULL,
+  do.scale = TRUE, ...)
 }
 \arguments{
 \item{object}{Seurat object}

--- a/man/PCHeatmap.Rd
+++ b/man/PCHeatmap.Rd
@@ -5,9 +5,9 @@
 \title{Principal component heatmap}
 \usage{
 PCHeatmap(object, pc.use = 1, cells.use = NULL, num.genes = 30,
-  use.full = FALSE, disp.min = -2.5, disp.max = 2.5, do.return = FALSE,
-  col.use = PurpleAndYellow(), use.scale = TRUE, do.balanced = FALSE,
-  remove.key = FALSE, label.columns = NULL, ...)
+  use.full = FALSE, disp.min = -2.5, disp.max = 2.5,
+  do.return = FALSE, col.use = PurpleAndYellow(), use.scale = TRUE,
+  do.balanced = FALSE, remove.key = FALSE, label.columns = NULL, ...)
 }
 \arguments{
 \item{object}{Seurat object.}

--- a/man/PoissonDETest.Rd
+++ b/man/PoissonDETest.Rd
@@ -4,8 +4,9 @@
 \alias{PoissonDETest}
 \title{Poisson test for UMI-count based data}
 \usage{
-PoissonDETest(object, cells.1, cells.2, min.cells = 3, genes.use = NULL,
-  latent.vars = NULL, print.bar = TRUE, assay.type = "RNA")
+PoissonDETest(object, cells.1, cells.2, min.cells = 3,
+  genes.use = NULL, latent.vars = NULL, print.bar = TRUE,
+  assay.type = "RNA")
 }
 \arguments{
 \item{object}{Seurat object}

--- a/man/ProjectSeurat.Rd
+++ b/man/ProjectSeurat.Rd
@@ -15,10 +15,10 @@ ProjectSeurat(object, ...)
 \method{ProjectSeurat}{loom}(object, template, do.norm = TRUE,
   do.scale = TRUE, gene.names = "row_attrs/gene_names",
   cell.names = "col_attrs/cell_names", norm.data = "layers/norm_data",
-  scale.data = "layers/scale_data", chunk.size = 1000, overwrite = FALSE,
-  tsne.k = 11, tsne.rbf.gamma = 50, cluster.k = 11,
-  cluster.res = "res.0.8", display.progress = TRUE, chunk.dims = c(256,
-  256))
+  scale.data = "layers/scale_data", chunk.size = 1000,
+  overwrite = FALSE, tsne.k = 11, tsne.rbf.gamma = 50,
+  cluster.k = 11, cluster.res = "res.0.8", display.progress = TRUE,
+  chunk.dims = c(256, 256))
 }
 \arguments{
 \item{object}{An object to project back to}

--- a/man/ReorderIdent.Rd
+++ b/man/ReorderIdent.Rd
@@ -4,8 +4,8 @@
 \alias{ReorderIdent}
 \title{Reorder identity classes}
 \usage{
-ReorderIdent(object, feature = "PC1", rev = FALSE, aggregate.fxn = mean,
-  reorder.numeric = FALSE, ...)
+ReorderIdent(object, feature = "PC1", rev = FALSE,
+  aggregate.fxn = mean, reorder.numeric = FALSE, ...)
 }
 \arguments{
 \item{object}{Seurat object}

--- a/man/RidgePlot.Rd
+++ b/man/RidgePlot.Rd
@@ -5,11 +5,12 @@
 \title{Single cell ridge plot}
 \usage{
 RidgePlot(object, features.plot, ident.include = NULL, nCol = NULL,
-  do.sort = FALSE, y.max = NULL, same.y.lims = FALSE, size.x.use = 16,
-  size.y.use = 16, size.title.use = 20, cols.use = NULL,
-  group.by = NULL, y.log = FALSE, x.lab.rot = FALSE, y.lab.rot = FALSE,
-  legend.position = "right", single.legend = TRUE, remove.legend = FALSE,
-  do.return = FALSE, return.plotlist = FALSE, ...)
+  do.sort = FALSE, y.max = NULL, same.y.lims = FALSE,
+  size.x.use = 16, size.y.use = 16, size.title.use = 20,
+  cols.use = NULL, group.by = NULL, y.log = FALSE,
+  x.lab.rot = FALSE, y.lab.rot = FALSE, legend.position = "right",
+  single.legend = TRUE, remove.legend = FALSE, do.return = FALSE,
+  return.plotlist = FALSE, ...)
 }
 \arguments{
 \item{object}{Seurat object}

--- a/man/RunDiffusion.Rd
+++ b/man/RunDiffusion.Rd
@@ -4,9 +4,10 @@
 \alias{RunDiffusion}
 \title{Run diffusion map}
 \usage{
-RunDiffusion(object, cells.use = NULL, dims.use = 1:5, genes.use = NULL,
-  reduction.use = "pca", q.use = 0.01, max.dim = 2, scale.clip = 10,
-  reduction.name = "dm", reduction.key = "DM", ...)
+RunDiffusion(object, cells.use = NULL, dims.use = 1:5,
+  genes.use = NULL, reduction.use = "pca", q.use = 0.01,
+  max.dim = 2, scale.clip = 10, reduction.name = "dm",
+  reduction.key = "DM", ...)
 }
 \arguments{
 \item{object}{Seurat object}

--- a/man/RunICA.Rd
+++ b/man/RunICA.Rd
@@ -4,10 +4,10 @@
 \alias{RunICA}
 \title{Run Independent Component Analysis on gene expression}
 \usage{
-RunICA(object, ic.genes = NULL, ics.compute = 50, use.imputed = FALSE,
-  rev.ica = FALSE, print.results = TRUE, ics.print = 1:5,
-  genes.print = 50, ica.function = "icafast", seed.use = 1,
-  reduction.name = "ica", reduction.key = "IC", ...)
+RunICA(object, ic.genes = NULL, ics.compute = 50,
+  use.imputed = FALSE, rev.ica = FALSE, print.results = TRUE,
+  ics.print = 1:5, genes.print = 50, ica.function = "icafast",
+  seed.use = 1, reduction.name = "ica", reduction.key = "IC", ...)
 }
 \arguments{
 \item{object}{Seurat object}

--- a/man/RunPCA.Rd
+++ b/man/RunPCA.Rd
@@ -17,11 +17,13 @@ RunPCA(object, ...)
 
 \method{RunPCA}{loom}(object, pcs.compute = 75, pc.genes = NULL,
   online.pca = TRUE, covariance.mat = NULL, cells.initial = 50000,
-  chunk.size = 1000, do.print = TRUE, pcs.print = 1:5, genes.print = 30,
-  gene.names = "row_attrs/gene_names", gene.means = "row_attrs/gene_means",
+  chunk.size = 1000, do.print = TRUE, pcs.print = 1:5,
+  genes.print = 30, gene.names = "row_attrs/gene_names",
+  gene.means = "row_attrs/gene_means",
   gene.variance = "row_attrs/gene_dispersion",
   var.genes = "row_attrs/var_genes", scale.data = "layers/scale_data",
-  ngene = NULL, overwrite = FALSE, display.progress = TRUE, ...)
+  cell.names = "col_attrs/cell_names", ngene = NULL,
+  overwrite = FALSE, display.progress = TRUE, ...)
 }
 \arguments{
 \item{object}{An object to run PCA on}
@@ -71,6 +73,8 @@ NULL will not set a seed.}
 \item{gene.variance}{Path to gene variance dataset}
 
 \item{scale.data}{Path to scaled data matrix}
+
+\item{cell.names}{Path to cell names dataset}
 
 \item{ngene}{Number of variable genes to use}
 

--- a/man/RunTSNE.Rd
+++ b/man/RunTSNE.Rd
@@ -9,16 +9,17 @@
 \usage{
 RunTSNE(object, ...)
 
-\method{RunTSNE}{seurat}(object, reduction.use = "pca", cells.use = NULL,
-  dims.use = 1:5, genes.use = NULL, seed.use = 1, tsne.method = "Rtsne",
-  add.iter = 0, dim.embed = 2, distance.matrix = NULL,
-  reduction.name = "tsne", reduction.key = "tSNE_", ...)
+\method{RunTSNE}{seurat}(object, reduction.use = "pca",
+  cells.use = NULL, dims.use = 1:5, genes.use = NULL, seed.use = 1,
+  tsne.method = "Rtsne", add.iter = 0, dim.embed = 2,
+  distance.matrix = NULL, reduction.name = "tsne",
+  reduction.key = "tSNE_", ...)
 
 \method{RunTSNE}{loom}(object, reduction.use = "pca", cells.use = NULL,
-  dims.use = 1:5, genes.use = NULL, seed.use = 1, tsne.method = "Rtsne",
-  add.iter = 0, dim.embed = 2, distance.matrix = NULL,
-  reduction.name = "tsne", reduction.key = "tSNE_", overwrite = FALSE,
-  ...)
+  dims.use = 1:5, genes.use = NULL, seed.use = 1,
+  tsne.method = "Rtsne", add.iter = 0, dim.embed = 2,
+  distance.matrix = NULL, reduction.name = "tsne",
+  reduction.key = "tSNE_", overwrite = FALSE, ...)
 }
 \arguments{
 \item{object}{Seurat object}

--- a/man/RunUMAP.Rd
+++ b/man/RunUMAP.Rd
@@ -4,10 +4,10 @@
 \alias{RunUMAP}
 \title{Run UMAP}
 \usage{
-RunUMAP(object, cells.use = NULL, dims.use = 1:5, reduction.use = "pca",
-  genes.use = NULL, assay.use = "RNA", max.dim = 2L,
-  reduction.name = "umap", reduction.key = "UMAP", n_neighbors = 30L,
-  min_dist = 0.3, metric = "correlation", ...)
+RunUMAP(object, cells.use = NULL, dims.use = 1:5,
+  reduction.use = "pca", genes.use = NULL, assay.use = "RNA",
+  max.dim = 2L, reduction.name = "umap", reduction.key = "UMAP",
+  n_neighbors = 30L, min_dist = 0.3, metric = "correlation", ...)
 }
 \arguments{
 \item{object}{Seurat object}

--- a/man/SampleUMI.Rd
+++ b/man/SampleUMI.Rd
@@ -4,7 +4,8 @@
 \alias{SampleUMI}
 \title{Sample UMI}
 \usage{
-SampleUMI(data, max.umi = 1000, upsample = FALSE, progress.bar = TRUE)
+SampleUMI(data, max.umi = 1000, upsample = FALSE,
+  progress.bar = TRUE)
 }
 \arguments{
 \item{data}{Matrix with the raw count data}

--- a/man/ScaleData.Rd
+++ b/man/ScaleData.Rd
@@ -9,17 +9,19 @@
 ScaleData(object, ...)
 
 \method{ScaleData}{seurat}(object, genes.use = NULL, data.use = NULL,
-  vars.to.regress, model.use = "linear", use.umi = FALSE, do.scale = TRUE,
-  do.center = TRUE, scale.max = 10, block.size = 1000,
-  min.cells.to.block = 3000, display.progress = TRUE, assay.type = "RNA",
-  do.cpp = TRUE, check.for.norm = TRUE, do.par = FALSE, num.cores = 1)
+  vars.to.regress, model.use = "linear", use.umi = FALSE,
+  do.scale = TRUE, do.center = TRUE, scale.max = 10,
+  block.size = 1000, min.cells.to.block = 3000,
+  display.progress = TRUE, assay.type = "RNA", do.cpp = TRUE,
+  check.for.norm = TRUE, do.par = FALSE, num.cores = 1)
 
 \method{ScaleData}{loom}(object, genes.use = "row_attrs/var_genes",
   name = "scale_data", vars.to.regress = NULL, model.use = "linear",
-  use.umi = FALSE, do.scale = TRUE, do.center = TRUE, scale.max = 10,
-  chunk.size = 1000, normalized.data = "layers/norm_data",
-  overwrite = FALSE, display.progress = TRUE, dtype = h5types$float,
-  chunk.dims = c(256, 256))
+  use.umi = FALSE, do.scale = TRUE, do.center = TRUE,
+  scale.max = 10, chunk.size = 1000,
+  normalized.data = "layers/norm_data", overwrite = FALSE,
+  display.progress = TRUE, dtype = h5types$float, chunk.dims = c(256,
+  256))
 }
 \arguments{
 \item{object}{Object to scale}

--- a/man/ScaleDataR.Rd
+++ b/man/ScaleDataR.Rd
@@ -4,8 +4,8 @@
 \alias{ScaleDataR}
 \title{Old R based implementation of ScaleData. Scales and centers the data}
 \usage{
-ScaleDataR(object, genes.use = NULL, data.use = NULL, do.scale = TRUE,
-  do.center = TRUE, scale.max = 10)
+ScaleDataR(object, genes.use = NULL, data.use = NULL,
+  do.scale = TRUE, do.center = TRUE, scale.max = 10)
 }
 \arguments{
 \item{object}{Seurat object}

--- a/man/SetDimReduction.Rd
+++ b/man/SetDimReduction.Rd
@@ -9,7 +9,8 @@
 \usage{
 SetDimReduction(object, ...)
 
-\method{SetDimReduction}{seurat}(object, reduction.type, slot, new.data, ...)
+\method{SetDimReduction}{seurat}(object, reduction.type, slot, new.data,
+  ...)
 
 \method{SetDimReduction}{loom}(object, reduction.type, slot, new.data,
   overwrite = FALSE, ...)

--- a/man/SubsetData.Rd
+++ b/man/SubsetData.Rd
@@ -4,11 +4,11 @@
 \alias{SubsetData}
 \title{Return a subset of the Seurat object}
 \usage{
-SubsetData(object, cells.use = NULL, subset.name = NULL, ident.use = NULL,
-  ident.remove = NULL, accept.low = -Inf, accept.high = Inf,
-  accept.value = NULL, do.center = FALSE, do.scale = FALSE,
-  max.cells.per.ident = Inf, random.seed = 1, do.clean = FALSE,
-  subset.raw, ...)
+SubsetData(object, cells.use = NULL, subset.name = NULL,
+  ident.use = NULL, ident.remove = NULL, accept.low = -Inf,
+  accept.high = Inf, accept.value = NULL, do.center = FALSE,
+  do.scale = FALSE, max.cells.per.ident = Inf, random.seed = 1,
+  do.clean = FALSE, subset.raw, ...)
 }
 \arguments{
 \item{object}{Seurat object}

--- a/man/SubsetSeurat.Rd
+++ b/man/SubsetSeurat.Rd
@@ -9,10 +9,12 @@
 SubsetSeurat(object, cells, ...)
 
 \S4method{SubsetSeurat}{loom}(object, cells, return.type = "seurat",
-  cell.names = "col_attrs/cell_names", gene.names = "row_attrs/gene_names",
-  filename = NULL, remove.existing = FALSE, display.progress = TRUE,
-  chunk.size = 1000, keep.layers = FALSE, norm.data = "layers/norm_data",
-  scale.data = "layers/scale_data", ...)
+  cell.names = "col_attrs/cell_names",
+  gene.names = "row_attrs/gene_names", filename = NULL,
+  remove.existing = FALSE, display.progress = TRUE,
+  chunk.size = 1000, keep.layers = FALSE,
+  norm.data = "layers/norm_data", scale.data = "layers/scale_data",
+  ...)
 }
 \arguments{
 \item{object}{An object to subset}

--- a/man/VariableGenePlot.Rd
+++ b/man/VariableGenePlot.Rd
@@ -5,11 +5,11 @@
 \title{View variable genes}
 \usage{
 VariableGenePlot(object, do.text = TRUE, cex.use = 0.5,
-  cex.text.use = 0.5, do.spike = FALSE, pch.use = 16, col.use = "black",
-  spike.col.use = "red", plot.both = FALSE, do.contour = TRUE,
-  contour.lwd = 3, contour.col = "white", contour.lty = 2,
-  x.low.cutoff = 0.1, x.high.cutoff = 8, y.cutoff = 1,
-  y.high.cutoff = Inf)
+  cex.text.use = 0.5, do.spike = FALSE, pch.use = 16,
+  col.use = "black", spike.col.use = "red", plot.both = FALSE,
+  do.contour = TRUE, contour.lwd = 3, contour.col = "white",
+  contour.lty = 2, x.low.cutoff = 0.1, x.high.cutoff = 8,
+  y.cutoff = 1, y.high.cutoff = Inf)
 }
 \arguments{
 \item{object}{Seurat object}

--- a/man/VlnPlot.Rd
+++ b/man/VlnPlot.Rd
@@ -5,12 +5,13 @@
 \title{Single cell violin plot}
 \usage{
 VlnPlot(object, features.plot, ident.include = NULL, nCol = NULL,
-  do.sort = FALSE, y.max = NULL, same.y.lims = FALSE, size.x.use = 16,
-  size.y.use = 16, size.title.use = 20, adjust.use = 1,
-  point.size.use = 1, cols.use = NULL, group.by = NULL, y.log = FALSE,
-  x.lab.rot = FALSE, y.lab.rot = FALSE, legend.position = "right",
-  single.legend = TRUE, remove.legend = FALSE, do.return = FALSE,
-  return.plotlist = FALSE, ...)
+  do.sort = FALSE, y.max = NULL, same.y.lims = FALSE,
+  size.x.use = 16, size.y.use = 16, size.title.use = 20,
+  adjust.use = 1, point.size.use = 1, cols.use = NULL,
+  group.by = NULL, y.log = FALSE, x.lab.rot = FALSE,
+  y.lab.rot = FALSE, legend.position = "right", single.legend = TRUE,
+  remove.legend = FALSE, do.return = FALSE, return.plotlist = FALSE,
+  ...)
 }
 \arguments{
 \item{object}{Seurat object}

--- a/man/WhichCells.Rd
+++ b/man/WhichCells.Rd
@@ -4,9 +4,10 @@
 \alias{WhichCells}
 \title{Identify cells matching certain criteria}
 \usage{
-WhichCells(object, ident = NULL, ident.remove = NULL, cells.use = NULL,
-  subset.name = NULL, accept.low = -Inf, accept.high = Inf,
-  accept.value = NULL, max.cells.per.ident = Inf, random.seed = 1, ...)
+WhichCells(object, ident = NULL, ident.remove = NULL,
+  cells.use = NULL, subset.name = NULL, accept.low = -Inf,
+  accept.high = Inf, accept.value = NULL, max.cells.per.ident = Inf,
+  random.seed = 1, ...)
 }
 \arguments{
 \item{object}{Seurat object}

--- a/man/WilcoxDETest.Rd
+++ b/man/WilcoxDETest.Rd
@@ -4,8 +4,8 @@
 \alias{WilcoxDETest}
 \title{Differential expression using Wilcoxon Rank Sum}
 \usage{
-WilcoxDETest(object, cells.1, cells.2, genes.use = NULL, print.bar = TRUE,
-  assay.type = "RNA", ...)
+WilcoxDETest(object, cells.1, cells.2, genes.use = NULL,
+  print.bar = TRUE, assay.type = "RNA", ...)
 }
 \arguments{
 \item{object}{Seurat object}


### PR DESCRIPTION
There're several things I have changed here, for the loom branch. First, the original loom branch often assumes that the gene names are stored in "row_attrs/gene_names" and cell names are stored in "col_attrs/cell_names". Actually the functions `GetAssayData` and `GetDimReduction` have arguments that allow us to specify custom names for datasets for gene names and cell names, but other functions that call them do not give us the opportunity to specify and assume the default names. I got a dataset where the cell names are in "col_attrs/CellID" and I want to use transcript accessions in "row_attrs/Accession" rather than names since there're multiple isoforms of the same gene, so I added the `gene.names` and `cell.names` arguments to `RunPCA` and `RunTSNE` so we can use custom datasets names.

Another important thing I changed is to make `FindVariableGenes.loom` store parameters as attributes to `row_attrs/var_genes`, for I think that's the most sensible place to store such parameters. I have made some other changes to fix what I perceived to be bugs. See the commits and diffs. Now the modified version of Seurat for loom works for my purposes. There's another thing to note: I often got warnings from loom when running PCA that batch.next and batch.scan are deprecated and use map and apply instead. I did not fix this since it doesn't seem to affect results, but in order to get the new version of Seurat to CRAN, you'd better fix this.