### PR TITLE
Updated suggestions that recommended deprecated MeanVarPlot function

### DIFF
--- a/R/dimensional_reduction.R
+++ b/R/dimensional_reduction.R
@@ -544,7 +544,7 @@ RunCCA <- function(
     if (missing(x = genes.use)) {
       genes.use <- union(x = object@var.genes, y = object2@var.genes)
       if (length(x = genes.use) == 0) {
-        stop("No variable genes present. Run MeanVarPlot and retry")
+        stop("No variable genes present. Run FindVariableGenes and retry")
       }
     }
     if (scale.data) {
@@ -810,7 +810,7 @@ RunMultiCCA <- function(
       }
       genes.use <- unique(genes.use)
       if (length(x = genes.use) == 0) {
-        stop("No variable genes present. Run MeanVarPlot and retry")
+        stop("No variable genes present. Run FindVariableGenes and retry")
       }
     }
     for(obj in object.list) {

--- a/R/dimensional_reduction_internal.R
+++ b/R/dimensional_reduction_internal.R
@@ -48,7 +48,7 @@ PrepDR <- function(
   assay.type="RNA"
 ) {
   if (length(object@var.genes) == 0 && is.null(x = genes.use)) {
-    stop("Variable genes haven't been set. Run MeanVarPlot() or provide a vector
+    stop("Variable genes haven't been set. Run FindVariableGenes() or provide a vector
           of genes names in genes.use and retry.")
   }
   if (use.imputed) {


### PR DESCRIPTION
`MeanVarPlot` has been replaced by `FindVariableGenes`. Updated error messages to reflect this.