### PR TITLE
Add keep.scale param to FeaturePlot when creating split plots

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Seurat
-Version: 3.2.2.9012
-Date: 2020-11-17
+Version: 3.2.2.9013
+Date: 2020-12-04
 Title: Tools for Single Cell Genomics
 Description: A toolkit for quality control, analysis, and exploration of single cell RNA sequencing data. 'Seurat' aims to enable users to identify and interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse types of single cell data. See Satija R, Farrell J, Gennert D, et al (2015) <doi:10.1038/nbt.3192>, Macosko E, Basu A, Satija R, et al (2015) <doi:10.1016/j.cell.2015.05.002>, and Stuart T, Butler A, et al (2019) <doi:10.1016/j.cell.2019.05.031> for more details.
 Authors@R: c(

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 ### Added
 - Titles added to `DimPlot` when specifying `group.by` parameter
+- `keep.scale` parameter added to `FeaturePlot` to control scaling across multiple features and/or splits.
 
 ### Changes
 - `Same` deprecated in favor of `base::identity`

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -896,7 +896,7 @@ DimPlot <- function(
 #'  may specify quantile in the form of 'q##' where '##' is the quantile (eg, 'q1', 'q10')
 #' @param split.by A factor in object metadata to split the feature plot by, pass 'ident'
 #'  to split by cell identity'; similar to the old \code{FeatureHeatmap}
-#' @param keep.scale How to plot color scale across 'split.by' plots. Options are:
+#' @param keep.scale How to handle the color scale across multiple plots. Options are:
 #' \itemize{
 #'   \item{"feature" (default; by row/feature scaling):}{ The plots for each individual feature are scaled to the maximum expression of the feature across the conditions provided to 'split.by'.}
 #'   \item{"all" (universal scaling):}{ The plots for all features and conditions are scaled to the maximum expression value for the feature with the highest overall expression.}
@@ -1308,7 +1308,7 @@ FeaturePlot <- function(
           )
         }
       }
-      if (!(is.null(keep.scale)) && keep.scale == "feature" && !is.null(x = split.by)) {
+      if (!(is.null(keep.scale)) && keep.scale == "feature") {
         feature.data <- FetchData(
           object = object,
           vars = feature,
@@ -1447,7 +1447,7 @@ FeaturePlot <- function(
     if (!is.null(x = legend) && legend == 'none') {
       plots <- plots & NoLegend()
     }
-    if (!(is.null(keep.scale)) && keep.scale == "all" && !is.null(x = split.by)) {
+    if (!(is.null(keep.scale)) && keep.scale == "all") {
       feature.data <- FetchData(
         object = object,
         vars = features,

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -991,7 +991,7 @@ FeaturePlot <- function(
   }
   # Check keep.scale param for valid entries
   if (!(is.null(x = keep.scale)) && !(keep.scale %in% c("feature", "all"))) {
-    stop("`keep.scale` must be either `feature`, `all`, or NULL")
+    stop("`keep.scale` must be set to either `feature`, `all`, or NULL")
   }
   # Set a theme to remove right-hand Y axis lines
   # Also sets right-hand Y axis text label formatting

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -1313,9 +1313,9 @@ FeaturePlot <- function(
           object = object,
           vars = feature,
           slot = slot)
-        max.exp.value <- max(feature.data)
-        min.exp.value <- min(feature.data)
-        plot <- suppressMessages(plot & scale_color_gradientn(colors = cols, limits = c(min.exp.value, max.exp.value)))
+        max.feature.value <- max(feature.data)
+        min.feature.value <- min(feature.data)
+        plot <- suppressMessages(plot & scale_color_gradientn(colors = cols, limits = c(min.feature.value, max.feature.value)))
       }
       # Add coord_fixed
       if (coord.fixed) {
@@ -1452,9 +1452,9 @@ FeaturePlot <- function(
         object = object,
         vars = features,
         slot = slot)
-      max.exp.value <- max(feature.data)
-      min.exp.value <- min(feature.data)
-      plots <- suppressMessages(plots & scale_color_gradientn(colors = cols, limits = c(min.exp.value, max.exp.value)))
+      max.feature.value <- max(feature.data)
+      min.feature.value <- min(feature.data)
+      plots <- suppressMessages(plots & scale_color_gradientn(colors = cols, limits = c(min.feature.value, max.feature.value)))
     }
   }
   return(plots)

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -896,6 +896,7 @@ DimPlot <- function(
 #'  may specify quantile in the form of 'q##' where '##' is the quantile (eg, 'q1', 'q10')
 #' @param split.by A factor in object metadata to split the feature plot by, pass 'ident'
 #'  to split by cell identity'; similar to the old \code{FeatureHeatmap}
+#' @param keep.scale logical, whether to keep the color scale constant across split plots (default = FALSE)
 #' @param slot Which slot to pull expression data from?
 #' @param blend Scale and blend expression values to visualize coexpression of two features
 #' @param blend.threshold The color cutoff from weak signal to strong signal; ranges from 0 to 1.
@@ -947,6 +948,7 @@ FeaturePlot <- function(
   max.cutoff = NA,
   reduction = NULL,
   split.by = NULL,
+  keep.scale = FALSE,
   shape.by = NULL,
   slot = 'data',
   blend = FALSE,
@@ -1426,6 +1428,15 @@ FeaturePlot <- function(
     }
     if (!is.null(x = legend) && legend == 'none') {
       plots <- plots & NoLegend()
+    }
+    if (keep.scale && !is.null(x = split.by)) {
+      feature.data <- FetchData(
+        object = object,
+        vars = features,
+        slot = slot)
+      max.feature.value <- max(feature.data)
+      min.feature.value <- min(feature.data)
+      plots <- plots & scale_color_gradientn(colors = cols, limits = c(min.feature.value, max.feature.value))
     }
   }
   return(plots)

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -896,7 +896,12 @@ DimPlot <- function(
 #'  may specify quantile in the form of 'q##' where '##' is the quantile (eg, 'q1', 'q10')
 #' @param split.by A factor in object metadata to split the feature plot by, pass 'ident'
 #'  to split by cell identity'; similar to the old \code{FeatureHeatmap}
-#' @param keep.scale logical, whether to keep the color scale constant across split plots (default = TRUE)
+#' @param keep.scale How to plot color scale across 'split.by' plots. Options are:
+#' \itemize{
+#'   \item{"feature" (default; by row/feature scaling):}{ The plots for each individual feature are scaled to the maximum expression of the feature across the conidtions provided to 'split.by'.}
+#'   \item{"all" (universal scaling):}{ The plots for all features and conditions are scaled to the maximum expression value for the feature with the highest expression.}
+#'   \item{NULL (no scaling):}{ Each individual plot is scaled to the maximum expression value of the feature in the condition provided to 'split.by'. Be aware setting NULL will result in color scales that are not comparable between plots.}
+#' }
 #' @param slot Which slot to pull expression data from?
 #' @param blend Scale and blend expression values to visualize coexpression of two features
 #' @param blend.threshold The color cutoff from weak signal to strong signal; ranges from 0 to 1.
@@ -948,7 +953,7 @@ FeaturePlot <- function(
   max.cutoff = NA,
   reduction = NULL,
   split.by = NULL,
-  keep.scale = TRUE,
+  keep.scale = "feature",
   shape.by = NULL,
   slot = 'data',
   blend = FALSE,
@@ -983,6 +988,10 @@ FeaturePlot <- function(
       reduction = reduction,
       slot = slot
     ))
+  }
+  # Check keep.scale param for valid entries
+  if (!(is.null(x = keep.scale)) && !(keep.scale %in% c("feature", "all"))) {
+    stop("`keep.scale` must be either `feature`, `all`, or NULL")
   }
   # Set a theme to remove right-hand Y axis lines
   # Also sets right-hand Y axis text label formatting
@@ -1299,6 +1308,15 @@ FeaturePlot <- function(
           )
         }
       }
+      if (!(is.null(keep.scale)) && keep.scale == "feature" && !is.null(x = split.by)) {
+        feature.data <- FetchData(
+          object = object,
+          vars = feature,
+          slot = slot)
+        max.exp.value <- max(feature.data)
+        min.exp.value <- min(feature.data)
+        plot <- suppressMessages(plot & scale_color_gradientn(colors = cols, limits = c(min.exp.value, max.exp.value)))
+      }
       # Add coord_fixed
       if (coord.fixed) {
         plot <- plot + coord_fixed()
@@ -1429,14 +1447,14 @@ FeaturePlot <- function(
     if (!is.null(x = legend) && legend == 'none') {
       plots <- plots & NoLegend()
     }
-    if (keep.scale && !is.null(x = split.by)) {
+    if (!(is.null(keep.scale)) && keep.scale == "all" && !is.null(x = split.by)) {
       feature.data <- FetchData(
         object = object,
         vars = features,
         slot = slot)
-      max.feature.value <- max(feature.data)
-      min.feature.value <- min(feature.data)
-      plots <- suppressMessages(plots & scale_color_gradientn(colors = cols, limits = c(min.feature.value, max.feature.value)))
+      max.exp.value <- max(feature.data)
+      min.exp.value <- min(feature.data)
+      plots <- suppressMessages(plots & scale_color_gradientn(colors = cols, limits = c(min.exp.value, max.exp.value)))
     }
   }
   return(plots)

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -896,7 +896,7 @@ DimPlot <- function(
 #'  may specify quantile in the form of 'q##' where '##' is the quantile (eg, 'q1', 'q10')
 #' @param split.by A factor in object metadata to split the feature plot by, pass 'ident'
 #'  to split by cell identity'; similar to the old \code{FeatureHeatmap}
-#' @param keep.scale logical, whether to keep the color scale constant across split plots (default = FALSE)
+#' @param keep.scale logical, whether to keep the color scale constant across split plots (default = TRUE)
 #' @param slot Which slot to pull expression data from?
 #' @param blend Scale and blend expression values to visualize coexpression of two features
 #' @param blend.threshold The color cutoff from weak signal to strong signal; ranges from 0 to 1.

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -898,8 +898,8 @@ DimPlot <- function(
 #'  to split by cell identity'; similar to the old \code{FeatureHeatmap}
 #' @param keep.scale How to plot color scale across 'split.by' plots. Options are:
 #' \itemize{
-#'   \item{"feature" (default; by row/feature scaling):}{ The plots for each individual feature are scaled to the maximum expression of the feature across the conidtions provided to 'split.by'.}
-#'   \item{"all" (universal scaling):}{ The plots for all features and conditions are scaled to the maximum expression value for the feature with the highest expression.}
+#'   \item{"feature" (default; by row/feature scaling):}{ The plots for each individual feature are scaled to the maximum expression of the feature across the conditions provided to 'split.by'.}
+#'   \item{"all" (universal scaling):}{ The plots for all features and conditions are scaled to the maximum expression value for the feature with the highest overall expression.}
 #'   \item{NULL (no scaling):}{ Each individual plot is scaled to the maximum expression value of the feature in the condition provided to 'split.by'. Be aware setting NULL will result in color scales that are not comparable between plots.}
 #' }
 #' @param slot Which slot to pull expression data from?

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -948,7 +948,7 @@ FeaturePlot <- function(
   max.cutoff = NA,
   reduction = NULL,
   split.by = NULL,
-  keep.scale = FALSE,
+  keep.scale = TRUE,
   shape.by = NULL,
   slot = 'data',
   blend = FALSE,

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -1436,7 +1436,7 @@ FeaturePlot <- function(
         slot = slot)
       max.feature.value <- max(feature.data)
       min.feature.value <- min(feature.data)
-      plots <- plots & scale_color_gradientn(colors = cols, limits = c(min.feature.value, max.feature.value))
+      plots <- suppressMessages(plots & scale_color_gradientn(colors = cols, limits = c(min.feature.value, max.feature.value)))
     }
   }
   return(plots)

--- a/man/FeaturePlot.Rd
+++ b/man/FeaturePlot.Rd
@@ -18,6 +18,7 @@ FeaturePlot(
   max.cutoff = NA,
   reduction = NULL,
   split.by = NULL,
+  keep.scale = "feature",
   shape.by = NULL,
   slot = "data",
   blend = FALSE,
@@ -70,6 +71,13 @@ may specify quantile in the form of 'q##' where '##' is the quantile (eg, 'q1', 
 
 \item{split.by}{A factor in object metadata to split the feature plot by, pass 'ident'
 to split by cell identity'; similar to the old \code{FeatureHeatmap}}
+
+\item{keep.scale}{How to handle the color scale across multiple plots. Options are:
+\itemize{
+  \item{"feature" (default; by row/feature scaling):}{ The plots for each individual feature are scaled to the maximum expression of the feature across the conditions provided to 'split.by'.}
+  \item{"all" (universal scaling):}{ The plots for all features and conditions are scaled to the maximum expression value for the feature with the highest overall expression.}
+  \item{NULL (no scaling):}{ Each individual plot is scaled to the maximum expression value of the feature in the condition provided to 'split.by'. Be aware setting NULL will result in color scales that are not comparable between plots.}
+}}
 
 \item{shape.by}{If NULL, all points are circles (default). You can specify any
 cell attribute (that can be pulled with FetchData) allowing for both


### PR DESCRIPTION
Hi Seurat Team,

This is PR to add new param to `FeaturePlot`.  The current behavior of `FeaturePlot` when plotting a split feature plot is to create a gradient scale for each of the plots independently.  However, this can be deceiving to user if the legend is not plotted as the same color on the different plots can represent incredibly different values.
Example of current behavior with following code:
```
FeaturePlot(object = obj, features = "Gene", split.by = "Meta_Name", order = T) & theme(legend.position = "right")
```
![OLD_split](https://user-images.githubusercontent.com/38284410/99563201-0411ad80-2997-11eb-9367-1064529e5927.png)

This PR adds an additional parameter `keep.scale`.  This rescales the gradient to be constant across all plots.
Example:
```
FeaturePlot(object = obj, features = "Gene", split.by = "Meta_Name", keep_scale = T, order = T) & theme(legend.position = "right")
```
![keep-scale_split](https://user-images.githubusercontent.com/38284410/99563511-56eb6500-2997-11eb-89be-af7c9f2dc952.png)

Couple of notes about implementation.
1.  There may be better way to implement this behavior than I have done so open to changes if it fits better with intended function behavior.

2.  While I would normally try and preserve the current implementation of figure when adding new parameters, in this case I think a default value of `keep.scale = TRUE` is optimal even though is contrary to current function behavior.  My reasoning was two-fold. One, as the function is currently implemented the lack of legends when plotting a `split.by` plot may lead user to believe that both plots are on the same scale.  Two, the potential for confusion is potentially confounded by the patchwork  vs. ggplot2 modification syntax.  If user was to simply add `FeaturePlot(...) + theme(legend.position = "right")` instead of `FeaturePlot(...) & theme(legend.position = "right")` they would end up with legend they may think applies to all plots but in fact only applies to final plot in the series.  Of course, final choice up to you but just my thoughts.

_\*Edit\* Gene name and split.by titles were removed post from these plots.  They will appear when code is run._

Thanks very much as ever for all the work you do and excellent package!!
Best,
Sam

