### PR TITLE
Fix for MASTDETest regression in 4.0.6

### DIFF
--- a/R/differential_expression.R
+++ b/R/differential_expression.R
@@ -1812,15 +1812,14 @@ MASTDETest <- function(
     object = paste0(" ~ ", paste(latent.vars.names, collapse = "+"))
   )
   zlmCond <- MAST::zlm(formula = fmla, sca = sca, ...)
-  summaryCond <- summary(object = zlmCond, doLRT = 'conditionGroup2')
-  summaryDt <- summaryCond$datatable
+  lr_results <- MAST::lrTest(zlmCond, 'condition')
   # fcHurdle <- merge(
   #   summaryDt[contrast=='conditionGroup2' & component=='H', .(primerid, `Pr(>Chisq)`)], #hurdle P values
   #   summaryDt[contrast=='conditionGroup2' & component=='logFC', .(primerid, coef, ci.hi, ci.lo)], by='primerid'
   # ) #logFC coefficients
   # fcHurdle[,fdr:=p.adjust(`Pr(>Chisq)`, 'fdr')]
-  p_val <- summaryDt[summaryDt[, "component"] == "H", 4]
-  genes.return <- summaryDt[summaryDt[, "component"] == "H", 1]
+  p_val <- lr_results[,"hurdle", "Pr(>Chisq)"]
+  genes.return <- names(p_val)
   # p_val <- subset(summaryDt, component == "H")[, 4]
   # genes.return <- subset(summaryDt, component == "H")[, 1]
   to.return <- data.frame(p_val, row.names = genes.return)


### PR DESCRIPTION
Fix for  #5419, https://github.com/RGLab/MAST/issues/170, etc..

For ...reasons..the MAST S4 generic for `summary` was no longer being found...
I now use `lrTest` rather than `summary` to get p values.  `MAST::summary` on line 1815 works, too, but no reason to need to run the whole summary function here.

I ran R CMD check and got the following output.  The errors and warnings appear to be the same before and after the fix.

<details>
── R CMD check results ───────────────────────────── Seurat 4.0.6.9003 ────
Duration: 4m 41.7s

> checking examples ... ERROR
Running examples in ‘Seurat-Ex.R’ failed
The error most likely occurred in:
  
  > base::assign(".ptime", proc.time(), pos = "CheckExEnv")
> ### Name: PrepSCTFindMarkers
  > ### Title: Prepare object to run differential expression on SCT assay with
  > ###   multiple models
  > ### Aliases: PrepSCTFindMarkers
  > 
  > ### ** Examples
  > 
  > data("pbmc_small")
> pbmc_small1 <- SCTransform(object = pbmc_small, variable.features.n = 20)
Calculating cell attributes from input UMI matrix: log_umi
Variance stabilizing transformation of count matrix of size 220 by 80
Model formula is y ~ log_umi
Get Negative Binomial regression parameters per gene
Using 220 genes, 80 cells

|                                                                            
  |                                                                      |   0%
|                                                                            
  |======================================================================| 100%
Second step: Get residuals using fitted parameters for 220 genes

|                                                                            
  |                                                                      |   0%
|                                                                            
  |======================================================================| 100%
Computing corrected count matrix for 220 genes

|                                                                            
  |                                                                      |   0%
|                                                                            
  |======================================================================| 100%
Calculating gene attributes
Wall clock passed: Time difference of 0.357425 secs
Determine variable features
Place corrected count matrix in counts slot
Centering data matrix

|                                                                            
  |                                                                      |   0%
|                                                                            
  |======================================================================| 100%
Set default assay to SCT
> pbmc_small2 <- SCTransform(object = pbmc_small, variable.features.n = 20)
Calculating cell attributes from input UMI matrix: log_umi
Variance stabilizing transformation of count matrix of size 220 by 80
Model formula is y ~ log_umi
Get Negative Binomial regression parameters per gene
Using 220 genes, 80 cells

|                                                                            
  |                                                                      |   0%
|                                                                            
  |======================================================================| 100%
Second step: Get residuals using fitted parameters for 220 genes

|                                                                            
  |                                                                      |   0%
|                                                                            
  |======================================================================| 100%
Computing corrected count matrix for 220 genes

|                                                                            
  |                                                                      |   0%
|                                                                            
  |======================================================================| 100%
Calculating gene attributes
Wall clock passed: Time difference of 0.358021 secs
Determine variable features
Place corrected count matrix in counts slot
Centering data matrix

|                                                                            
  |                                                                      |   0%
|                                                                            
  |======================================================================| 100%
Set default assay to SCT
> pbmc_merged <- merge(x = pbmc_small1, y = pbmc_small2)
Warning in CheckDuplicateCellNames(object.list = objects) :
  Some cell names are duplicated across objects provided. Renaming to enforce unique cell names.
> pbmc_merged <- PrepSCTFindMarkers(object = pbmc_merged)
Minimum UMI unchanged. Skipping re-correction.
> markers <- FindMarkers(object = pbmc_merged, ident.1="0", ident.2="1", assay="SCT")
> pbmc_subset <- subset(pbmc_merged, idents =Run c("0", "1"))
Error: unexpected symbol in "pbmc_subset <- subset(pbmc_merged, idents =Run c"
Execution halted

> checking tests ...
See below...

> checking Rd \usage sections ... WARNING
Undocumented arguments in documentation object 'FindMarkers'
‘recorrect_umi’

Functions with \usage entries need to have the appropriate \alias
entries, and all their arguments documented.
The \usage entries must correspond to syntactically valid R code.
See chapter ‘Writing R documentation files’ in the ‘Writing R
Extensions’ manual.

> checking for unstated dependencies in examples ... WARNING
Warning: parse error in file 'lines':
  48: unexpected symbol
1438: markers <- FindMarkers(object = pbmc_merged, ident.1="0", ident.2="1", assay="SCT")
1439: pbmc_subset <- subset(pbmc_merged, idents =Run c
                            ^
                              
                              > checking package dependencies ... NOTE
                            Packages suggested but not available for checking: 'DESeq2', 'monocle'
                            
                            Imports includes 41 non-default packages.
                            Importing from so many packages makes the package vulnerable to any of
                            them becoming unavailable.  Move as many as possible to Suggests and
                            use conditionally.
                            
                            > checking Rd line widths ... NOTE
                            Rd file 'PrepSCTFindMarkers.Rd':
                              \examples lines wider than 100 characters:
                              markers_subset <- FindMarkers(object = pbmcx, ident.1="0", ident.2="1", assay="SCT", recorrect_umi = FALSE)
                            
                            These lines will be truncated in the PDF manual.
                            
                            > checking Rd cross-references ... NOTE
                            Package unavailable to check Rd xrefs: ‘Signac’
                            
                            ── Test failures ──────────────────────────────────────────── testthat ────
                            
                            > library(testthat)
                            > library(Seurat)
                            Attaching SeuratObject
                            > 
                              > test_check("Seurat")
                            ══ Warnings ════════════════════════════════════════════════════════════════════
                            ── Warning (test_load_10X.R:35:3): (code run outside of `test_that()`) ─────────
                            'giveCsparse' has been deprecated; setting 'repr = "T"' for you
                            Backtrace:
                              1. Seurat::Load10X_Spatial(data.dir = "../testdata/visium") test_load_10X.R:35:2
                            2. Seurat::Read10X_h5(...)
                            3. Matrix::sparseMatrix(...)
                            
                            ══ Failed tests ════════════════════════════════════════════════════════════════
                            ── Error (test_integration.R:259:3): FindTransferAnchors with default SCT works ──
                            Error in `validObject(.Object)`: invalid class "SCTModel" object: invalid object for slot "median_umi" in class "SCTModel": got class "NULL", should be or extend class "numeric"
                            Backtrace:
                              █
                            1. └─Seurat::FindTransferAnchors(...) test_integration.R:259:2
                            2.   └─Seurat:::ValidateParams_FindTransferAnchors(...)
                            3.     └─Seurat::SCTransform(...)
                            4.       └─methods::as(object = assay.out, Class = "SCTAssay")
                            5.         └─Seurat:::asMethod(object)
                            6.           └─base::lapply(...)
                            7.             └─Seurat:::FUN(X[[i]], ...)
                            8.               └─Seurat:::PrepVSTResults(vst.res = vst.res[[i]], cell.names = colnames(x = from))
                            9.                 └─Seurat:::SCTModel(...)
                            10.                   └─methods::new(structure("SCTModel", package = "Seurat"), ...)
                            11.                     ├─methods::initialize(value, ...)
                            12.                     └─methods::initialize(value, ...)
                            13.                       └─methods::validObject(.Object)
                            ── Error (test_integration.R:301:3): FindTransferAnchors with default SCT works ──
                            Error in `validObject(.Object)`: invalid class "SCTModel" object: invalid object for slot "median_umi" in class "SCTModel": got class "NULL", should be or extend class "numeric"
                            Backtrace:
                              █
                            1. └─Seurat::FindTransferAnchors(...) test_integration.R:301:2
                            2.   └─Seurat:::ValidateParams_FindTransferAnchors(...)
                            3.     └─Seurat::SCTransform(...)
                            4.       └─methods::as(object = assay.out, Class = "SCTAssay")
                            5.         └─Seurat:::asMethod(object)
                            6.           └─base::lapply(...)
                            7.             └─Seurat:::FUN(X[[i]], ...)
                            8.               └─Seurat:::PrepVSTResults(vst.res = vst.res[[i]], cell.names = colnames(x = from))
                            9.                 └─Seurat:::SCTModel(...)
                            10.                   └─methods::new(structure("SCTModel", package = "Seurat"), ...)
                            11.                     ├─methods::initialize(value, ...)
                            12.                     └─methods::initialize(value, ...)
                            13.                       └─methods::validObject(.Object)
                            ── Error (test_integration.R:360:3): FindTransferAnchors with SCT and l2.norm FALSE work ──
                            Error in `validObject(.Object)`: invalid class "SCTModel" object: invalid object for slot "median_umi" in class "SCTModel": got class "NULL", should be or extend class "numeric"
                            Backtrace:
                              █
                            1. └─Seurat::FindTransferAnchors(...) test_integration.R:360:2
                            2.   └─Seurat:::ValidateParams_FindTransferAnchors(...)
                            3.     └─Seurat::SCTransform(...)
                            4.       └─methods::as(object = assay.out, Class = "SCTAssay")
                            5.         └─Seurat:::asMethod(object)
                            6.           └─base::lapply(...)
                            7.             └─Seurat:::FUN(X[[i]], ...)
                            8.               └─Seurat:::PrepVSTResults(vst.res = vst.res[[i]], cell.names = colnames(x = from))
                            9.                 └─Seurat:::SCTModel(...)
                            10.                   └─methods::new(structure("SCTModel", package = "Seurat"), ...)
                            11.                     ├─methods::initialize(value, ...)
                            12.                     └─methods::initialize(value, ...)
                            13.                       └─methods::validObject(.Object)
                            ── Failure (test_preprocessing.R:316:3): SCTransform ncells param works ────────
                            as.numeric(colSums(GetAssayData(object = object[["SCT"]], slot = "data"))[1]) not equal to 55.42253476.
                            1/1 mismatches
                            [1] 56.2 - 55.4 == 0.799
                            ── Failure (test_preprocessing.R:317:3): SCTransform ncells param works ────────
                            as.numeric(rowSums(GetAssayData(object = object[["SCT"]], slot = "data"))[5]) not equal to 11.36674295.
                            1/1 mismatches
                            [1] 11.6 - 11.4 == 0.223
                            ── Failure (test_preprocessing.R:318:3): SCTransform ncells param works ────────
                            as.numeric(colSums(GetAssayData(object = object[["SCT"]], slot = "counts"))[1]) not equal to 119.
                            1/1 mismatches
                            [1] 122 - 119 == 3
                            ── Failure (test_preprocessing.R:319:3): SCTransform ncells param works ────────
                            as.numeric(rowSums(GetAssayData(object = object[["SCT"]], slot = "counts"))[5]) not equal to 26.
                            1/1 mismatches
                            [1] 27 - 26 == 1
                            ── Failure (test_preprocessing.R:325:3): SCTransform ncells param works ────────
                            fa["MS4A1", "residual_mean"] not equal to 0.3084931639.
                            1/1 mismatches
                            [1] 0.314 - 0.308 == 0.00599
                            ── Failure (test_preprocessing.R:326:3): SCTransform ncells param works ────────
                            fa["MS4A1", "residual_variance"] not equal to 3.721067314.
                            1/1 mismatches
                            [1] 3.97 - 3.72 == 0.247
                            
                            [ FAIL 9 | WARN 1 | SKIP 0 | PASS 749 ]
                            Error: Test failures
                            Execution halted
                            
                            2 errors x | 2 warnings x | 3 notes x
                            Error: R CMD check found ERRORs
                            Execution halted
                            
                            Exited with status 1.
</details>