### PR TITLE
Rename `percent.mito` to `fraction.mito`

### DIFF
--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -872,7 +872,7 @@ Read10X_h5 <- function(filename, use.names = TRUE) {
 #' is set to NULL; default is 1.3
 #' @param return.dev.residuals Place deviance residuals instead of Pearson residuals in scale.data slot; default is FALSE
 #' @param vars.to.regress Variables to regress out in a second non-regularized linear
-#' regression. For example, percent.mito. Default is NULL
+#' regression. For example, fraction.mito. Default is NULL
 #' @param do.scale Whether to scale residuals to have unit variance; default is FALSE
 #' @param do.center Whether to center residuals to have mean zero; default is TRUE
 #' @param clip.range Range to clip the residuals to; default is \code{c(-sqrt(n/30), sqrt(n/30))},
@@ -1829,7 +1829,7 @@ RunALRA.Seurat <- function(
 #'
 #' @param features Vector of features names to scale/center. Default is all features
 #' @param vars.to.regress Variables to regress out (previously latent.vars in
-#' RegressOut). For example, nUMI, or percent.mito.
+#' RegressOut). For example, nUMI, or fraction.mito.
 #' @param latent.data Extra data to regress out, should be cells x latent data
 #' @param model.use Use a linear model or generalized linear model
 #' (poisson, negative binomial) for the regression. Options are 'linear'

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -685,7 +685,7 @@ DimPlot <- function(
 #' @param features Vector of features to plot. Features can come from:
 #' \itemize{
 #'     \item An \code{Assay} feature (e.g. a gene name - "MS4A1")
-#'     \item A column name from meta.data (e.g. mitochondrial percentage - "percent.mito")
+#'     \item A column name from meta.data (e.g. mitochondrial percentage - "fraction.mito")
 #'     \item A column name from a \code{DimReduc} object corresponding to the cell embedding values
 #'     (e.g. the PC1 scores - "PC_1")
 #' }
@@ -2220,7 +2220,7 @@ FeatureLocator <- function(plot, ...) {
 #' @examples
 #' \dontrun{
 #' plot <- DimPlot(object = pbmc_small)
-#' HoverLocator(plot = plot, information = FetchData(object = pbmc_small, vars = 'percent.mito'))
+#' HoverLocator(plot = plot, information = FetchData(object = pbmc_small, vars = 'fraction.mito'))
 #' }
 #'
 HoverLocator <- function(

--- a/man/FeaturePlot.Rd
+++ b/man/FeaturePlot.Rd
@@ -18,7 +18,7 @@ FeaturePlot(object, features, dims = c(1, 2), cells = NULL,
 \item{features}{Vector of features to plot. Features can come from:
 \itemize{
     \item An \code{Assay} feature (e.g. a gene name - "MS4A1")
-    \item A column name from meta.data (e.g. mitochondrial percentage - "percent.mito")
+    \item A column name from meta.data (e.g. mitochondrial percentage - "fraction.mito")
     \item A column name from a \code{DimReduc} object corresponding to the cell embedding values
     (e.g. the PC1 scores - "PC_1")
 }}

--- a/man/HoverLocator.Rd
+++ b/man/HoverLocator.Rd
@@ -21,7 +21,7 @@ Get quick information from a scatterplot by hovering over points
 \examples{
 \dontrun{
 plot <- DimPlot(object = pbmc_small)
-HoverLocator(plot = plot, information = FetchData(object = pbmc_small, vars = 'percent.mito'))
+HoverLocator(plot = plot, information = FetchData(object = pbmc_small, vars = 'fraction.mito'))
 }
 
 }

--- a/man/PolyFeaturePlot.Rd
+++ b/man/PolyFeaturePlot.Rd
@@ -14,7 +14,7 @@ PolyFeaturePlot(object, features, cells = NULL, poly.data = "spatial",
 \item{features}{Vector of features to plot. Features can come from:
 \itemize{
     \item An \code{Assay} feature (e.g. a gene name - "MS4A1")
-    \item A column name from meta.data (e.g. mitochondrial percentage - "percent.mito")
+    \item A column name from meta.data (e.g. mitochondrial percentage - "fraction.mito")
     \item A column name from a \code{DimReduc} object corresponding to the cell embedding values
     (e.g. the PC1 scores - "PC_1")
 }}

--- a/man/SCTransform.Rd
+++ b/man/SCTransform.Rd
@@ -29,7 +29,7 @@ is set to NULL; default is 1.3}
 \item{return.dev.residuals}{Place deviance residuals instead of Pearson residuals in scale.data slot; default is FALSE}
 
 \item{vars.to.regress}{Variables to regress out in a second non-regularized linear
-regression. For example, percent.mito. Default is NULL}
+regression. For example, fraction.mito. Default is NULL}
 
 \item{do.scale}{Whether to scale residuals to have unit variance; default is FALSE}
 

--- a/man/ScaleData.Rd
+++ b/man/ScaleData.Rd
@@ -34,7 +34,7 @@ ScaleData(object, ...)
 \item{features}{Vector of features names to scale/center. Default is all features}
 
 \item{vars.to.regress}{Variables to regress out (previously latent.vars in
-RegressOut). For example, nUMI, or percent.mito.}
+RegressOut). For example, nUMI, or fraction.mito.}
 
 \item{latent.data}{Extra data to regress out, should be cells x latent data}
 


### PR DESCRIPTION
The data range is 0 - 1, not 0 - 100.
Thus, when specifying `percent.mito=1` to ask for 1 %, in fact the interpretation is in 100 %.

Instead of changing the behaviour, the name is adjusted to break as little existing code (and in a controlled manner only, resulting in an error message instead of silently changing the results).

All changes in this commit were introduced by the following command:

```sh
find -type f -not -path ./.git/\* \
  -exec sed -i 's/percent\.mito/fraction.mito/g' "{}" \;
```

This commit fixes #1235.