### PR TITLE
fix bug when regress out only 1 gene

### DIFF
--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -2624,7 +2624,7 @@ ScaleData.default <- function(
     if (any(vars.to.regress %in% rownames(x = object))) {
       latent.data <- cbind(
         latent.data,
-        t(x = object[vars.to.regress[vars.to.regress %in% rownames(x = object)], ])
+        t(x = object[vars.to.regress[vars.to.regress %in% rownames(x = object)], , drop=F ])
       )
     }
     # Currently, RegressOutMatrix will do nothing if latent.data = NULL


### PR DESCRIPTION
when regress out only one gene, like vars.to.regress = c("nFeature_RNA", "CD79A"),
there will be a wrong message containing all the cell barcode and subsequent lm error, which can be corrected by adding `, drop=F`

```
> pbmc_small3 <- ScaleData(pbmc_small, features = all.genes,
+                          vars.to.regress = c("nFeature_RNA", "CD79A"))
Warning: Requested variables to regress not in object: CD79A
Regressing out nFeature_RNA, ATGCCAGAACGACT, CATGGCCTGTGCAT, GAACCTGATGAACC, TGACTGGATTCTCA, AGTCAGACTGCACA, TCTGATACACGTGT, TGGTATCTAAACAG, GCAGCTCTGTTTCT, GATATAACACGCAT, AATGTTGACAGTCA, AGGTCATGAGTGTC, AGAGATGATCTCGC, GGGTAACTCTAGTG, CATGAGACACGGGA, TACGCCACTCCGAA, CTAAACCTGTGCAT, GTAAGCACTCATTC, TTGGTACTGAATCC, CATCATACGGAGCA, TACATCACGCTAAC, TTACCATGAATCGC, ATAGGAGAAACAGA, GCGCACGACTTTAC, ACTCGCACGAAAGT, ATTACCTGCCTTAT, CCCAACTGCAATCG, AAATTCGAATCACG, CCATCCGATTCGCC, TCCACTCTGAGCTT, CATCAGGATGCACA, CTAAACCTCTGACA, GATAGAGAAGGGTG, CTAACGGAACCGAT, AGATATACCCGTAA, TACTCTGAATCGAC, GCGCATCTTGCTCC, GTTGACGATATCGG, ACAGGTACTGGTGT, GGCATATGCTTATC, CATTACACCAACTG, TAGGGACTGAACTC, GCTCCATGAGAAGT, TACAATGATGCTAG, CTTCATGACCGAAT, CTGCCAACAGGAGC, TTGCATTGAGCTAC, AAGCAAGAGCTTAG, CGGCACGAACTCAG, GGTGGAGATTACTC, GGCCGATGTACTCT, CGTAGCCTGTATGC, TGAGCTGAATGCTG, CCTATAACGAGACG, ATAAGTTGGTACGT, AAGCGACTTTGACG, ACCAGTGAATACCG, ATTGCACTTGCTTT, CTAGGTGATGGTTG, GCACTAGACCTTTA, CATGCGCTAGTCAC, TTGAGGACTACGCA, ATACCACTCTAAGC, CATATAGACTAAGC, TTTAGCTGTACTCT, GACATTCTCCACCT, ACGTGATGCCATGA, ATTGTAGATTCCCG, GATAGAGATCACGA, AATGCGTGGACGGA, GCGTAAACACGGTT, ATTCAGCTCATTGG, GGCATATGGGGAGT, ATCATCTGACACCA, GTCATACTTCGCCT, TTACGTACGTTCAG, GAGTTGTGGTAGCT, GACGCTCTCTCTCG, AGTCTTACTTCGGA, GGAACACTTCAGAC, CTTGATTGATCTTC
  |==================================================================================| 100%
Centering and scaling data matrix
  |==================================================================================| 100%
```