### PR TITLE
fixes satijalab/seurat#1737

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: Seurat
-Version: 3.0.3.9004
+Version: 3.0.3.9005
 Date: 2019-06-25
 Title: Tools for Single Cell Genomics
 Description: A toolkit for quality control, analysis, and exploration of single cell RNA sequencing data. 'Seurat' aims to enable users to identify and interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse types of single cell data. See Satija R, Farrell J, Gennert D, et al (2015) <doi:10.1038/nbt.3192>, Macosko E, Basu A, Satija R, et al (2015) <doi:10.1016/j.cell.2015.05.002>, and Butler A and Satija R (2017) <doi:10.1101/164889> for more details.

--- a/R/objects.R
+++ b/R/objects.R
@@ -853,7 +853,7 @@ FetchData <- function(object, vars, cells = NULL, slot = 'data') {
   )
   # Pull identities
   if ('ident' %in% vars && !'ident' %in% colnames(x = object[[]])) {
-    data.fetched[['ident']] <- Idents(object = object)
+    data.fetched[['ident']] <- Idents(object = object)[cells]
   }
   # Try to find ambiguous vars
   fetched <- names(x = data.fetched)


### PR DESCRIPTION
idents were not being subsetted by `cells` argument to `FetchData`.