### PR TITLE
Correct lost gene expression column when loading NanoString CosMx data

### DIFF
--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -1870,7 +1870,7 @@ ReadNanostring <- function(
           tx <- subset(tx, select = -c(fov, cell_ID))
         }
 
-        tx <- as.data.frame(t(x = as.matrix(x = tx[, -1, drop = FALSE])))
+        tx <- as.data.frame(t(x = as.matrix(x = tx)))
         if (!is.na(x = genes.filter)) {
           ptx(
             message = paste("Filtering genes with pattern", genes.filter),


### PR DESCRIPTION
The LoadNanostring() function drops the first gene from the assay expression matrix.  This patch corrects this and no longer drops this gene from the expression matrix.

Specifically, the gene is dropped only from the "assay" slot but not from the "images" slot as show here:
![image](https://github.com/satijalab/seurat/assets/13070845/bc6a8413-2635-4dbf-b220-1ae29f83d6d9)

Example of this issue not present after the patch in this PR:
![image](https://github.com/satijalab/seurat/assets/13070845/cbd3bb1c-f252-471e-aa81-42b15b299f60)
