### PR TITLE
Fix highlight order depending on alpha order

### DIFF
--- a/R/visualization.R
+++ b/R/visualization.R
@@ -4811,7 +4811,7 @@ SetHighlight <- function(
   plot.order <- sort(x = unique(x = highlight), na.last = TRUE)
   plot.order[is.na(x = plot.order)] <- 'Unselected'
   highlight[is.na(x = highlight)] <- 'Unselected'
-  highlight <- as.factor(x = highlight)
+  highlight <- factor(x = highlight, levels = plot.order)
   return(list(
     plot.order = plot.order,
     highlight = highlight,


### PR DESCRIPTION
Hi,

I can also submit this separately as an issue but I think I traced down the issue.

When I followed the spatial vignette for my cell type classifications, I noticed that some of the visualizations were inverted (red where the cell type was present and grey where it was not). I attached a minimally working example notebook \[3\] but, to summarize, as far as I can tell, it depends on the alphabetical order of the class name compared to the internal `Unselected` class name. So if I create two identical identity classes with names `V_true` and `UA_True`, then `V_true`  returns the inverted version [1] but `UA_True` returns the correct version [2].

Tracing it through, the code goes out of its way to avoid this but when it `factor`izes the `highlight` variable in `SetHighlight`, it doesn't set the level order and this order is used by `ggplot` later

Happy to work with you on debugging further!


\[1\]: 

![image](https://user-images.githubusercontent.com/1739784/98165913-ab311800-1eb4-11eb-9fad-eaede7e74221.png)


\[2\]: 

![image](https://user-images.githubusercontent.com/1739784/98165346-bfc0e080-1eb3-11eb-9533-206ecb797edf.png)

\[3\]:
[Seurat_Dimplot_alpha_inversion.zip](https://github.com/satijalab/seurat/files/5490399/Seurat_Dimplot_alpha_inversion.zip)
