### PR TITLE
Fix mean.fxn setting in FindMarkers.SCTAssay function

### DIFF
--- a/R/differential_expression.R
+++ b/R/differential_expression.R
@@ -752,12 +752,17 @@ FindMarkers.SCTAssay <- function(
     'scale.data' = GetAssayData(object = object, slot = "counts"),
     numeric()
   )
-  if (is.null(x = mean.fxn)){
-    mean.fxn <- function(x) {
-      return(log(x = rowMeans(x = expm1(x = x)) + pseudocount.use, base = base))
-
-    }
+  default.mean.fxn <- function(x) {
+	return(log(x = rowMeans(x = expm1(x = x)) + pseudocount.use, base = base))
   }
+  mean.fxn <- mean.fxn %||% switch(
+    EXPR = slot,
+    'counts' = function(x) {
+        return(log(x = rowMeans(x = x) + pseudocount.use, base = base))
+      },
+    'scale.data' = rowMeans,
+    default.mean.fxn
+  )
   fc.results <- FoldChange(
     object = object,
     slot = data.slot,


### PR DESCRIPTION
Hi Seurat team,

I made this PR to fix an error in average log2FC computation in FindMarkers function. I described the error in more details in the issue #7095 

Christophe