### PR TITLE
Consistent behavior of Leiden clustering between v3.1.1 and v3.1.2

### DIFF
--- a/R/clustering.R
+++ b/R/clustering.R
@@ -726,6 +726,8 @@ RunLeiden <- function(
   }
   input <- if (inherits(x = object, what = 'list')) {
     graph_from_adj_list(adjlist = object)
+  } else if (inherits(x = object, what = "Graph") ) {
+    as( object, "matrix" )    
   } else if (inherits(x = object, what = c('dgCMatrix', 'matrix', "Matrix"))) {
     graph_from_adjacency_matrix(adjmatrix = object)
   } else if (inherits(x = object, what = 'igraph')) {


### PR DESCRIPTION
* preprocessing code to leiden algorithm input was changed between
  v3.1.1 and v3.1.2 producing different default behavior of
  FindCluster
* this is to make it consistent to the previous version.

# Note

Thanks for your interest in contributing! Please make your PR to the `develop` branch. You can check out our [wiki](https://github.com/satijalab/seurat/wiki) for the current developers guide. 
