### PR TITLE
Unable to wrap PCA/TSNA/UMAPPlot function in custom function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: Seurat
-Version: 3.0.3.9029
+Version: 3.0.3.9030
 Date: 2019-08-09
 Title: Tools for Single Cell Genomics
 Description: A toolkit for quality control, analysis, and exploration of single cell RNA sequencing data. 'Seurat' aims to enable users to identify and interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse types of single cell data. See Satija R, Farrell J, Gennert D, et al (2015) <doi:10.1038/nbt.3192>, Macosko E, Basu A, Satija R, et al (2015) <doi:10.1016/j.cell.2015.05.002>, and Butler A and Satija R (2017) <doi:10.1101/164889> for more details.

--- a/R/convenience.R
+++ b/R/convenience.R
@@ -55,7 +55,8 @@ UMAPPlot <- function(object, ...) {
 # @rdname DimPlot
 #
 SpecificDimPlot <- function(object, ...) {
-  name <- as.character(x = sys.calls()[[1]])[1]
+  funs <- sys.calls()
+  name <- as.character(x = funs[[length(funs) - 1]])[1]
   name <- tolower(x = gsub(pattern = 'Plot', replacement = '', x = name))
   args <- list('object' = object)
   args <- c(args, list(...))

--- a/R/convenience.R
+++ b/R/convenience.R
@@ -56,7 +56,7 @@ UMAPPlot <- function(object, ...) {
 #
 SpecificDimPlot <- function(object, ...) {
   funs <- sys.calls()
-  name <- as.character(x = funs[[length(funs) - 1]])[1]
+  name <- as.character(x = funs[[length(x = funs) - 1]])[1]
   name <- tolower(x = gsub(pattern = 'Plot', replacement = '', x = name))
   args <- list('object' = object)
   args <- c(args, list(...))


### PR DESCRIPTION
```r
library(Seurat)
data("pbmc_small")

make_plot <- function(object){
  PCAPlot(object)
}

make_plot(pbmc_small)
##'Error in `[[.Seurat`(object, reduction) : 
##'Cannot find 'make_plot' in this Seurat object
```

`SpecificDimPlot()` checks the first function of the call stack to determine which reduction (pca, tsne, etc) should be called. This behavior breaks when another function (in this case `make_plot`) is higher in the call stack. 

