### PR TITLE
Improve BPCells compatibility (JackStraw + RunPCA)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: Seurat
-Version: 5.1.0.9011
+Version: 5.1.0.9012
 Title: Tools for Single Cell Genomics
 Description: A toolkit for quality control, analysis, and exploration of single cell RNA sequencing data. 'Seurat' aims to enable users to identify and interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse types of single cell data. See Satija R, Farrell J, Gennert D, et al (2015) <doi:10.1038/nbt.3192>, Macosko E, Basu A, Satija R, et al (2015) <doi:10.1016/j.cell.2015.05.002>, Stuart T, Butler A, et al (2019) <doi:10.1016/j.cell.2019.05.031>, and Hao, Hao, et al (2020) <doi:10.1101/2020.10.12.335331> for more details.
 Authors@R: c(

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,8 @@
 - Fixed `RunPCA` to avoid converting `BPCells` matrices into dense matrices - significantly reduces the function's memory usage when running on `BPCells` matrices
 - Added `features` parameter to `LeverageScore` and `SketchData`
 - Updated `SketchData`'s `ncells` parameter to accept integer vector
+- Updated `JackStraw` to support `BPCells` matrices
+- Updated `RunPCA` to use the `BPCells`-provided SVD solver on `BPCells` matrices
 
 # Seurat 5.1.0 (2024-05-08)
 

--- a/R/dimensional_reduction.R
+++ b/R/dimensional_reduction.R
@@ -2335,7 +2335,7 @@ JackRandom <- function(
     rand.genes <- sample(x = rownames(x = scaled.data), size = 3)
   }
   data.mod <- scaled.data
-  data.mod[rand.genes, ] <- MatrixRowShuffle(x = scaled.data[rand.genes, ])
+  data.mod[rand.genes, ] <- MatrixRowShuffle(x = as.matrix(scaled.data[rand.genes, ]))
   temp.object <- RunPCA(
     object = data.mod,
     assay = "temp",

--- a/R/dimensional_reduction.R
+++ b/R/dimensional_reduction.R
@@ -865,19 +865,22 @@ RunPCA.default <- function(
   }
  if (inherits(x = object, what = 'matrix')) {
    RowVar.function <- RowVar
+   svd.function <- irlba
  } else if (inherits(x = object, what = 'dgCMatrix')) {
    RowVar.function <- RowVarSparse
+   svd.function <- irlba
  } else if (inherits(x = object, what = 'IterableMatrix')) {
    RowVar.function <- function(x) {
      return(BPCells::matrix_stats(
        matrix = x,
        row_stats = 'variance'
      )$row_stats['variance',])
-     }
+    }
+    svd.function <- function(A, nv, ...) BPCells::svds(A=A, k = nv)
  }
   if (rev.pca) {
     npcs <- min(npcs, ncol(x = object) - 1)
-    pca.results <- irlba(A = object, nv = npcs, ...)
+    pca.results <- svd.function(A = object, nv = npcs, ...)
     total.variance <- sum(RowVar.function(x = t(x = object)))
     sdev <- pca.results$d/sqrt(max(1, nrow(x = object) - 1))
     if (weight.by.var) {
@@ -891,7 +894,7 @@ RunPCA.default <- function(
     total.variance <- sum(RowVar.function(x = object))
     if (approx) {
       npcs <- min(npcs, nrow(x = object) - 1)
-      pca.results <- irlba(A = t(x = object), nv = npcs, ...)
+      pca.results <- svd.function(A = t(x = object), nv = npcs, ...)
       feature.loadings <- pca.results$v
       sdev <- pca.results$d/sqrt(max(1, ncol(object) - 1))
       if (weight.by.var) {


### PR DESCRIPTION
These are some changes brought about from [this BPCells issue](https://github.com/bnprks/BPCells/issues/62), then referenced in Seurat issue #8267

1. Make the `JackStraw` function compatible with BPCells objects. This approach shuffles the matrix subset as a dense matrix, but leaves the remainder of the data on-disk. For best performance the BPCells object should be stored in row-major order so that the matrix subsets can be performed efficiently, but it will work either way.
2. Improve performance of `RunPCA` by using the BPCells svds function. This takes advantage of the same solver RSpectra uses, but at the C++ level to avoid overheads of repeatedly creating BPCells C++ objects on each solver iteration. It also avoids the pitfall that irlba can only use its fast C version with in-memory matrices and otherwise falls back to a slower pure-R implemenation.