### PR TITLE
Add stroke.size parameter DimPlot

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: Seurat
-Version: 5.1.0.9014
+Version: 5.1.0.9015
 Title: Tools for Single Cell Genomics
 Description: A toolkit for quality control, analysis, and exploration of single cell RNA sequencing data. 'Seurat' aims to enable users to identify and interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse types of single cell data. See Satija R, Farrell J, Gennert D, et al (2015) <doi:10.1038/nbt.3192>, Macosko E, Basu A, Satija R, et al (2015) <doi:10.1016/j.cell.2015.05.002>, Stuart T, Butler A, et al (2019) <doi:10.1016/j.cell.2019.05.031>, and Hao, Hao, et al (2020) <doi:10.1101/2020.10.12.335331> for more details.
 Authors@R: c(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 ## Changes
+- Added `stroke.size` parameter to `DimPlot` ([#8180](https://github.com/satijalab/seurat/pull/8180))
 - Updated `RunLeiden` to use the `leidenbase` package instead of `leiden`; deprecated the `method` parameter for `RunLeiden` and `FindClusters`; updated `RunLeiden` to reset `random.seed` to 1 if the value is 0 or less ([#6792](https://github.com/satijalab/seurat/pull/6792))
 - Updated `RunUMAP` to support `umap-learn` version >= 0.5.0 ([#9559](https://github.com/satijalab/seurat/pull/9559))
 - Surfaced more fine-grained control over what parts of a Xenium experiment are loaded in `LoadXenium`

--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -852,7 +852,7 @@ LoadCurioSeeker <- function(data.dir, assay = "Spatial") {
 #' @export
 #' @concept preprocessing
 #'
-#' @references \url{https://www.biorxiv.org/content/10.1101/387241v1}
+#' @references \url{https://doi.org/10.1038/s41592-019-0433-8}
 #'
 #' @examples
 #' \dontrun{

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -875,6 +875,7 @@ DimPlot <- function(
   label.box = FALSE,
   repel = FALSE,
   alpha = 1,
+  stroke.size = NULL,
   cells.highlight = NULL,
   cols.highlight = '#DE2D26',
   sizes.highlight = 1,
@@ -941,6 +942,7 @@ DimPlot <- function(
         shape.by = shape.by,
         order = order,
         alpha = alpha,
+        stroke.size = stroke.size
         label = FALSE,
         cells.highlight = cells.highlight,
         cols.highlight = cols.highlight,
@@ -8224,6 +8226,7 @@ SingleDimPlot <- function(
   shape.by = NULL,
   alpha = 1,
   alpha.by = NULL,
+  stroke.size = NULL,
   order = NULL,
   label = FALSE,
   repel = FALSE,
@@ -8241,6 +8244,10 @@ SingleDimPlot <- function(
   }
   raster <- raster %||% (nrow(x = data) > 1e5)
   pt.size <- pt.size %||% AutoPointSize(data = data, raster = raster)
+
+  if (is.null(x = stroke.size)) {
+    stroke.size <- 0.600075815011372
+  }
 
   if (!is.null(x = cells.highlight) && pt.size != AutoPointSize(data = data, raster = raster) && sizes.highlight != pt.size && isTRUE(x = raster)) {
     warning("When `raster = TRUE` highlighted and non-highlighted cells must be the same size. Plot will use the value provided to 'sizes.highlight'.")
@@ -8352,7 +8359,8 @@ SingleDimPlot <- function(
         alpha = alpha.by
       ),
       size = pt.size,
-      alpha = alpha
+      alpha = alpha,
+      stroke = stroke.size
     )
   }
   plot <- plot +

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -8185,6 +8185,7 @@ SingleCorPlot <- function(
 #' allowing for both different colors and different shapes on cells.
 #' @param alpha Alpha value for plotting (default is 1)
 #' @param alpha.by Mapping variable for the point alpha value
+#' @param stroke.size Adjust stroke (outline) size of points
 #' @param order Specify the order of plotting for the idents. This can be
 #' useful for crowded plots if points of interest are being buried. Provide
 #' either a full list of valid idents or a subset to be plotted last (on top).

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -814,6 +814,7 @@ ColorDimSplit <- function(
 #' @param label.box Whether to put a box around the label text (geom_text vs
 #' geom_label)
 #' @param alpha Alpha value for plotting (default is 1)
+#' @param stroke.size Adjust stroke (outline) size of points
 #' @param repel Repel labels
 #' @param cells.highlight A list of character or numeric vectors of cells to
 #' highlight. If only one group of cells desired, can simply

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -943,7 +943,7 @@ DimPlot <- function(
         shape.by = shape.by,
         order = order,
         alpha = alpha,
-        stroke.size = stroke.size
+        stroke.size = stroke.size,
         label = FALSE,
         cells.highlight = cells.highlight,
         cols.highlight = cols.highlight,

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -814,8 +814,8 @@ ColorDimSplit <- function(
 #' @param label.box Whether to put a box around the label text (geom_text vs
 #' geom_label)
 #' @param alpha Alpha value for plotting (default is 1)
-#' @param stroke.size Adjust stroke (outline) size of points
 #' @param repel Repel labels
+#' @param stroke.size Adjust stroke (outline) size of points
 #' @param cells.highlight A list of character or numeric vectors of cells to
 #' highlight. If only one group of cells desired, can simply
 #' pass a vector instead of a list. If set, colors selected cells to the color(s)

--- a/man/ColorDimSplit.Rd
+++ b/man/ColorDimSplit.Rd
@@ -55,6 +55,7 @@ useful for crowded plots if points of interest are being buried. (default is FAL
 geom_label)}
     \item{\code{alpha}}{Alpha value for plotting (default is 1)}
     \item{\code{repel}}{Repel labels}
+    \item{\code{stroke.size}}{Adjust stroke (outline) size of points}
     \item{\code{cells.highlight}}{A list of character or numeric vectors of cells to
 highlight. If only one group of cells desired, can simply
 pass a vector instead of a list. If set, colors selected cells to the color(s)

--- a/man/DimPlot.Rd
+++ b/man/DimPlot.Rd
@@ -27,6 +27,7 @@ DimPlot(
   label.box = FALSE,
   repel = FALSE,
   alpha = 1,
+  stroke.size = NULL,
   cells.highlight = NULL,
   cols.highlight = "#DE2D26",
   sizes.highlight = 1,
@@ -90,6 +91,8 @@ geom_label)}
 \item{repel}{Repel labels}
 
 \item{alpha}{Alpha value for plotting (default is 1)}
+
+\item{stroke.size}{Adjust stroke (outline) size of points}
 
 \item{cells.highlight}{A list of character or numeric vectors of cells to
 highlight. If only one group of cells desired, can simply

--- a/man/MULTIseqDemux.Rd
+++ b/man/MULTIseqDemux.Rd
@@ -42,6 +42,6 @@ object <- MULTIseqDemux(object)
 
 }
 \references{
-\url{https://www.biorxiv.org/content/10.1101/387241v1}
+\url{https://doi.org/10.1038/s41592-019-0433-8}
 }
 \concept{preprocessing}

--- a/man/SingleDimPlot.Rd
+++ b/man/SingleDimPlot.Rd
@@ -13,6 +13,7 @@ SingleDimPlot(
   shape.by = NULL,
   alpha = 1,
   alpha.by = NULL,
+  stroke.size = NULL,
   order = NULL,
   label = FALSE,
   repel = FALSE,
@@ -46,6 +47,8 @@ allowing for both different colors and different shapes on cells.}
 \item{alpha}{Alpha value for plotting (default is 1)}
 
 \item{alpha.by}{Mapping variable for the point alpha value}
+
+\item{stroke.size}{Adjust stroke (outline) size of points}
 
 \item{order}{Specify the order of plotting for the idents. This can be
 useful for crowded plots if points of interest are being buried. Provide


### PR DESCRIPTION
Hi Seurat Team,

This is PR to address #7087.  This adds the `stroke.size` parameter to `DimPlot` and consequently `SingleDimPlot`.  The parameter is set to `NULL` by default.  When this is the case the `stroke.size` is set to static value which appears to be default ggplot2 value.  I tested the plotting with this value of stroke.size vs. current DimPlot and the plots appeared identical to me.

Best,
Sam