### PR TITLE
Let RunPCA report total variance

### DIFF
--- a/R/dimensional_reduction.R
+++ b/R/dimensional_reduction.R
@@ -812,7 +812,7 @@ RunPCA.default <- function(
   if (rev.pca) {
     npcs <- min(npcs, ncol(x = object) - 1)
     pca.results <- irlba(A = object, nv = npcs, ...)
-    total_variance <- sum(RowVar(t(object)))
+    total.variance <- sum(RowVar(x = t(x = object)))
     sdev <- pca.results$d/sqrt(max(1, nrow(x = object) - 1))
     if (weight.by.var) {
       feature.loadings <- pca.results$u %*% diag(pca.results$d)
@@ -825,7 +825,7 @@ RunPCA.default <- function(
     if (approx) {
       npcs <- min(npcs, nrow(x = object) - 1)
       pca.results <- irlba(A = t(x = object), nv = npcs, ...)
-      total_variance <- sum(RowVar(object))
+      total.variance <- sum(RowVar(x = object))
       feature.loadings <- pca.results$v
       sdev <- pca.results$d/sqrt(max(1, ncol(object) - 1))
       if (weight.by.var) {
@@ -838,7 +838,7 @@ RunPCA.default <- function(
       pca.results <- prcomp(x = t(object), rank. = npcs, ...)
       feature.loadings <- pca.results$rotation
       sdev <- pca.results$sdev
-      total_variance <- sum(sdev)
+      total.variance <- sum(sdev)
       if (weight.by.var) {
         cell.embeddings <- pca.results$x %*% diag(pca.results$sdev[1:npcs]^2)
       } else {
@@ -856,7 +856,7 @@ RunPCA.default <- function(
     assay = assay,
     stdev = sdev,
     key = reduction.key,
-    misc = list(total_variance = total_variance)
+    misc = list(total.variance = total.variance)
   )
   if (verbose) {
     print(x = reduction.data, dims = ndims.print, nfeatures = nfeatures.print)

--- a/R/dimensional_reduction.R
+++ b/R/dimensional_reduction.R
@@ -812,6 +812,7 @@ RunPCA.default <- function(
   if (rev.pca) {
     npcs <- min(npcs, ncol(x = object) - 1)
     pca.results <- irlba(A = object, nv = npcs, ...)
+    total_variance <- sum(RowVar(t(object)))
     sdev <- pca.results$d/sqrt(max(1, nrow(x = object) - 1))
     if (weight.by.var) {
       feature.loadings <- pca.results$u %*% diag(pca.results$d)
@@ -824,6 +825,7 @@ RunPCA.default <- function(
     if (approx) {
       npcs <- min(npcs, nrow(x = object) - 1)
       pca.results <- irlba(A = t(x = object), nv = npcs, ...)
+      total_variance <- sum(RowVar(object))
       feature.loadings <- pca.results$v
       sdev <- pca.results$d/sqrt(max(1, ncol(object) - 1))
       if (weight.by.var) {
@@ -836,6 +838,7 @@ RunPCA.default <- function(
       pca.results <- prcomp(x = t(object), rank. = npcs, ...)
       feature.loadings <- pca.results$rotation
       sdev <- pca.results$sdev
+      total_variance <- sum(sdev)
       if (weight.by.var) {
         cell.embeddings <- pca.results$x %*% diag(pca.results$sdev[1:npcs]^2)
       } else {
@@ -852,7 +855,8 @@ RunPCA.default <- function(
     loadings = feature.loadings,
     assay = assay,
     stdev = sdev,
-    key = reduction.key
+    key = reduction.key,
+    misc = list(total_variance = total_variance)
   )
   if (verbose) {
     print(x = reduction.data, dims = ndims.print, nfeatures = nfeatures.print)

--- a/R/objects.R
+++ b/R/objects.R
@@ -118,6 +118,7 @@ JackStrawData <- setClass(
 #' @slot key Key for the DimReduc, must be alphanumerics followed by an underscore
 #' @slot jackstraw A \code{\link{JackStrawData-class}} object associated with this DimReduc
 #' @slot misc Utility slot for storing additional data associated with the DimReduc
+#'       (e.g. the total variance of the PCA)
 #'
 #' @name DimReduc-class
 #' @rdname DimReduc-class

--- a/man/DimReduc-class.Rd
+++ b/man/DimReduc-class.Rd
@@ -27,6 +27,7 @@ loadings matrix.
 
 \item{\code{jackstraw}}{A \code{\link{JackStrawData-class}} object associated with this DimReduc}
 
-\item{\code{misc}}{Utility slot for storing additional data associated with the DimReduc}
+\item{\code{misc}}{Utility slot for storing additional data associated with the DimReduc
+(e.g. the total variance of the PCA)}
 }}
 

--- a/tests/testthat/test_dimensional_reduction.R
+++ b/tests/testthat/test_dimensional_reduction.R
@@ -42,7 +42,7 @@ test_that("pca returns total variance (see #982)", {
   prcomp_result <- stats::prcomp(scaled_data, center = FALSE, scale. = FALSE)
 
   # Compare
-  expect_equivalent(slot(object = pca_result[["pca"]], name = "misc")$total_variance,
+  expect_equivalent(slot(object = pca_result[["pca"]], name = "misc")$total.variance,
                     sum(prcomp_result$sdev^2))
 
 })

--- a/tests/testthat/test_dimensional_reduction.R
+++ b/tests/testthat/test_dimensional_reduction.R
@@ -34,8 +34,8 @@ test_that("pca returns total variance (see #982)", {
   obj <- CreateSeuratObject(counts = dummyexpMat)
 
   # Scale and compute PCA, using RunPCA
-  obj <- ScaleData(object = obj)
-  pca_result <- RunPCA(object = obj, features = rownames(x = obj))
+  obj <- ScaleData(object = obj, verbose = FALSE)
+  pca_result <- suppressWarnings(expr = RunPCA(object = obj, features = rownames(x = obj), verbose = FALSE))
 
   # Using stats::prcomp
   scaled_data <- Seurat::GetAssayData(object = obj, slot = "scale.data")

--- a/tests/testthat/test_dimensional_reduction.R
+++ b/tests/testthat/test_dimensional_reduction.R
@@ -21,3 +21,28 @@ test_that("different ways of passing distance matrix", {
   expect_equivalent(RunTSNE(obj, distance.matrix = distMat)@reductions$tsne,
                     RunTSNE(as.matrix(distMat), assay = "RNA", is_distance = TRUE))
 })
+
+test_that("pca returns total variance (see #982)", {
+  # Generate dummy data exp matrix
+  set.seed(1)
+  dummyexpMat <- matrix(data = sample(x = c(1:50), size = 1e4, replace = TRUE),
+                        ncol = 100, nrow = 100)
+  colnames(dummyexpMat) <- paste0("cell", seq(ncol(dummyexpMat)))
+  row.names(dummyexpMat) <- paste0("gene", seq(nrow(dummyexpMat)))
+
+  # Create Seurat object for testing
+  obj <- CreateSeuratObject(counts = dummyexpMat)
+
+  # Scale and compute PCA, using RunPCA
+  obj <- ScaleData(obj)
+  pca_result <- RunPCA(obj, features = rownames(obj))
+
+  # Using stats::prcomp
+  scaled_data <- Seurat::GetAssayData(object = obj, slot = "scale.data")
+  prcomp_result <- stats::prcomp(scaled_data, center = FALSE, scale. = FALSE)
+
+  # Compare
+  expect_equivalent(slot(pca_result[["pca"]], "misc")$total_variance,
+                    sum(prcomp_result$sdev^2))
+
+})

--- a/tests/testthat/test_dimensional_reduction.R
+++ b/tests/testthat/test_dimensional_reduction.R
@@ -24,25 +24,25 @@ test_that("different ways of passing distance matrix", {
 
 test_that("pca returns total variance (see #982)", {
   # Generate dummy data exp matrix
-  set.seed(1)
+  set.seed(seed = 1)
   dummyexpMat <- matrix(data = sample(x = c(1:50), size = 1e4, replace = TRUE),
                         ncol = 100, nrow = 100)
-  colnames(dummyexpMat) <- paste0("cell", seq(ncol(dummyexpMat)))
-  row.names(dummyexpMat) <- paste0("gene", seq(nrow(dummyexpMat)))
+  colnames(x = dummyexpMat) <- paste0("cell", seq(ncol(x = dummyexpMat)))
+  row.names(x = dummyexpMat) <- paste0("gene", seq(nrow(x = dummyexpMat)))
 
   # Create Seurat object for testing
   obj <- CreateSeuratObject(counts = dummyexpMat)
 
   # Scale and compute PCA, using RunPCA
-  obj <- ScaleData(obj)
-  pca_result <- RunPCA(obj, features = rownames(obj))
+  obj <- ScaleData(object = obj)
+  pca_result <- RunPCA(object = obj, features = rownames(x = obj))
 
   # Using stats::prcomp
   scaled_data <- Seurat::GetAssayData(object = obj, slot = "scale.data")
   prcomp_result <- stats::prcomp(scaled_data, center = FALSE, scale. = FALSE)
 
   # Compare
-  expect_equivalent(slot(pca_result[["pca"]], "misc")$total_variance,
+  expect_equivalent(slot(object = pca_result[["pca"]], name = "misc")$total_variance,
                     sum(prcomp_result$sdev^2))
 
 })


### PR DESCRIPTION
When doing a PCA it is common to report the % explained variance of the represented principal components. However, the Seurat package does not report that value.

When someone asked in an issue [Is it possible to figure out PC variance explained in Seurat?](https://github.com/satijalab/seurat/issues/982), the first answer was that it could trivially be done by summing all the `sdev^2` returned by Seurat. This is wrong, because it only accounts for the computed PCs, and not all the variance in the matrix. In other words, it is wrong because `RunPCA(..., npcs = 1)` would always return "100% of the variance explained" if we followed that approach.

This PR adds the `total_variance` to the `misc` list of the `DimReduc` object in the `RunPCA` function. I have used your custom C++ `RowVar` function (for performance) and I have added a test to ensure the validity of the results. After this PR, the total variance can be obtained with:  `slot(pca_result[["pca"]], "misc")$total_variance`

Thanks for your work and time, looking forward to the final 3.0 release!