### PR TITLE
Fix: UpdateSymbolList incorrectly renames genes

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -221,7 +221,7 @@ AddModuleScore <- function(
           if (search) {
             tryCatch(
               expr = {
-                updated.features <- UpdateSymbolList(symbols = missing.features, ...)
+                updated.features <- UpdateSymbolList(object = object, symbols = missing.features, ...)
                 names(x = updated.features) <- missing.features
                 for (miss in names(x = updated.features)) {
                   index <- which(x == miss)

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -1726,6 +1726,7 @@ SetQuantile <- function(cutoff, data) {
 #' }
 #'
 UpdateSymbolList <- function(
+  object,
   symbols,
   timeout = 10,
   several.ok = FALSE,
@@ -1740,6 +1741,10 @@ UpdateSymbolList <- function(
     verbose = verbose,
     ...
   ))
+
+  # avoid incorrect renaming
+  new.symbols <- new.symbols[!new.symbols %in% Features(object)]
+
   if (length(x = new.symbols) < 1) {
     warning("No updated symbols found", call. = FALSE, immediate. = TRUE)
   } else {


### PR DESCRIPTION
Hi Seurat Team,

This is PR that builds on previous fix described in #4545.  This is by no means perfect fix (explanation below) so I leave it to you to decide path forward.  If you decide a different solution is warranted I'm happy to help with PR if desired.

The issues is with potential for `UpdateSymbolList` to inappropriately rename genes.  In original case the search for alias symbols was removed from internals of `UpdateSymbolList` by manually setting the parameter to previous symbols only.  However, that unfortunately still causes issues as there are a number of previous symbols which are now symbols of different genes.  For instance the genes MCM2, MCM7, and CCNL1 which are all currently approved genes.  However, in current form `UpdateSymbolList` reverts changes:

```
> UpdateSymbolList(symbols = c("MCM2", "MCM7", "CCNL1"))
  |==============================================================================================================| 100%
Found updated symbols for 2 symbols
MCM2 -> MCM7
CCNL1 -> MCM2
[1] "MCM7" "MCM7" "MCM2"
```

Using the most recent 10X human reference genome (which is filtered so this is not full extent of potential issues), I have found >100 genes which would be inappropriately swapped.

The "simple" solution which is in this PR to avoid potential issues I added parameter to require that an object be specified and synonyms only be used if they are genes not already found in the object.  This limits the function to use with Seurat object but protects against inappropriate renames (though not completely).

The reason it's not complete solution is because most Seurat objects are filtered versions of the count matrix and this often results in objects with half the genes present in the annotation file.  Therefore the function does still leave the possibility to inappropriately rename a gene if it was gene that was filtered out during object creation.  In order to avoid completely, it different fix and for Seurat to store full feature list from the `counts` input somewhere in the object to check against vs checking against the current features with `Features`.

Again if current PR solution is not desired that is totally fine but wanted you to be alert to issue.

Best,
Sam