### PR TITLE
Update preprocessing.R

### DIFF
--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -1558,7 +1558,7 @@ SCTransform <- function(
   assay <- assay %||% DefaultAssay(object = object)
   assay.obj <- GetAssay(object = object, assay = assay)
   umi <- GetAssayData(object = assay.obj, slot = 'counts')
-  cell.attr <- slot(object = object, name = 'meta.data')
+  cell.attr <- slot(object = object, name = 'meta.data') %>% as.character()
   vst.args <- list(...)
   # check for batch_var in meta data
   if ('batch_var' %in% names(x = vst.args)) {


### PR DESCRIPTION
After rename seurat cells' name, colnames(obj $RAN@counts) returens a named vector.

> head(colnames(obj@assays$RNA@counts), 2)
AAACCCACAACTAGAA_1 AAACCCACAAGGGTCA_1
"AAACCCACAACTAGAA-col0" "AAACCCACAAGGGTCA-col0"

SCTransform will return an error because of the following code.

```r
# Make sure rownames of cell attributes match cell names in count matrix
if (!identical(rownames(cell_attr), colnames(umi))) {
  stop('cell attribute row names must match column names of count matrix')
}
```

