### PR TITLE
Fix access to layer data for DietSeurat in V5.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: Seurat
-Version: 5.1.0.9008
+Version: 5.1.0.9009
 Title: Tools for Single Cell Genomics
 Description: A toolkit for quality control, analysis, and exploration of single cell RNA sequencing data. 'Seurat' aims to enable users to identify and interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse types of single cell data. See Satija R, Farrell J, Gennert D, et al (2015) <doi:10.1038/nbt.3192>, Macosko E, Basu A, Satija R, et al (2015) <doi:10.1016/j.cell.2015.05.002>, Stuart T, Butler A, et al (2019) <doi:10.1016/j.cell.2019.05.031>, and Hao, Hao, et al (2020) <doi:10.1101/2020.10.12.335331> for more details.
 Authors@R: c(

--- a/R/objects.R
+++ b/R/objects.R
@@ -601,13 +601,13 @@ DietSeurat <- function(
       }
       for (lyr in layers.rm) {
         suppressWarnings(object <- tryCatch(expr = {
-          object[[assay]][[lyr]] <- NULL
+          object[[assay]][lyr] <- NULL
           object
         }, error = function(e) {
           if (lyr == "data"){
-            object[[assay]][[lyr]] <- sparseMatrix(i = 1, j = 1, x = 1,
-                         dims = dim(object[[assay]][[lyr]]),
-                         dimnames = dimnames(object[[assay]][[lyr]]))
+            object[[assay]][lyr] <- sparseMatrix(i = 1, j = 1, x = 1,
+                         dims = dim(object[[assay]][lyr]),
+                         dimnames = dimnames(object[[assay]][lyr]))
           } else{
             slot(object = object[[assay]], name = lyr) <- new(Class = "dgCMatrix")
           }


### PR DESCRIPTION
This fixes #8054 which is caused by a change in mojaveazure/seurat-object@d6aa9af2acc999da35a82bf760ff92cca0af0854 that changed the behavior of brakets.

