### PR TITLE
fix RenameCells bug

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Seurat
-Version: 3.2.2.9008
-Date: 2020-10-27
+Version: 3.2.2.9009
+Date: 2020-11-03
 Title: Tools for Single Cell Genomics
 Description: A toolkit for quality control, analysis, and exploration of single cell RNA sequencing data. 'Seurat' aims to enable users to identify and interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse types of single cell data. See Satija R, Farrell J, Gennert D, et al (2015) <doi:10.1038/nbt.3192>, Macosko E, Basu A, Satija R, et al (2015) <doi:10.1016/j.cell.2015.05.002>, and Stuart T, Butler A, et al (2019) <doi:10.1016/j.cell.2019.05.031> for more details.
 Authors@R: c(

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Modify subset.Seurat to allow specialized Assay subsetting methods
 - Fix image selection in interactive spatial plots
 - Update Rcpp functions with `export(rng=FALSE)` to avoid potential future warnings
+- Fix RenameCells bug for integrated SCT assays
 
 ## [3.2.2] - 2020-09-25
 ### Changes

--- a/R/objects.R
+++ b/R/objects.R
@@ -4968,7 +4968,7 @@ RenameCells.Assay <- function(object, new.names = NULL, ...) {
         Misc(object, slot = "vst.set") <- lapply(
           X = Misc(object = object, slot = "vst.set"),
           FUN = function(x) {
-            new.names.vst <- new.names[which(x = x$cells_step1 %in% Cells(x = object))]
+            new.names.vst <- new.names[which(x = rownames(x$cell_attr) %in% Cells(x = object))]
             x$cells_step1 <- new.names.vst
             rownames(x = x$cell_attr) <- new.names.vst
             return(x)

--- a/R/objects.R
+++ b/R/objects.R
@@ -4961,16 +4961,16 @@ RenameCells.Assay <- function(object, new.names = NULL, ...) {
   CheckDots(...)
   if (IsSCT(assay = object)) {
     if (is.null(x = Misc(object = object, slot = 'vst.set'))) {
-      suppressWarnings(Misc(object = object, slot = "vst.out")$cells_step1 <- new.names)
-      suppressWarnings(rownames(x = Misc(object = object, slot = "vst.out")$cell_attr) <- new.names)
+      x <- Misc(object = object, slot = "vst.out")
+      suppressWarnings(Misc(object = object, slot = "vst.out")$cells_step1 <- new.names[which(x = x$cells_step1 %in% Cells(x = object))])
+      suppressWarnings(rownames(x = Misc(object = object, slot = "vst.out")$cell_attr) <- new.names[which(x = rownames(x$cell_attr) %in% Cells(x = object))])
     } else{
       suppressWarnings(
         Misc(object, slot = "vst.set") <- lapply(
           X = Misc(object = object, slot = "vst.set"),
           FUN = function(x) {
-            new.names.vst <- new.names[which(x = rownames(x$cell_attr) %in% Cells(x = object))]
-            x$cells_step1 <- new.names.vst
-            rownames(x = x$cell_attr) <- new.names.vst
+            x$cells_step1 <- new.names[which(x = x$cells_step1 %in% Cells(x = object))]
+            rownames(x = x$cell_attr) <- new.names[which(x = rownames(x$cell_attr) %in% Cells(x = object))]
             return(x)
           }
         )


### PR DESCRIPTION
Hello! I came across a bug in RenameCells, for datasets that have gone through batch integration via the SCTransform route, per https://satijalab.org/seurat/v3.0/integration.html. 

It uses `cells_step1` to pull the relevant cells, but this will fail when SCTransform was run with ncells is less than the number of cells in that batch. 

I started writing up an issue but it seemed easier to just submit a PR since it is just one line of code. I'm happy to submit an issue or provide more info if needed. Thanks!
