### PR TITLE
Update objects.R: Preserve feature order when subsetting

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Seurat
-Version: 3.1.5.9002
-Date: 2020-05-05
+Version: 3.1.5.9003
+Date: 2020-05-06
 Title: Tools for Single Cell Genomics
 Description: A toolkit for quality control, analysis, and exploration of single cell RNA sequencing data. 'Seurat' aims to enable users to identify and interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse types of single cell data. See Satija R, Farrell J, Gennert D, et al (2015) <doi:10.1038/nbt.3192>, Macosko E, Basu A, Satija R, et al (2015) <doi:10.1016/j.cell.2015.05.002>, and Stuart T, Butler A, et al (2019) <doi:10.1016/j.cell.2019.05.031> for more details. Please note:  SDMTools is available is available from the CRAN archives with install.packages(<"https://cran.rstudio.com//src/contrib/Archive/SDMTools/SDMTools_1.1-221.2.tar.gz">, repos = NULL); it is not in the standard repositories.
 Authors@R: c(

--- a/R/objects.R
+++ b/R/objects.R
@@ -6002,7 +6002,7 @@ subset.Assay <- function(x, cells = NULL, features = NULL, ...) {
     replacement = '',
     x = features
   )
-  features <- intersect(x = rownames(x = x), y = features)
+  features <- intersect(x = features, y = rownames(x = x))
   if (length(x = features) == 0) {
     stop("Cannot find features provided")
   }


### PR DESCRIPTION
Invert call to intersect() so that subset.Assay() preserves the order of features.

# Note

Thanks for your interest in contributing! Please make your PR to the `develop` branch. You can check out our [wiki](https://github.com/satijalab/seurat/wiki) for the current developers guide. 
