### PR TITLE
Add "do.shuffle" feature to DimPlot

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Seurat
-Version: 3.2.0.9014
-Date: 2020-08-19
+Version: 3.2.0.9015
+Date: 2020-08-24
 Title: Tools for Single Cell Genomics
 Description: A toolkit for quality control, analysis, and exploration of single cell RNA sequencing data. 'Seurat' aims to enable users to identify and interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse types of single cell data. See Satija R, Farrell J, Gennert D, et al (2015) <doi:10.1038/nbt.3192>, Macosko E, Basu A, Satija R, et al (2015) <doi:10.1016/j.cell.2015.05.002>, and Stuart T, Butler A, et al (2019) <doi:10.1016/j.cell.2019.05.031> for more details.
 Authors@R: c(

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 - Added support for nearest neighbor input and `return.model` parameter in `RunUMAP()`
 - Enable named color vectors in `DoHeatmap()`
 - Add `label.color` and `label.box` parameters to `DimPlot`
+- Added `shuffle` and `seed` parameters to `DimPlot()` to help with overplotting.
 
 ### Changes
 - Allow setting `slot` parameter in `RunUMAP`

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -704,6 +704,8 @@ ColorDimSplit <- function(
 #' @param order Specify the order of plotting for the idents. This can be
 #' useful for crowded plots if points of interest are being buried. Provide
 #' either a full list of valid idents or a subset to be plotted last (on top)
+#' @param do.shuffle Whether to randomly shuffle the order of points. This can be
+#' useful for crowded plots if points of interest are being buried. (default is FALSE)
 #' @param label Whether to label the clusters
 #' @param label.size Sets size of labels
 #' @param label.color Sets the color of the label text
@@ -755,6 +757,7 @@ DimPlot <- function(
   split.by = NULL,
   shape.by = NULL,
   order = NULL,
+  do.shuffle = FALSE,
   label = FALSE,
   label.size = 4,
   label.color = 'black',
@@ -789,6 +792,11 @@ DimPlot <- function(
   }
   if (!is.null(x = split.by)) {
     data[, split.by] <- object[[split.by, drop = TRUE]]
+  }
+  if (do.shuffle) {
+    set.seed(1)
+    idx <- sample(1:nrow(data))
+    data <- data[idx, ]
   }
   plots <- lapply(
     X = group.by,

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -704,8 +704,9 @@ ColorDimSplit <- function(
 #' @param order Specify the order of plotting for the idents. This can be
 #' useful for crowded plots if points of interest are being buried. Provide
 #' either a full list of valid idents or a subset to be plotted last (on top)
-#' @param do.shuffle Whether to randomly shuffle the order of points. This can be
+#' @param shuffle Whether to randomly shuffle the order of points. This can be
 #' useful for crowded plots if points of interest are being buried. (default is FALSE)
+#' @param seed Sets the seed if randomly shuffling the order of points.
 #' @param label Whether to label the clusters
 #' @param label.size Sets size of labels
 #' @param label.color Sets the color of the label text
@@ -757,7 +758,8 @@ DimPlot <- function(
   split.by = NULL,
   shape.by = NULL,
   order = NULL,
-  do.shuffle = FALSE,
+  shuffle = FALSE,
+  seed = 1,
   label = FALSE,
   label.size = 4,
   label.color = 'black',
@@ -775,6 +777,10 @@ DimPlot <- function(
   }
   reduction <- reduction %||% DefaultDimReduc(object = object)
   cells <- cells %||% colnames(x = object)
+  if (isTRUE(x = shuffle)) {
+    set.seed(seed = seed)
+    cells <- sample(x = cells)
+  }
   data <- Embeddings(object = object[[reduction]])[cells, dims]
   data <- as.data.frame(x = data)
   dims <- paste0(Key(object = object[[reduction]]), dims)
@@ -792,11 +798,6 @@ DimPlot <- function(
   }
   if (!is.null(x = split.by)) {
     data[, split.by] <- object[[split.by, drop = TRUE]]
-  }
-  if (do.shuffle) {
-    set.seed(1)
-    idx <- sample(1:nrow(data))
-    data <- data[idx, ]
   }
   plots <- lapply(
     X = group.by,

--- a/man/ColorDimSplit.Rd
+++ b/man/ColorDimSplit.Rd
@@ -45,6 +45,9 @@ different colors and different shapes on cells}
     \item{\code{order}}{Specify the order of plotting for the idents. This can be
 useful for crowded plots if points of interest are being buried. Provide
 either a full list of valid idents or a subset to be plotted last (on top)}
+    \item{\code{shuffle}}{Whether to randomly shuffle the order of points. This can be
+useful for crowded plots if points of interest are being buried. (default is FALSE)}
+    \item{\code{seed}}{Sets the seed if randomly shuffling the order of points.}
     \item{\code{label}}{Whether to label the clusters}
     \item{\code{label.size}}{Sets size of labels}
     \item{\code{label.color}}{Sets the color of the label text}

--- a/man/DimPlot.Rd
+++ b/man/DimPlot.Rd
@@ -19,6 +19,8 @@ DimPlot(
   split.by = NULL,
   shape.by = NULL,
   order = NULL,
+  shuffle = FALSE,
+  seed = 1,
   label = FALSE,
   label.size = 4,
   label.color = "black",
@@ -67,6 +69,11 @@ different colors and different shapes on cells}
 \item{order}{Specify the order of plotting for the idents. This can be
 useful for crowded plots if points of interest are being buried. Provide
 either a full list of valid idents or a subset to be plotted last (on top)}
+
+\item{shuffle}{Whether to randomly shuffle the order of points. This can be
+useful for crowded plots if points of interest are being buried. (default is FALSE)}
+
+\item{seed}{Sets the seed if randomly shuffling the order of points.}
 
 \item{label}{Whether to label the clusters}
 


### PR DESCRIPTION
Hi Seurat Team,

This PR adds an additional logical parameter to `DimPlot` called `do.shuffle`.  This feature is based on the code/parameter of the same name from LIGER's [`plotByDatasetAndCluster` function](https://github.com/MacoskoLab/liger/blob/2532a37e0af6b5a13f821c7e8d2cdc9945fcdf9e/R/liger.R#L3040-L3044).  It makes for simple way to create a random ordering of the points in `DimPlot`.  This is especially useful when visualizing dim reduction by sample/dataset of origin and there are large number of cells and datasets. Below is example of default `DimPlot` on the left and `DimPlot` with `do.shuffle = TRUE` on the right.
![do_shuffle_example](https://user-images.githubusercontent.com/38284410/90910797-ef2c7a80-e3a5-11ea-91f2-28f75b256d15.png)

Since this is new feature I have set `do.shuffle = FALSE` as the default.

Believe everything should be in keeping with wiki guidelines for PRs but can easily change if needed.

Best,
Sam
