### PR TITLE
Revised CellRanger input versioning logic

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,4 +1,4 @@
-oPackage: Seurat
+Package: Seurat
 Version: 3.2.2.9012
 Date: 2020-11-17
 Title: Tools for Single Cell Genomics

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
-Package: Seurat
-Version: 3.2.2.9011
-Date: 2020-11-09
+oPackage: Seurat
+Version: 3.2.2.9012
+Date: 2020-11-17
 Title: Tools for Single Cell Genomics
 Description: A toolkit for quality control, analysis, and exploration of single cell RNA sequencing data. 'Seurat' aims to enable users to identify and interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse types of single cell data. See Satija R, Farrell J, Gennert D, et al (2015) <doi:10.1038/nbt.3192>, Macosko E, Basu A, Satija R, et al (2015) <doi:10.1016/j.cell.2015.05.002>, and Stuart T, Butler A, et al (2019) <doi:10.1016/j.cell.2019.05.031> for more details.
 Authors@R: c(

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Update Rcpp functions with `export(rng=FALSE)` to avoid potential future warnings
 - Fix RenameCells bug for integrated SCT assays
 - Fix highlight order with proper factor levels when using `SetHighlight` in plots
+- Small change in CellRanger version detection logic of h5 file to improve robustness to outside tools.
 
 ## [3.2.2] - 2020-09-25
 ### Changes

--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -1152,7 +1152,7 @@ Read10X_h5 <- function(filename, use.names = TRUE, unique.features = TRUE) {
   infile <- hdf5r::H5File$new(filename = filename, mode = 'r')
   genomes <- names(x = infile)
   output <- list()
-  if (!infile$attr_exists("PYTABLES_FORMAT_VERSION")) {
+  if (hdf5r::existsGroup(infile, 'matrix')) {
     # cellranger version 3
     if (use.names) {
       feature_slot <- 'features/name'


### PR DESCRIPTION
Resolves #3653

This small change improves the robustness of the logic for determining input CellRanger h5 version.  Outside software tools that are written in python and save files in CellRanger format using PyTables have a `PYTABLES_FORMAT_VERSION` attribute regardless of whether the format is v2 or v3.  This change makes the v2/v3 decision based on the presence of `'matrix'` in the h5 file, which is a major organizational change between CellRanger v2 and v3 files.
