### PR TITLE
Fix getEdges() Method of the Network Class

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Seurat
-Version: 3.1.2.9000
-Date: 2019-12-16
+Version: 3.1.2.9002
+Date: 2020-01-03
 Title: Tools for Single Cell Genomics
 Description: A toolkit for quality control, analysis, and exploration of single cell RNA sequencing data. 'Seurat' aims to enable users to identify and interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse types of single cell data. See Satija R, Farrell J, Gennert D, et al (2015) <doi:10.1038/nbt.3192>, Macosko E, Basu A, Satija R, et al (2015) <doi:10.1016/j.cell.2015.05.002>, and Butler A and Satija R (2017) <doi:10.1101/164889> for more details.
 Authors@R: c(

--- a/src/ModularityOptimizer.cpp
+++ b/src/ModularityOptimizer.cpp
@@ -244,7 +244,7 @@ std::vector<IVector> Network::getEdges() {
   std::vector<IVector> edge(2);
   edge[0].resize(nEdges);
   for(int i=0; i < nNodes; i++) {
-    std::fill(edge[0].begin() + firstNeighborIndex.at(i), edge[0].end() + firstNeighborIndex.at(i + 1), i);
+    std::fill(edge[0].begin() + firstNeighborIndex.at(i), edge[0].begin() + firstNeighborIndex.at(i + 1), i);
   }
   edge.at(1) = neighbor;
   return edge;


### PR DESCRIPTION
The `getEdges` method was a public method of the `Network` class that allows users to obtain a copy of the Edges of a Network object.  This method/interface was ported over from Java to C++ with a bug in it, though because the `getEdges` method is never called by either the Java or C++ version of the code, this bug had no effect on the current code.  However, to improve the code and maintain it's similarity with the original Java version, it's probably worth fixing this unused method.

The specific bug was that instead of filling an array from `start + value_1` to `start + value_2` with a constant value, it was filled from `start + value_1` to `end + value_2` with a constant value, which leads to unexpected behavior due to an array overflow.

