### PR TITLE
FeatureScatter plot with split.by option

### DIFF
--- a/R/visualization.R
+++ b/R/visualization.R
@@ -1434,43 +1434,31 @@ FeatureScatter <- function(
   slot = 'data',
   split.by = NULL
 ) {
-    if(is.null(x = split.by)) {
-     cells <- cells %||% colnames(x = object)
-     group.by <- group.by %||% Idents(object = object)[cells]
-     if (length(x = group.by) == 1) {
-         group.by <- object[[]][, group.by]
-     }
-     plot <- SingleCorPlot(data = FetchData(object = object, vars = c(feature1, 
-         feature2), cells = cells, slot = slot), col.by = group.by, 
-         cols = cols, pt.size = pt.size, smooth = smooth, legend.title = "Identity")
-     if (!is.null(x = span)) {
-         plot <- plot + geom_smooth(mapping = aes_string(x = feature1, 
-             y = feature2), method = "loess", span = span)
-     }
-      return(plot)
-     }
-     if(!is.null(x = split.by)) {
-      cells <- cells %||% colnames(x = object)
-      group.by <- group.by %||% Idents(object = object)[cells]
-      split.by <- split.by %||% Idents(object = object)[cells]
-      if (length(x = group.by) == 1) {
+    cells <- cells %||% colnames(x = object)
+    group.by <- group.by %||% Idents(object = object)[cells]
+    if (length(x = group.by) == 1) {
           group.by <- object[[]][, group.by]
-      }
-      if (length(x = split.by) == 1) {
-          split.by <- object[[]][, split.by]
-      }
-      plot <- SingleCorPlot(data = FetchData(object = object, vars = c(feature1, 
-        feature2), cells = cells, slot = slot), col.by = group.by, 
+    }
+    plot <- SingleCorPlot(data = FetchData(object = object, vars = c(feature1, 
+    	feature2), cells = cells, slot = slot), col.by = group.by, 
         cols = cols, pt.size = pt.size, smooth = smooth, legend.title = "Identity")
-      if (!is.null(x = span)) {
-          plot <- plot + geom_smooth(mapping = aes_string(x = feature1, 
-            y = feature2), method = "loess", span = span)
-      }
-      data = FetchData(object = object, vars = c(feature1, feature2), cells = cells)
-      data <- as.data.frame(data)
-      data$split <- split.by
-      plot <- plot + facet_grid(. ~data$split)
-      return(plot)
+    if (!is.null(x = span)) {
+        plot <- plot + geom_smooth(mapping = aes_string(x = feature1, 
+        y = feature2), method = "loess", span = span)
+    }
+    if (!is.null(x = split.by)) {
+        split.by <- split.by %||% Idents(object = object)[cells]
+        if (length(x = split.by) == 1) {
+          split.by <- object[[]][, split.by]
+        }
+        data = FetchData(object = object, vars = c(feature1, feature2), cells = cells)
+        data <- as.data.frame(data)
+        data$split <- split.by
+        plot <- plot + facet_grid(. ~data$split)
+        return (plot)
+     }
+     else {
+     return(plot)
      }
 }
 

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -1399,6 +1399,7 @@ CellScatter <- function(
 #' (for example, orig.ident); pass 'ident' to group by identity class
 #' @param cols Colors to use for identity class plotting.
 #' @param pt.size Size of the points on the plot
+#' @param split.by Name of a metadata column to split plot by;
 #' @param shape.by Ignored for now
 #' @param span Spline span in loess function call, if \code{NULL}, no spline added
 #' @param smooth Smooth the graph (similar to smoothScatter)
@@ -1407,6 +1408,9 @@ CellScatter <- function(
 #' @return A ggplot object
 #'
 #' @importFrom ggplot2 geom_smooth aes_string
+#' @importFrom rlang !!
+#' @importFrom ggplot2 facet_wrap vars sym
+#' @importFrom ggplot2 facet_grid
 #' @export
 #'
 #' @aliases GenePlot
@@ -1451,7 +1455,8 @@ FeatureScatter <- function(
     legend.title = 'Identity',
     span = span
   )
-  plot <- plot + facet_grid(. ~split.by)
+  split <- factor(split.by)
+  plot <- plot + facet_grid(. ~split)
   return(plot)
 }
 

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -1425,12 +1425,17 @@ FeatureScatter <- function(
   shape.by = NULL,
   span = NULL,
   smooth = FALSE,
-  slot = 'data'
+  slot = 'data',
+  split.by = NULL
 ) {
   cells <- cells %||% colnames(x = object)
   group.by <- group.by %||% Idents(object = object)[cells]
+  split.by <- split.by %||% Idents(object = object)[cells]
   if (length(x = group.by) == 1) {
     group.by <- object[[]][, group.by]
+  }
+  if (length(x = split.by) == 1) {
+    split.by <- object[[]][, split.by]
   }
   plot <- SingleCorPlot(
     data = FetchData(
@@ -1446,6 +1451,7 @@ FeatureScatter <- function(
     legend.title = 'Identity',
     span = span
   )
+  plot <- plot + facet_grid(. ~split.by)
   return(plot)
 }
 

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -1459,16 +1459,17 @@ FeatureScatter <- function(
       if (length(x = split.by) == 1) {
           split.by <- object[[]][, split.by]
       }
-      data <- as.data.frame(data)
-      data$split <- split.by
-      plot <- SingleCorPlot(data = FetchData(object = object, vars = c(feature1, feature2), cells = cells, slot = slot), col.by = group.by, 
-          cols = cols, pt.size = pt.size, smooth = smooth, legend.title = "Identity")
+      plot <- SingleCorPlot(data = FetchData(object = object, vars = c(feature1, 
+        feature2), cells = cells, slot = slot), col.by = group.by, 
+        cols = cols, pt.size = pt.size, smooth = smooth, legend.title = "Identity")
       if (!is.null(x = span)) {
           plot <- plot + geom_smooth(mapping = aes_string(x = feature1, 
             y = feature2), method = "loess", span = span)
       }
+      data = FetchData(object = object, vars = c(feature1, feature2), cells = cells)
+      data <- as.data.frame(data)
+      data$split <- split.by
       plot <- plot + facet_grid(. ~data$split)
-             
       return(plot)
      }
 }

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -1411,6 +1411,8 @@ CellScatter <- function(
 #' @importFrom rlang !!
 #' @importFrom ggplot2 facet_wrap vars sym
 #' @importFrom ggplot2 facet_grid
+#' @importFrom dplyr
+#' @importFrom tidyverse
 #' @export
 #'
 #' @aliases GenePlot
@@ -1432,32 +1434,43 @@ FeatureScatter <- function(
   slot = 'data',
   split.by = NULL
 ) {
-  cells <- cells %||% colnames(x = object)
-  group.by <- group.by %||% Idents(object = object)[cells]
-  split.by <- split.by %||% Idents(object = object)[cells]
-  if (length(x = group.by) == 1) {
-    group.by <- object[[]][, group.by]
-  }
-  if (length(x = split.by) == 1) {
-    split.by <- object[[]][, split.by]
-  }
-  plot <- SingleCorPlot(
-    data = FetchData(
-      object = object,
-      vars = c(feature1, feature2),
-      cells = cells,
-      slot = slot
-    ),
-    col.by = group.by,
-    cols = cols,
-    pt.size = pt.size,
-    smooth = smooth,
-    legend.title = 'Identity',
-    span = span
-  )
-  split <- factor(split.by)
-  plot <- plot + facet_grid(. ~split)
-  return(plot)
+    if(is.null(x = split.by)) {
+     cells <- cells %||% colnames(x = object)
+     group.by <- group.by %||% Idents(object = object)[cells]
+     if (length(x = group.by) == 1) {
+         group.by <- object[[]][, group.by]
+     }
+     plot <- SingleCorPlot(data = FetchData(object = object, vars = c(feature1, 
+         feature2), cells = cells, slot = slot), col.by = group.by, 
+         cols = cols, pt.size = pt.size, smooth = smooth, legend.title = "Identity")
+     if (!is.null(x = span)) {
+         plot <- plot + geom_smooth(mapping = aes_string(x = feature1, 
+             y = feature2), method = "loess", span = span)
+     }
+      return(plot)
+     }
+     if(!is.null(x = split.by)) {
+      cells <- cells %||% colnames(x = object)
+      group.by <- group.by %||% Idents(object = object)[cells]
+      split.by <- split.by %||% Idents(object = object)[cells]
+      if (length(x = group.by) == 1) {
+          group.by <- object[[]][, group.by]
+      }
+      if (length(x = split.by) == 1) {
+          split.by <- object[[]][, split.by]
+      }
+      data <- as.data.frame(data)
+      data$split <- split.by
+      plot <- SingleCorPlot(data = FetchData(object = object, vars = c(feature1, feature2), cells = cells, slot = slot), col.by = group.by, 
+          cols = cols, pt.size = pt.size, smooth = smooth, legend.title = "Identity")
+      if (!is.null(x = span)) {
+          plot <- plot + geom_smooth(mapping = aes_string(x = feature1, 
+            y = feature2), method = "loess", span = span)
+      }
+      plot <- plot + facet_grid(. ~data$split)
+             
+      return(plot)
+     }
 }
 
 #' View variable features


### PR DESCRIPTION
# 
Dear Seurat Team,
I have added a functionality to split FeatureScatter plots based on conditions of interest like time, sample-type, dosage etc.

[FeatureScatter_SplitByExample1.pdf](https://github.com/satijalab/seurat/files/4094305/FeatureScatter_SplitByExample1.pdf)
[FeatureScatter_SplitByExample2.pdf](https://github.com/satijalab/seurat/files/4094306/FeatureScatter_SplitByExample2.pdf)
 
Examples using dataset 'pbmc_small'
![FeatureScatter_splitByClusters](https://user-images.githubusercontent.com/55851416/73023450-91c55080-3df9-11ea-890c-479504a05cf8.png)
![FeatureScatter_splitByGroups](https://user-images.githubusercontent.com/55851416/73023451-91c55080-3df9-11ea-93c8-6ffa5e056614.png)
![FeatureScatter_splitByLetters idents](https://user-images.githubusercontent.com/55851416/73023452-91c55080-3df9-11ea-8462-53a67ee47775.png)

Please provide your invaluable feedback.



Thanks for your interest in contributing! Please make your PR to the `develop` branch. You can check out our [wiki](https://github.com/satijalab/seurat/wiki) for the current developers guide. 
