### PR TITLE
Restore `image` argument to `Load10X_Spatial()` for `seurat5`

### DIFF
--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -523,6 +523,7 @@ Load10X_Spatial <- function(
   slice = 'slice1',
   filter.matrix = TRUE,
   to.upper = FALSE,
+  image = NULL,
   ...
 ) {
   if (length(x = data.dir) > 1) {


### PR DESCRIPTION
The `image` argument appears to have been removed from `Load10X_Spatial()` upstream from the `seurat5` development branch in a merge commit [here](https://github.com/satijalab/seurat/commit/2eb825c2c06ffbaf77d18a4973887dea80c5f518#r123838753). This PR fixes #7560 and resolves #7608 which note the following issues:

1. Checking `is.null(x = image)` evaluates to `FALSE`, raising an **inheritance error** from:
   * `if (!inherits(x = image, what = "VisiumV1"))`

This might be due to a namespace conflict with the standard generic `graphics::image`. When `image` is not set to `NULL` in the function scope, the check evaluates to `FALSE` given an existing method:

```.zsh
% Rscript --vanilla -e 'is.null(image)' -e 'image'
[1] FALSE
function (x, ...) 
UseMethod("image")
<bytecode: 0x14c0a71f8>
<environment: namespace:graphics>
```

2. Specifying an input to `image` (e.g., with a call to `Read10X_Image`) raises an **unused argument error**
   * The `image` argument is dot-forwarded to `Read10X_h5()`, which lacks the defined argument
      + See #7608

```.r
> Load10X_Spatial(data.dir = tempdir(), image = NULL)

Error in Read10X_h5(filename = file.path(data.dir, filename), ...) (preprocessing.R#534): unused argument (image = NULL)
Show stack trace

> names(formals(Read10X_h5))
[1] "filename"        "use.names"       "unique.features"
```

# Note

> Thanks for your interest in contributing! Please make your PR to the `develop` branch. You can check out our [wiki](https://github.com/satijalab/seurat/wiki) for the current developers guide. 

I am submitting this PR directly to the `seurat5` branch from an up-to-date fork instead of the `develop` branch, given the issue appears to be localized to the v5 development branch. Hope that is alright!
