### PR TITLE
Add misc removal to DietSeurat

### DIFF
--- a/R/objects.R
+++ b/R/objects.R
@@ -454,6 +454,7 @@ CreateSCTAssayObject <- function(
 #' remove all DimReducs)
 #' @param graphs Only keep a subset of Graphs specified here (if NULL, remove
 #' all Graphs)
+#' @param misc Preserve the `@misc` slot (default is TRUE)
 #'
 #' @export
 #' @concept objects
@@ -466,7 +467,8 @@ DietSeurat <- function(
   features = NULL,
   assays = NULL,
   dimreducs = NULL,
-  graphs = NULL
+  graphs = NULL,
+  misc = TRUE
 ) {
   object <- UpdateSlots(object = object)
   assays <- assays %||% FilterObjects(object = object, classes.keep = "Assay")
@@ -508,6 +510,11 @@ DietSeurat <- function(
       }
     }
   }
+  # remove misc when desired
+  if (isFALSE(x = misc)) {
+    object@misc <- list()
+  }
+
   # remove unspecified DimReducs and Graphs
   all.objects <- FilterObjects(object = object, classes.keep = c('DimReduc', 'Graph'))
   objects.to.remove <- all.objects[!all.objects %in% c(dimreducs, graphs)]


### PR DESCRIPTION
Hi Seurat Team,

So I realize this is edge case but I think it's edge case with little downside to add.  This is PR to add parameter to remove the `@misc` slot when using `DietSeurat`  since the misc slot can store anything it can become quite large in size and users may want to remove easily when using `DietSeurat` to reduce object size.  I set the default to TRUE because like I said this is probably edge case where users would want to remove it so under normal circumstances it wouldn't be removed.

Thanks,
Sam
