### PR TITLE
Fix pseudo count

### DIFF
--- a/R/differential_expression.R
+++ b/R/differential_expression.R
@@ -681,6 +681,7 @@ FindMarkers.DimReduc <- function(
   min.cells.group = 3,
   pseudocount.use = 1,
   mean.fxn = rowMeans,
+  fc.name = NULL,
   ...
 
 ) {
@@ -706,7 +707,9 @@ FindMarkers.DimReduc <- function(
     object = object,
     cells.1 = cells.1,
     cells.2 = cells.2,
-    features = features
+    features = features,
+    mean.fxn = mean.fxn,
+    fc.name = fc.name
   )
   # subsample cell groups if they are too large
   if (max.cells.per.ident < Inf) {

--- a/R/differential_expression.R
+++ b/R/differential_expression.R
@@ -627,6 +627,7 @@ FindMarkers.Assay <- function(
     cells.1 = cells.1,
     cells.2 = cells.2,
     features = features,
+    pseudocount.use = pseudocount.use,
     mean.fxn = mean.fxn,
     fc.name = fc.name,
     base = base


### PR DESCRIPTION
Hi,
Here is a bug I noticed:
```
library(dplyr)
library(Seurat)
library(patchwork)

# Load the PBMC dataset
pbmc.data <- Read10X(data.dir = "~/Downloads//filtered_gene_bc_matrices/hg19/")
# Initialize the Seurat object with the raw (non-normalized data).
pbmc <- CreateSeuratObject(counts = pbmc.data, project = "pbmc3k", min.cells = 3, min.features = 200)
pbmc <- NormalizeData(pbmc)
pbmc <- FindVariableFeatures(pbmc, selection.method = "vst", nfeatures = 2000)
all.genes <- rownames(pbmc)
pbmc <- ScaleData(pbmc, features = all.genes)
pbmc <- RunPCA(pbmc, features = VariableFeatures(object = pbmc))
pbmc <- FindNeighbors(pbmc, dims = 1:10)
pbmc <- FindClusters(pbmc, resolution = 0.5)
FindMarkers(pbmc, ident.1 = 2, min.pct = 0.25,
            features = "LTB")
# It gives 1.18 as avg_log2FC
Seurat:::FindMarkers.Seurat(pbmc, ident.1 = 2, min.pct = 0.25,
                            features = "LTB", pseudocount.use = 0)
# It also gives 1.18 instead of 1.24
FoldChange(pbmc, WhichCells(pbmc, idents = 2),
           WhichCells(pbmc, idents = setdiff(Idents(pbmc), "2")),
           features = "LTB",
           pseudocount.use = 0)
# This gives 1.24
Seurat:::FindMarkers.Assay(pbmc[['RNA']], cells.1 =  WhichCells(pbmc, idents = 2),
                           cells.2 = WhichCells(pbmc, idents = setdiff(Idents(pbmc), "2")),
                           features = "LTB",
                           pseudocount.use = 0)
# This also gives 1.18 instead of 1.24
```
I found the error and corrected it.
Then I also noticed that if you specify `mean.fxn` in `FindMarkers.DimReduc` it was not used so I corrected it.
I hope it helps.