### PR TITLE
scVIIntegration function from seurat-wrappers still needs a seurat object as input

### DIFF
--- a/R/integration5.R
+++ b/R/integration5.R
@@ -621,15 +621,24 @@ IntegrateLayers <- function(
     }
   }
   # Run the integration method
-  value <- method(
-    object = object[[assay]],
-    assay = assay,
-    orig = obj.orig,
-    layers = layers,
-    scale.layer = scale.layer,
-    features = features,
-    ...
-  )
+  if (identical(method, scVIIntegration)) {
+    value <- method(
+      object = object, 
+      assay = assay,
+      orig = obj.orig, 
+      scale.layer = scale.layer,
+      features = features, ...)
+  }else{
+    value <- method(
+      object = object[[assay]],
+      assay = assay,
+      orig = obj.orig,
+      layers = layers,
+      scale.layer = scale.layer,
+      features = features,
+      ...
+    )
+  }
   for (i in names(x = value)) {
     object[[i]] <- value[[i]]
   }


### PR DESCRIPTION
To fix the bug [Problem with integration with vignette code](https://github.com/satijalab/seurat/issues/7944)， the scVIIntegration function from seurat-wrappers still needs a seurat object as input now~