### PR TITLE
PrepDR5 with BPCells remove dense matrix conversion

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Seurat
-Version: 5.1.0.9001
-Date: 2024-06-10
+Version: 5.1.0.9002
+Date: 2024-07-02
 Title: Tools for Single Cell Genomics
 Description: A toolkit for quality control, analysis, and exploration of single cell RNA sequencing data. 'Seurat' aims to enable users to identify and interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse types of single cell data. See Satija R, Farrell J, Gennert D, et al (2015) <doi:10.1038/nbt.3192>, Macosko E, Basu A, Satija R, et al (2015) <doi:10.1016/j.cell.2015.05.002>, Stuart T, Butler A, et al (2019) <doi:10.1016/j.cell.2019.05.031>, and Hao, Hao, et al (2020) <doi:10.1101/2020.10.12.335331> for more details.
 Authors@R: c(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 ## Changes
+- Fixed `RunPCA` to avoid converting `BPCells` matrices into dense matrices - significantly reduces the function's memory usage when running on `BPCells` matrices
 - Added `features` parameter to `LeverageScore` and `SketchData`
 - Updated `SketchData`'s `ncells` parameter to accept integer vector
 

--- a/R/dimensional_reduction.R
+++ b/R/dimensional_reduction.R
@@ -2432,7 +2432,11 @@ PrepDR5 <- function(object, features = NULL, layer = 'scale.data', verbose = TRU
   if (!length(x = features)) {
     stop("No variable features, run FindVariableFeatures() or provide a vector of features", call. = FALSE)
   }
-  features.var <- apply(X = data.use, MARGIN = 1L, FUN = var)
+  if (is(data.use, "IterableMatrix")) {
+    features.var <- BPCells::matrix_stats(matrix=data.use, row_stats="variance")$row_stats["variance",]
+  } else {
+    features.var <- apply(X = data.use, MARGIN = 1L, FUN = var)
+  }
   features.keep <- features[features.var > 0]
   if (!length(x = features.keep)) {
     stop("None of the requested features have any variance", call. = FALSE)


### PR DESCRIPTION
I think this is the likely culprit for issue #8391.

The problem here is that `PrepDR5` has a check to remove features which have the same value for every cell (i.e. have zero variance). Unfortunately, the way it does this causes BPCells matrices to be converted to dense matrices in memory. This change instead uses the variance function provided by BPCells which can operate fully disk-backed.

This means that RunPCA effectively does not get any memory-usage benefit from using BPCells, since PrepDR5 will unnecessarily convert the whole scale.data matrix in-memory. 

With this fix, the RunPCA function should be able to use consistently low memory for BPCells-enabled Seurat objects.

My guess is that the crashes from issue #8391 are people with large datasets running out of memory due to this small oversight in PrepDR5.