### PR TITLE
Try to restore high res image import.

### DIFF
--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -1148,8 +1148,8 @@ Read10X_h5 <- function(filename, use.names = TRUE, unique.features = TRUE) {
 #' @export
 #' @concept preprocessing
 #'
-Read10X_Image <- function(image.dir, filter.matrix = TRUE, ...) {
-  image <- readPNG(source = file.path(image.dir, 'tissue_lowres_image.png'))
+Read10X_Image <- function(image.dir, image.name = "tissue_lowres_image.png", filter.matrix = TRUE, ...) {
+  image <- readPNG(source = file.path(image.dir, image.name))
   scale.factors <- fromJSON(txt = file.path(image.dir, 'scalefactors_json.json'))
   tissue.positions.path <- Sys.glob(paths = file.path(image.dir, 'tissue_positions*'))
   tissue.positions <- read.csv(


### PR DESCRIPTION
This aims to fix #8381 by restoring `image.name` option for `readPNG()` and consequently `Read10X_Image()`. The master branch version has "tissue_lowres_image.png" hard-coded. This was not the case in an earlier [version](https://github.com/satijalab/seurat/blob/ff03fdf21f1b8fea9ee247d0fd83df5811507027/R/preprocessing.R#L1033C1-L1034C62), so I just copied it back. There is a scale factor [error](#5614) if the high res image is used, which can be mitigated by: 
```
hires <- Read10X_Image(paste0(data.dir,'spatial',sep=''),image.name='tissue_hires_image.png')
hires@scale.factors$lowres = hires@scale.factors$hires
```
Also mentioned [here](https://github.com/satijalab/seurat/issues/5614#issuecomment-1194555472).

Hope this can help.