### PR TITLE
Reads H5AD files with zeroed cols

### DIFF
--- a/R/objects.R
+++ b/R/objects.R
@@ -2631,7 +2631,7 @@ ReadH5AD.H5File <- function(file, assay = 'RNA', verbose = TRUE, ...) {
     x <- Matrix::sparseMatrix(i = file[["X"]][["indices"]][],
                      p = file[["X"]][["indptr"]][],
                      x = file[["X"]][["data"]][],
-                     dims = hdf5r::h5attr(file[['X']], 'h5sparse_shape')[c(2, 1)])
+                     dims = hdf5r::h5attr(x = file[['X']], which = 'h5sparse_shape')[c(2, 1)])
   } else {
     x <- file[['X']][, ]
   }

--- a/R/objects.R
+++ b/R/objects.R
@@ -2628,8 +2628,10 @@ ReadH5AD.H5File <- function(file, assay = 'RNA', verbose = TRUE, ...) {
     message("Pulling expression matrices and metadata")
   }
   if (is(object = file[['X']], class2 = 'H5Group')) {
-    x <- as.sparse(x = file[['X']])
-    slot(object = x, name = 'Dim') <- c(length(file[["var"]][]$index), length(file[["obs"]][]$index))
+    x <- Matrix::sparseMatrix(i = file[["X"]][["indices"]][],
+                     p = file[["X"]][["indptr"]][],
+                     x = file[["X"]][["data"]][],
+                     dims = h5attr(file[['X']], 'h5sparse_shape')[c(2, 1)])
   } else {
     x <- file[['X']][, ]
   }

--- a/R/objects.R
+++ b/R/objects.R
@@ -2631,7 +2631,7 @@ ReadH5AD.H5File <- function(file, assay = 'RNA', verbose = TRUE, ...) {
     x <- Matrix::sparseMatrix(i = file[["X"]][["indices"]][],
                      p = file[["X"]][["indptr"]][],
                      x = file[["X"]][["data"]][],
-                     dims = h5attr(file[['X']], 'h5sparse_shape')[c(2, 1)])
+                     dims = hdf5r::h5attr(file[['X']], 'h5sparse_shape')[c(2, 1)])
   } else {
     x <- file[['X']][, ]
   }


### PR DESCRIPTION
`as.sparse()` returns `indptr` as wrong size if some columns or rows are zeroed. setting the `Dim` slot after allows the rownames to be set and the seurat object to be created. But the dgcmatrix is not able to be computed on because 'p' is still the wrong length. 

Explicitly creating the sparse matrix with the `dims` argument set fixes issue #1021 

This may also need to be done for `WriteH5AD()` 