### PR TITLE
removed duplicate or incorrect roxygen2 comments

### DIFF
--- a/R/integration.R
+++ b/R/integration.R
@@ -2179,7 +2179,7 @@ LocalStruct <- function(
 #' @param projectumap.args A named list of additional arguments to
 #' \code{\link{ProjectUMAP}}
 #'
-#' @return Returns a modified query Seurat object containing:#'
+#' @return Returns a modified query Seurat object containing:
 #' \itemize{
 #'   \item{New Assays corresponding to the features transferred and/or their
 #'   corresponding prediction scores from \code{\link{TransferData}}}
@@ -7484,7 +7484,7 @@ ProjectDimReduc <- function(query,
 #' @param bridge.query.assay Assay name for bridge used for query mapping. ATAC by default
 #' @param supervised.reduction Type of supervised dimensional reduction to be performed
 #' for integrating the bridge and query.
-#' #' Options are:
+#' Options are:
 #' \itemize{
 #'    \item{slsi: Perform supervised LSI as the dimensional reduction for
 #'    the bridge-query integration}
@@ -7810,7 +7810,7 @@ FindBridgeIntegrationAnchors <- function(
 #'
 #' This is a convenience wrapper function around the following three functions
 #' that are often run together when perform integration.
-#' #' \code{\link{FindIntegrationAnchors}}, \code{\link{RunPCA}},
+#' \code{\link{FindIntegrationAnchors}}, \code{\link{RunPCA}},
 #' \code{\link{IntegrateEmbeddings}}.
 #'
 #' @inheritParams FindIntegrationAnchors


### PR DESCRIPTION
Hey Seurat team!

I removed some unplaced roxygen2 comments that I found in the integration.R file. I haven't `roxygen2::roxygenise`'d the entire directory, but I'm thinking these updates will be incorporated into the corresponding .Rd files the next time this is run by the devs. Let me know if you'd like me to run this myself, though.

Thanks!