### PR TITLE
Add pct.diff parameter to DE results dataframe

### DIFF
--- a/R/differential_expression.R
+++ b/R/differential_expression.R
@@ -892,12 +892,13 @@ FoldChange.default <- function(
       length(x = cells.2),
     digits = 3
   )
+  pct.diff <- pct.1 - pct.2
   # Calculate fold change
   data.1 <- mean.fxn(object[features, cells.1, drop = FALSE])
   data.2 <- mean.fxn(object[features, cells.2, drop = FALSE])
   fc <- (data.1 - data.2)
-  fc.results <- as.data.frame(x = cbind(fc, pct.1, pct.2))
-  colnames(fc.results) <- c(fc.name, "pct.1", "pct.2")
+  fc.results <- as.data.frame(x = cbind(fc, pct.1, pct.2, pct.diff))
+  colnames(fc.results) <- c(fc.name, "pct.1", "pct.2", "pct.diff")
   return(fc.results)
 }
 


### PR DESCRIPTION
Hi Seurat Team,

Just quick PR and not 100% sure changes are in right place so feel free to edit.  Just PR to add a percent difference column in addition to pct.1 and pct.2 to the results from `FindMarkers`/`FindAllMarkers`.  While it's easy to calculate and add post-hoc thought it might be nice to have included by default as it provides nice quick idea of the basic magnitude and direction of change in percent expressing.

Thanks as always!
Sam
