### PR TITLE
Update preprocessing.R to create more metadata import options 

### DIFF
--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -1997,14 +1997,11 @@ ReadNanostring <- function(
     several.ok = TRUE
   )
   if (!is.null(metadata)) {
+    names <-colnames(read.delim(metadata.file, sep =","))
     metadata <- match.arg(
       arg = metadata,
-      choices = c(
-        "Area", "fov", "Mean.MembraneStain", "Mean.DAPI", "Mean.G",
-        "Mean.Y", "Mean.R", "Max.MembraneStain", "Max.DAPI", "Max.G",
-        "Max.Y", "Max.R"
-      ),
-      several.ok = TRUE
+      choices = names,
+      several.ok = TRUE  
     )
   }
 


### PR DESCRIPTION
Reads all available colnames of the metadata.file instead of hardcoding a few choices to be given in hardcoded choices.

The options to load nanostring data had a hardcoded choice option where things like "Mean.Y" and "Mean.R" are coded. However, the standard Flatfiles from Cosmx data have different colnames. Therefore this code changes the hardcoding into reading the colnames of the metadata.file. See also issue #8895 