### PR TITLE
Fix/PlotPerturbScore

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Seurat
-Version: 4.1.1.9001
-Date: 2022-05-20
+Version: 4.1.1.9002
+Date: 2022-06-17
 Title: Tools for Single Cell Genomics
 Description: A toolkit for quality control, analysis, and exploration of single cell RNA sequencing data. 'Seurat' aims to enable users to identify and interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse types of single cell data. See Satija R, Farrell J, Gennert D, et al (2015) <doi:10.1038/nbt.3192>, Macosko E, Basu A, Satija R, et al (2015) <doi:10.1016/j.cell.2015.05.002>, Stuart T, Butler A, et al (2019) <doi:10.1016/j.cell.2019.05.031>, and Hao, Hao, et al (2020) <doi:10.1101/2020.10.12.335331> for more details.
 Authors@R: c(

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## Changes
 - Fix legend color in `DoHeatmap()` ([#5783](https://github.com/satijalab/seurat/issues/5783))
 - Fix bug in `ScaleData()` when regressing out one gene ([#5970](https://github.com/satijalab/seurat/pull/5970))
+- Fix name pulling in `PlotPerturbScore()` ([#6081](https://github.com/satijalab/seurat/pull/6081))
 
 # Seurat 4.1.1 (2022-05-01)
 

--- a/R/mixscape.R
+++ b/R/mixscape.R
@@ -1027,8 +1027,8 @@ PlotPerturbScore <- function(
   prtb_score[, 2] <- as.factor(x = prtb_score[, 2])
   gd <- setdiff(x = unique(x = prtb_score[, target.gene.class]), y = target.gene.ident)
   colnames(x = prtb_score)[2] <- "gene"
-  prtb_score$cell.bc <- sapply(rownames(prtb_score), FUN = function(x) strsplit(x, split = "[.]")[[1]][2])
-
+  prtb_score$cell.bc <- sapply(rownames(prtb_score), FUN = function(x) substring(x, regexpr("[.]", x) + 1))
+  
   if (isTRUE(x = before.mixscape)) {
     cols <- setNames(
       object = c("grey49", col),


### PR DESCRIPTION
Made a small change to fix #5134.
The issue was the cell name structure and how we were pulling those names inside `PlotPerturbScore`. Hopefully this new version will be more flexible to different cell name structures.