### PR TITLE
Change raster warning only if not explicitly supplied

### DIFF
--- a/R/visualization.R
+++ b/R/visualization.R
@@ -8123,7 +8123,7 @@ SingleDimPlot <- function(
   raster = NULL,
   raster.dpi = NULL
 ) {
-  if ((nrow(x = data) > 1e5) & !isFALSE(raster)){
+  if ((nrow(x = data) > 1e5) & is.null(x = raster)){
     message("Rasterizing points since number of points exceeds 100,000.",
             "\nTo disable this behavior set `raster=FALSE`")
   }
@@ -8321,7 +8321,7 @@ SingleExIPlot <- function(
   if (PackageCheck('ggrastr', error = FALSE)) {
     # Set rasterization to true if ggrastr is installed and
     # number of points exceeds 100,000
-    if ((nrow(x = data) > 1e5) & !isFALSE(raster)){
+    if ((nrow(x = data) > 1e5) & is.null(x = raster)){
       message("Rasterizing points since number of points exceeds 100,000.",
               "\nTo disable this behavior set `raster=FALSE`")
       # change raster to TRUE


### PR DESCRIPTION
Hi Seurat Team,

This is small change to clean up console output.  Currently plots based on `SingleExIPlot` or `SingleDimPlot` issue a raster warning whenever the raster parameter is not `FALSE` and the number of points is over 100K.  However, because of this it also continuously prints the message even when user explicitly sets the parameter to be TRUE.  This can clutter output especially if return lots of plots in loop for something the user has explicitly set.  This was mentioned previously in #7745.  While I know that you can suppress such warnings many users may not.

This PR simply changes the `!isFALSE(raster)` to `is.null(raster)` since NULL is the default setting.  Therefore it will only print warning when setting is not explicitly provided by the user.

This may have been specific design decision to warn every time plot is rasterized but seems unnecessary if user is supplying parameter.  If it is  specific design decision then feel free to ignore and close this PR.

Thanks as always,
Sam

