### PR TITLE
PR Fixes: Fix raster warning message and pt size & PercentageFeatureSet fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: Seurat
-Version: 5.0.0.9002
+Version: 5.0.0.9003
 Date: 2023-11-10
 Title: Tools for Single Cell Genomics
 Description: A toolkit for quality control, analysis, and exploration of single cell RNA sequencing data. 'Seurat' aims to enable users to identify and interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse types of single cell data. See Satija R, Farrell J, Gennert D, et al (2015) <doi:10.1038/nbt.3192>, Macosko E, Basu A, Satija R, et al (2015) <doi:10.1016/j.cell.2015.05.002>, Stuart T, Butler A, et al (2019) <doi:10.1016/j.cell.2019.05.031>, and Hao, Hao, et al (2020) <doi:10.1101/2020.10.12.335331> for more details.

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,8 @@
 ## Changes
 
 - Fixed `SCTransform.StdAssay` to pass extra arguments to `sctransform::vst()`. Fixes [#875](https://github.com/satijalab/seurat/issues/7998)
-
+- Fixed [PercentageFeatureSet layer calling](https://github.com/satijalab/seurat/issues/8009)
+- Fixed [cell highlighting](https://github.com/satijalab/seurat/pull/7914) 
 
 # Seurat 5.0.0 (2023-10-25)
 

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -1170,7 +1170,7 @@ PercentageFeatureSet <- function(
     warn(message = "Both pattern and features provided. Pattern is being ignored.")
   }
   percent.featureset <- list()
-  layers <- Layers(object = object, pattern = "counts")
+  layers <- Layers(object = object, search = "counts")
   for (i in seq_along(along.with = layers)) {
     layer <- layers[i]
     features.layer <- features %||% grep(

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -7895,7 +7895,7 @@ SetHighlight <- function(
 
   # Check for raster
   if (isTRUE(x = raster)) {
-    size <- size[1]
+    size <- sizes.highlight[1]
   }
 
   plot.order <- sort(x = unique(x = highlight), na.last = TRUE)
@@ -8200,7 +8200,7 @@ SingleDimPlot <- function(
   raster <- raster %||% (nrow(x = data) > 1e5)
   pt.size <- pt.size %||% AutoPointSize(data = data, raster = raster)
 
-  if (!is.null(x = cells.highlight) && pt.size == AutoPointSize(data = data, raster = raster) && sizes.highlight != pt.size && isTRUE(x = raster)) {
+  if (!is.null(x = cells.highlight) && pt.size != AutoPointSize(data = data, raster = raster) && sizes.highlight != pt.size && isTRUE(x = raster)) {
     warning("When `raster = TRUE` highlighted and non-highlighted cells must be the same size. Plot will use the value provided to 'sizes.highlight'.")
   }
 


### PR DESCRIPTION
Hi Seurat Team,

This PR includes two fixes, the first is from previous PR #7938 to fix size and warnings when rasterizing points.

The second is fix for `PercentageFeatureSet` #8009 that has potential to cause incorrect values to be added to meta data (not replicated but possible) and also provides performance improvements (not running unnecessarily on non count layers).

Best,
Sam

_EDIT: fyi appears the CI fail is due to BioConductor connection issue._