### PR TITLE
Update convenience.R Xenium new blank unassigned assay

### DIFF
--- a/R/convenience.R
+++ b/R/convenience.R
@@ -201,7 +201,7 @@ LoadXenium <- function(data.dir, fov = 'fov', assay = 'Xenium') {
   )
 
   xenium.obj <- CreateSeuratObject(counts = data$matrix[["Gene Expression"]], assay = assay)
-  xenium.obj[["BlankCodeword"]] <- CreateAssayObject(counts = data$matrix[["Blank Codeword"]])
+  xenium.obj[["BlankCodeword"]] <- CreateAssayObject(counts = data$matrix[["Unassigned Codeword"]])
   xenium.obj[["ControlCodeword"]] <- CreateAssayObject(counts = data$matrix[["Negative Control Codeword"]])
   xenium.obj[["ControlProbe"]] <- CreateAssayObject(counts = data$matrix[["Negative Control Probe"]])
 


### PR DESCRIPTION
With new version of Xenium output, the output matrix "Blank Codeword" was changed to "Unassigned Codeword". Suggesting change to allow import of this updated Xenium output. Not sure if a data version check needs to also be included. Thanks @aclark5 for finding this.

# Note

Thanks for your interest in contributing! Please make your PR to the `develop` branch. You can check out our [wiki](https://github.com/satijalab/seurat/wiki) for the current developers guide. 
