### PR TITLE
Fix #5845 raster always on VlnPlot

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Seurat
-Version: 4.1.0.9003
-Date: 2022-03-29
+Version: 4.1.0.9004
+Date: 2022-04-15
 Title: Tools for Single Cell Genomics
 Description: A toolkit for quality control, analysis, and exploration of single cell RNA sequencing data. 'Seurat' aims to enable users to identify and interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse types of single cell data. See Satija R, Farrell J, Gennert D, et al (2015) <doi:10.1038/nbt.3192>, Macosko E, Basu A, Satija R, et al (2015) <doi:10.1016/j.cell.2015.05.002>, Stuart T, Butler A, et al (2019) <doi:10.1016/j.cell.2019.05.031>, and Hao, Hao, et al (2020) <doi:10.1101/2020.10.12.335331> for more details.
 Authors@R: c(

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 - Fix `giveCsparse` related warnings in `Read10X_h5`
 - Fix ident labeling for `SpatialPlot`
 - Fix `ReadMtx` on Windows ([#5687](https://github.com/satijalab/seurat/issues/5687))
+- Fix `VlnPlot` to switch on rasterization only when required ([#5846](https://github.com/satijalab/seurat/pull/5846))
 
 
 # Seurat 4.1.0 (2022-01-14)

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -7240,8 +7240,9 @@ SingleExIPlot <- function(
     if ((nrow(x = data) > 1e5) & !isFALSE(raster)){
       message("Rasterizing points since number of points exceeds 100,000.",
               "\nTo disable this behavior set `raster=FALSE`")
+      # change raster to TRUE
+      raster <- TRUE
     }
-    raster <- TRUE
   }
   if (!is.null(x = seed.use)) {
     set.seed(seed = seed.use)


### PR DESCRIPTION
Hi Seurat Team,

Quick fix for #5845 which turned raster on all the time as long as the package check passed instead of if the raster conditions were met.  Just moved `raster <- TRUE` up one set of brackets.

Best,
Sam
