### PR TITLE
update ReadParseBio to be compatible with latest split-pipe v1.1.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Seurat
-Version: 4.3.0.9008
-Date: 2023-07-06
+Version: 4.3.0.9009
+Date: 2023-07-12
 Title: Tools for Single Cell Genomics
 Description: A toolkit for quality control, analysis, and exploration of single cell RNA sequencing data. 'Seurat' aims to enable users to identify and interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse types of single cell data. See Satija R, Farrell J, Gennert D, et al (2015) <doi:10.1038/nbt.3192>, Macosko E, Basu A, Satija R, et al (2015) <doi:10.1016/j.cell.2015.05.002>, Stuart T, Butler A, et al (2019) <doi:10.1016/j.cell.2019.05.031>, and Hao, Hao, et al (2020) <doi:10.1101/2020.10.12.335331> for more details.
 Authors@R: c(

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 - Fix fold change calculation for assays ([#739](https://github.com/satijalab/seurat-private/pull/739))
 - Fix `pt.size` bug when rasterization is set to true ([#7379](https://github.com/satijalab/seurat/issues/7379)) 
 - Fix `FoldChange` and `FindMarkers` to support all normalization approaches ([#7115](https://github.com/satijalab/seurat/pull/7115),[#7110](https://github.com/satijalab/seurat/issues/7110),[#7095](https://github.com/satijalab/seurat/issues/7095),[#6976](https://github.com/satijalab/seurat/issues/6976),[#6654](https://github.com/satijalab/seurat/issues/6654),[#6701](https://github.com/satijalab/seurat/issues/6701),[#6773](https://github.com/satijalab/seurat/issues/6773), [#7107](https://github.com/satijalab/seurat/issues/7107))
+- Fix for handling newer ParseBio formats in `ReadParseBio` ([#7565](https://github.com/satijalab/seurat/pull/7565))
 
 # Seurat 4.3.0 (2022-11-18)
 

--- a/R/convenience.R
+++ b/R/convenience.R
@@ -391,7 +391,8 @@ SpecificDimPlot <- function(object, ...) {
 #' @export
 #'
 ReadParseBio <- function(data.dir, ...) {
-  mtx <- file.path(data.dir, "DGE.mtx")
+  file.dir <- list.files(path = data.dir, pattern = ".mtx")
+  mtx <- file.path(data.dir, file.dir)
   cells <- file.path(data.dir, "cell_metadata.csv")
   features <- file.path(data.dir, "all_genes.csv")
   return(ReadMtx(


### PR DESCRIPTION
Hi Seurat Team!

In the latest version of split-pipe (v1.1.0) from Parse Biosciences the `DGE.mtx` file name changed to `count_matrix.mtx`. This change breaks the `ReadParseBio()` so I modified the function to be compatible with both file name types.

I hope you can incorporate the change to the next Seurat update!

Best,
Efi 
