### PR TITLE
Suggestion: jitter & shuffle defaults FeatureScatter

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Seurat
-Version: 4.1.0.9005
-Date: 2022-04-18
+Version: 4.1.0.9006
+Date: 2022-04-25
 Title: Tools for Single Cell Genomics
 Description: A toolkit for quality control, analysis, and exploration of single cell RNA sequencing data. 'Seurat' aims to enable users to identify and interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse types of single cell data. See Satija R, Farrell J, Gennert D, et al (2015) <doi:10.1038/nbt.3192>, Macosko E, Basu A, Satija R, et al (2015) <doi:10.1016/j.cell.2015.05.002>, Stuart T, Butler A, et al (2019) <doi:10.1016/j.cell.2019.05.031>, and Hao, Hao, et al (2020) <doi:10.1101/2020.10.12.335331> for more details.
 Authors@R: c(

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 - Fix `ReadMtx` on Windows ([#5687](https://github.com/satijalab/seurat/issues/5687))
 - Fix `VlnPlot` to switch on rasterization only when required ([#5846](https://github.com/satijalab/seurat/pull/5846))
 - Fix `ncol` behavior in `SpatialPlot` ([#5774](https://github.com/satijalab/seurat/issues/5774))
+- Set `jitter` to FALSE in `FeatureScatter` ([#5876](https://github.com/satijalab/seurat/pull/5876))
 
 # Seurat 4.1.0 (2022-01-14)
 ## Added

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -1873,7 +1873,7 @@ CellScatter <- function(
 #' @param feature2 Second feature to plot.
 #' @param cells Cells to include on the scatter plot.
 #' @param shuffle Whether to randomly shuffle the order of points. This can be
-#' useful for crowded plots if points of interest are being buried. (default is TRUE)
+#' useful for crowded plots if points of interest are being buried. (default is FALSE)
 #' @param seed Sets the seed if randomly shuffling the order of points.
 #' @param group.by Name of one or more metadata columns to group (color) cells by
 #' (for example, orig.ident); pass 'ident' to group by identity class
@@ -1911,7 +1911,7 @@ FeatureScatter <- function(
   feature1,
   feature2,
   cells = NULL,
-  shuffle = TRUE,
+  shuffle = FALSE,
   seed = 1,
   group.by = NULL,
   cols = NULL,

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -1873,7 +1873,7 @@ CellScatter <- function(
 #' @param feature2 Second feature to plot.
 #' @param cells Cells to include on the scatter plot.
 #' @param shuffle Whether to randomly shuffle the order of points. This can be
-#' useful for crowded plots if points of interest are being buried. (default is FALSE)
+#' useful for crowded plots if points of interest are being buried. (default is TRUE)
 #' @param seed Sets the seed if randomly shuffling the order of points.
 #' @param group.by Name of one or more metadata columns to group (color) cells by
 #' (for example, orig.ident); pass 'ident' to group by identity class
@@ -1890,7 +1890,7 @@ CellScatter <- function(
 #' 100,000
 #' @param raster.dpi Pixel resolution for rasterized plots, passed to geom_scattermore().
 #' Default is c(512, 512).
-#' @param jitter Jitter for easier visualization of crowded points
+#' @param jitter Jitter for easier visualization of crowded points (default is FALSE)
 #'
 #' @return A ggplot object
 #'
@@ -1911,7 +1911,7 @@ FeatureScatter <- function(
   feature1,
   feature2,
   cells = NULL,
-  shuffle = FALSE,
+  shuffle = TRUE,
   seed = 1,
   group.by = NULL,
   cols = NULL,
@@ -1924,7 +1924,7 @@ FeatureScatter <- function(
   plot.cor = TRUE,
   raster = NULL,
   raster.dpi = c(512, 512),
-  jitter = TRUE
+  jitter = FALSE
 ) {
   cells <- cells %||% colnames(x = object)
   if (isTRUE(x = shuffle)) {

--- a/man/DietSeurat.Rd
+++ b/man/DietSeurat.Rd
@@ -35,7 +35,7 @@ remove all DimReducs)}
 \item{graphs}{Only keep a subset of Graphs specified here (if NULL, remove
 all Graphs)}
 
-\item{misc}{Preserve the `@misc` slot (default is TRUE)}
+\item{misc}{Preserve the \code{misc} slot; default is \code{TRUE}}
 }
 \description{
 Keep only certain aspects of the Seurat object. Can be useful in functions that utilize merge as

--- a/man/FeatureScatter.Rd
+++ b/man/FeatureScatter.Rd
@@ -23,7 +23,7 @@ FeatureScatter(
   plot.cor = TRUE,
   raster = NULL,
   raster.dpi = c(512, 512),
-  jitter = TRUE
+  jitter = FALSE
 )
 }
 \arguments{
@@ -67,7 +67,7 @@ which will automatically use raster if the number of points plotted is greater t
 \item{raster.dpi}{Pixel resolution for rasterized plots, passed to geom_scattermore().
 Default is c(512, 512).}
 
-\item{jitter}{Jitter for easier visualization of crowded points}
+\item{jitter}{Jitter for easier visualization of crowded points (default is FALSE)}
 }
 \value{
 A ggplot object


### PR DESCRIPTION
Hi Seurat Team,

Just wanted to pop in potential suggestion for change in defaults on `FeatureScatter` based on recent issue #5875 where the jitter default can give false impression of data.  In looking at this I started wondering whether changing the default behavior from `jitter = TRUE` and `shuffle = FALSE` might actually be more informative for the user.  I'll describe my rationale and leave examples below and then leave it to your team.  As I say just potential suggestion and I likely do not have the full rationale for the design choices so feel free to reject the PR.

In most cases on truly crowded plot the `jitter` being applied doesn't (at least to my eye) significantly alter the visualization.  However, setting `shuffle = TRUE` does significantly alter things by reducing identity layering effects which can mask cell/identity location.  I do concede that the interpretability of the shuffled plot is also difficult due to sheer number of points but overall I think the effect is better than `shuffle = FALSE`.

Using the SeuratData hcabm40K as moderately (compared to 100K+ cells at least) crowded dataset.  I also cropped axes of plots below to increase resolution to see an effect of these parameters as raw dataset has some outliers.  

Thanks again for everything you do!

Best,
Sam

```
library(tidyverse)
library(Seurat)
library(scCustomize)
library(patchwork)

hcabm40k <- hcabm40k.SeuratData::hcabm40k

hcabm40k <- Add_Mito_Ribo_Seurat(seurat_object = hcabm40k, species = "human")

p1 <- FeatureScatter(object = hcabm40k, cols = DiscretePalette(palette = "polychrome", n = 36), feature1 = "nCount_RNA", feature2 = "percent_mito", pt.size = 0.75, jitter = T) + NoLegend() + xlim(0, 75000) + ylim(0, 10)

p2 <- FeatureScatter(object = hcabm40k, cols = DiscretePalette(palette = "polychrome", n = 36), feature1 = "nCount_RNA", feature2 = "percent_mito", pt.size = 0.75, jitter = F) + NoLegend() + xlim(0, 75000) + ylim(0, 10)

wrap_plots(p1, p2)
```

![image](https://user-images.githubusercontent.com/38284410/164532879-468f082e-8aa8-40dd-bcdd-927bd535a896.png)


```
p3 <- FeatureScatter(object = hcabm40k, cols = DiscretePalette(palette = "polychrome", n = 36), feature1 = "nCount_RNA", feature2 = "percent_mito", pt.size = 0.75, shuffle = F) + NoLegend() + xlim(0, 75000) + ylim(0, 10)

p4 <- FeatureScatter(object = hcabm40k, cols = DiscretePalette(palette = "polychrome", n = 36), feature1 = "nCount_RNA", feature2 = "percent_mito", pt.size = 0.75, shuffle = T) + NoLegend() + xlim(0, 75000) + ylim(0, 10)

wrap_plots(p3, p4)
```

![image](https://user-images.githubusercontent.com/38284410/164533103-aad64b84-e6b7-4ced-a4c3-ce3c4bff2252.png)
