### PR TITLE
Fix corner case issue in `BlendExpression`

### DIFF
--- a/R/visualization.R
+++ b/R/visualization.R
@@ -6461,6 +6461,9 @@ BlendExpression <- function(data) {
     X = data,
     MARGIN = 2,
     FUN = function(x) {
+      if (min(x) == max(x)) {
+        return(rep(0, length(x)))
+      }
       return(round(x = 9 * (x - min(x)) / (max(x) - min(x))))
     }
   ))


### PR DESCRIPTION
This attempts to fix the issue when one of the features provided to `BlendExpression` is constant, min-max normalization returns `NaN`, yielding unusable output data.

This issue was discovered when we used `blend` with `split.by`:

```r
FeaturePlot(seu_obj, features = c("metadata", "GeneSymbol"), blend = TRUE, split.by = "group")

# Error in `palette()`:
# ! Insufficient values in manual scale. 1 needed but only 0 provided.
# Run `rlang::last_trace()` to see where the error occurred.
```
