### PR TITLE
New default handling of `weights` parameter for `RunLeiden`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Seurat
-Version: 3.1.5.9012
-Date: 2020-07-08
+Version: 3.1.5.9013
+Date: 2020-07-09
 Title: Tools for Single Cell Genomics
 Description: A toolkit for quality control, analysis, and exploration of single cell RNA sequencing data. 'Seurat' aims to enable users to identify and interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse types of single cell data. See Satija R, Farrell J, Gennert D, et al (2015) <doi:10.1038/nbt.3192>, Macosko E, Basu A, Satija R, et al (2015) <doi:10.1016/j.cell.2015.05.002>, and Stuart T, Butler A, et al (2019) <doi:10.1016/j.cell.2019.05.031> for more details. Please note:  SDMTools is available is available from the CRAN archives with install.packages(<"https://cran.rstudio.com//src/contrib/Archive/SDMTools/SDMTools_1.1-221.2.tar.gz">, repos = NULL); it is not in the standard repositories.
 Authors@R: c(

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@ object inheriting from the Assay class
 - Minor visual fixes in `DoHeatmap` group bar + labels
 - Efficiency improvements in anchor scoring (`ScoreAnchors`)
 - Fix bug in `FindClusters()` when the last node has no edges 
+- Default to weighted = TRUE when constructing igraph objects in `RunLeiden`. Remove corresponding weights parameter from `FindClusters()`.
 
 ## [3.1.5] - 2020-04-14
 ### Added

--- a/R/clustering.R
+++ b/R/clustering.R
@@ -15,7 +15,7 @@ NULL
 #' @importFrom future nbrOfWorkers
 #'
 #' @param modularity.fxn Modularity function (1 = standard; 2 = alternative).
-#' @param initial.membership,weights,node.sizes Parameters to pass to the Python leidenalg function.
+#' @param initial.membership,node.sizes Parameters to pass to the Python leidenalg function.
 #' @param resolution Value of the resolution parameter, use a value above
 #' (below) 1.0 if you want to obtain a larger (smaller) number of communities.
 #' @param algorithm Algorithm for modularity optimization (1 = original Louvain
@@ -40,7 +40,6 @@ FindClusters.default <- function(
   object,
   modularity.fxn = 1,
   initial.membership = NULL,
-  weights = NULL,
   node.sizes = NULL,
   resolution = 0.8,
   method = "matrix",
@@ -87,7 +86,6 @@ FindClusters.default <- function(
             method = method,
             partition.type = "RBConfigurationVertexPartition",
             initial.membership = initial.membership,
-            weights = weights,
             node.sizes = node.sizes,
             resolution.parameter = r,
             random.seed = random.seed,
@@ -125,7 +123,6 @@ FindClusters.default <- function(
           method = method,
           partition.type = "RBConfigurationVertexPartition",
           initial.membership = initial.membership,
-          weights = weights,
           node.sizes = node.sizes,
           resolution.parameter = r,
           random.seed = random.seed,
@@ -155,7 +152,6 @@ FindClusters.Seurat <- function(
   graph.name = NULL,
   modularity.fxn = 1,
   initial.membership = NULL,
-  weights = NULL,
   node.sizes = NULL,
   resolution = 0.8,
   method = "matrix",
@@ -181,7 +177,6 @@ FindClusters.Seurat <- function(
     object = object[[graph.name]],
     modularity.fxn = modularity.fxn,
     initial.membership = initial.membership,
-    weights = weights,
     node.sizes = node.sizes,
     resolution = resolution,
     method = method,
@@ -671,7 +666,7 @@ NNHelper <- function(data, query = data, k, method, ...) {
 # RBERVertexPartition, CPMVertexPartition, MutableVertexPartition,
 # SignificanceVertexPartition, SurpriseVertexPartition (see the Leiden python
 # module documentation for more details)
-# @param initial.membership,weights,node.sizes Parameters to pass to the Python leidenalg function.
+# @param initial.membership,node.sizes Parameters to pass to the Python leidenalg function.
 # @param resolution.parameter A parameter controlling the coarseness of the clusters
 # for Leiden algorithm. Higher values lead to more clusters. (defaults to 1.0 for
 # partition types that accept a resolution parameter)
@@ -701,7 +696,6 @@ RunLeiden <- function(
     'SurpriseVertexPartition'
   ),
   initial.membership = NULL,
-  weights = NULL,
   node.sizes = NULL,
   resolution.parameter = 1,
   random.seed = 0,
@@ -720,17 +714,12 @@ RunLeiden <- function(
       },
     "igraph" = {
       input <- if (inherits(x = object, what = 'list')) {
-        if (is.null(x = weights)) {
-          graph_from_adj_list(adjlist = object)
-        } else {
-          graph_from_adj_list(adjlist = object)
+        graph_from_adj_list(adjlist = object)
+      } else if (inherits(x = object, what = c('dgCMatrix', 'matrix', 'Matrix'))) {
+        if (inherits(x = object, what = 'Graph')) {
+          object <- as(object = object, Class = "dgCMatrix")
         }
-      } else if (inherits(x = object, what = c('dgCMatrix', 'matrix', "Matrix"))) {
-        if (is.null(x = weights)) {
-          graph_from_adjacency_matrix(adjmatrix = object)
-        } else {
           graph_from_adjacency_matrix(adjmatrix = object, weighted = TRUE)
-        }
       } else if (inherits(x = object, what = 'igraph')) {
         object
       } else {
@@ -747,7 +736,7 @@ RunLeiden <- function(
     object = input,
     partition_type = partition.type,
     initial_membership = initial.membership,
-    weights = weights,
+    weights = NULL,
     node_sizes = node.sizes,
     resolution_parameter = resolution.parameter,
     seed = random.seed,

--- a/man/DotPlot.Rd
+++ b/man/DotPlot.Rd
@@ -29,8 +29,9 @@ DotPlot(
 
 \item{assay}{Name of assay to use, defaults to the active assay}
 
-\item{features}{Input vector of features, or named list of feature vectors 
-if feature-grouped panels are desired (replicates the functionality of the old SplitDotPlotGG)}
+\item{features}{Input vector of features, or named list of feature vectors
+if feature-grouped panels are desired (replicates the functionality of the
+old SplitDotPlotGG)}
 
 \item{cols}{Colors to plot, can pass a single character giving the name of
 a palette from \code{RColorBrewer::brewer.pal.info}}
@@ -51,10 +52,11 @@ gene will have no dot drawn.}
 
 \item{group.by}{Factor to group the cells by}
 
-\item{split.by}{Factor to split the groups by (replicates the functionality of the old SplitDotPlotGG);
+\item{split.by}{Factor to split the groups by (replicates the functionality
+of the old SplitDotPlotGG);
 see \code{\link{FetchData}} for more details}
 
-\item{cluster.idents}{Whether to order Identities by hierarchical clusters 
+\item{cluster.idents}{Whether to order identities by hierarchical clusters
 based on given features, default is FALSE}
 
 \item{scale}{Determine whether the data is scaled, TRUE for default}

--- a/man/FindClusters.Rd
+++ b/man/FindClusters.Rd
@@ -12,7 +12,6 @@ FindClusters(object, ...)
   object,
   modularity.fxn = 1,
   initial.membership = NULL,
-  weights = NULL,
   node.sizes = NULL,
   resolution = 0.8,
   method = "matrix",
@@ -32,7 +31,6 @@ FindClusters(object, ...)
   graph.name = NULL,
   modularity.fxn = 1,
   initial.membership = NULL,
-  weights = NULL,
   node.sizes = NULL,
   resolution = 0.8,
   method = "matrix",
@@ -54,7 +52,7 @@ FindClusters(object, ...)
 
 \item{modularity.fxn}{Modularity function (1 = standard; 2 = alternative).}
 
-\item{initial.membership, weights, node.sizes}{Parameters to pass to the Python leidenalg function.}
+\item{initial.membership, node.sizes}{Parameters to pass to the Python leidenalg function.}
 
 \item{resolution}{Value of the resolution parameter, use a value above
 (below) 1.0 if you want to obtain a larger (smaller) number of communities.}


### PR DESCRIPTION
This PR addresses https://github.com/satijalab/seurat/issues/3168

When `FindClusters` is called with `algorithm = 4` (leiden algorithm) and `method = 'igraph`, the graph built with `igraph::graph_from_adjacency_matrix()` now always uses `weighted = TRUE`. This changes previous default behavior as the `weights` parameter in `FindClusters` previously determined whether this was set to `TRUE`. The `weights` parameter in `FindClusters` has correspondingly been removed from `FindClusters`. 

To maintain consistency between `method = "igraph"` and `method = "matrix"`, the `mode` parameter in `graph_from_adjacency_matrix` was left as the default (as opposed to setting to `undirected`). For some reason using `mode = "undirected"` here would sometimes give slightly different results. 

@TomKellyGenetics @therealgenna 