### PR TITLE
Add newlines to end of object definitions

### DIFF
--- a/R/objects.R
+++ b/R/objects.R
@@ -2274,7 +2274,7 @@ setMethod(
   definition = function(object) {
     cat('An AnchorSet object containing', nrow(x = slot(object = object, name = "anchors")),
         "anchors between the reference and query Seurat objects. \n",
-        "This can be used as input to TransferData.")
+        "This can be used as input to TransferData.\n")
   }
 )
 
@@ -2284,7 +2284,7 @@ setMethod(
   definition = function(object) {
     cat('An AnchorSet object containing', nrow(x = slot(object = object, name = "anchors")),
         "anchors between", length(x = slot(object = object, name = "object.list")), "Seurat objects \n",
-        "This can be used as input to IntegrateData.")
+        "This can be used as input to IntegrateData.\n")
   }
 )
 
@@ -2295,7 +2295,7 @@ setMethod(
     cat(
       'A ModalityWeights object containing modality weights between',
       paste(slot(object = object, name = "modality.assay"), collapse = " and "),
-      "assays \n", "This can be used as input to FindMultiModelNeighbors.")
+      "assays \n", "This can be used as input to FindMultiModelNeighbors.\n")
   }
 )
 
@@ -2307,7 +2307,7 @@ setMethod(
       "An sctransform model.\n",
       " Model formula: ", slot(object = object, name = "model"),
       "\n  Parameters stored for", nrow(x = SCTResults(object = object, slot = "feature.attributes")), "features,",
-      nrow(x = SCTResults(object = object, slot = "cell.attributes")), "cells")
+      nrow(x = SCTResults(object = object, slot = "cell.attributes")), "cells.\n")
   }
 )
 


### PR DESCRIPTION
This is a very minor commit to add newline characters to the end of some object definitions.

Previously, if we inspected an AnchorSet object in the console then we got:

An AnchorSet object containing <some number> anchors between the reference and query Seurat objects. 
 This can be used as input to TransferData.> 

i.e. the prompt is on the same line as the last line of the message. I presume that this is not deliberate? If it was deliberate then sorry for the pointless change! I made this change for objects with the TransferAnchorSet, IntegrationAnchorSet, ModalityWeights, and SCTModel signatures.

Thanks,
George

# Note

Thanks for your interest in contributing! Please make your PR to the `develop` branch. You can check out our [wiki](https://github.com/satijalab/seurat/wiki) for the current developers guide. 
