### PR TITLE
Fixed Description of return.only.var.genes default

### DIFF
--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -997,9 +997,9 @@ SampleUMI <- function(
 #' where n is the number of cells
 #' @param conserve.memory If set to TRUE the residual matrix for all genes is never
 #' created in full; useful for large data sets, but will take longer to run;
-#' this will also set return.only.var.genes to TRUE; default is FALSE
+#' this will also set return.only.var.genes to TRUE; default is TRUE
 #' @param return.only.var.genes If set to TRUE the scale.data matrices in output assay are
-#' subset to contain only the variable genes; default is FALSE
+#' subset to contain only the variable genes; default is TRUE
 #' @param seed.use Set a random seed. By default, sets the seed to 1448145. Setting
 #' NULL will not set a seed.
 #' @param verbose Whether to print messages and progress bars

--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -454,7 +454,7 @@ LogNormalize <- function(data, scale.factor = 1e4, verbose = TRUE, ...) {
 #' @param assay Name of the multiplexing assay (HTO by default)
 #' @param quantile The quantile to use for classification
 #' @param autoThresh Whether to perform automated threshold finding to define the best quantile. Default is FALSE
-#' @param maxiter Maximum number of iterations if autoThresh = TRUE. Default is
+#' @param maxiter Maximum number of iterations if autoThresh = TRUE. Default is 5
 #' @param qrange A range of possible quantile values to try if autoThresh = TRUE
 #' @param verbose Prints the output
 #'
@@ -997,7 +997,7 @@ SampleUMI <- function(
 #' where n is the number of cells
 #' @param conserve.memory If set to TRUE the residual matrix for all genes is never
 #' created in full; useful for large data sets, but will take longer to run;
-#' this will also set return.only.var.genes to TRUE; default is TRUE
+#' this will also set return.only.var.genes to TRUE; default is FALSE
 #' @param return.only.var.genes If set to TRUE the scale.data matrices in output assay are
 #' subset to contain only the variable genes; default is TRUE
 #' @param seed.use Set a random seed. By default, sets the seed to 1448145. Setting


### PR DESCRIPTION
Fixed the description of the default setting for return.only.var.genes (currently it says FALSE, but the setting is TRUE).

# Note

Thanks for your interest in contributing! Please make your PR to the `develop` branch. You can check out our [wiki](https://github.com/satijalab/seurat/wiki) for the current developers guide. 
