### PR TITLE
Hotfix highlight

### DIFF
--- a/R/visualization.R
+++ b/R/visualization.R
@@ -8200,7 +8200,7 @@ SingleDimPlot <- function(
   raster <- raster %||% (nrow(x = data) > 1e5)
   pt.size <- pt.size %||% AutoPointSize(data = data, raster = raster)
 
-  if (!is.null(x = cells.highlight) && pt.size == AutoPointSize(data = data, raster = raster) && sizes.highlight != pt.size && isTRUE(x = raster)) {
+  if (!is.null(x = cells.highlight) && pt.size != AutoPointSize(data = data, raster = raster) && sizes.highlight != pt.size && isTRUE(x = raster)) {
     warning("When `raster = TRUE` highlighted and non-highlighted cells must be the same size. Plot will use the value provided to 'sizes.highlight'.")
   }
 

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -7895,7 +7895,7 @@ SetHighlight <- function(
 
   # Check for raster
   if (isTRUE(x = raster)) {
-    size <- size[1]
+    size <- sizes.highlight[1]
   }
 
   plot.order <- sort(x = unique(x = highlight), na.last = TRUE)


### PR DESCRIPTION
Hi @Gesmira @saketkc,

Tagging you both here in hopes this gets seen before CRAN submission as I know that is imminent.  I found potential error in the PR (#7914) I pushed that was merged last week.

The prior code would have still allowed pt.size to override sizes.highlight in raster scenario depending on the ordering of the cells/identity being highlighted within the overall object.  (Fix `SetHighlight`).  The second commit addresses when the warning is presented to the user so that it is informatively presented.

Best and thanks as always!
Sam