### PR TITLE
Fix/load xenium

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: Seurat
-Version: 5.1.0.9003
+Version: 5.1.0.9004
 Date: 2024-07-22
 Title: Tools for Single Cell Genomics
 Description: A toolkit for quality control, analysis, and exploration of single cell RNA sequencing data. 'Seurat' aims to enable users to identify and interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse types of single cell data. See Satija R, Farrell J, Gennert D, et al (2015) <doi:10.1038/nbt.3192>, Macosko E, Basu A, Satija R, et al (2015) <doi:10.1016/j.cell.2015.05.002>, Stuart T, Butler A, et al (2019) <doi:10.1016/j.cell.2019.05.031>, and Hao, Hao, et al (2020) <doi:10.1101/2020.10.12.335331> for more details.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 ## Changes
+- Fixed `LoadXenium` to accommodate datasets without "Blank Codeword" or "Unassigned Codeword" matrices
 - Fixed `ReadXenium` to properly parse multiple molecular outputs at once ([#8265](https://github.com/satijalab/seurat/issues/8265))
 - Fixed `RunPCA` to avoid converting `BPCells` matrices into dense matrices - significantly reduces the function's memory usage when running on `BPCells` matrices
 - Added `features` parameter to `LeverageScore` and `SketchData`

--- a/R/convenience.R
+++ b/R/convenience.R
@@ -201,10 +201,11 @@ LoadXenium <- function(data.dir, fov = 'fov', assay = 'Xenium') {
   )
 
   xenium.obj <- CreateSeuratObject(counts = data$matrix[["Gene Expression"]], assay = assay)
-  if("Blank Codeword" %in% names(data$matrix))
+  if("Blank Codeword" %in% names(data$matrix)) {
     xenium.obj[["BlankCodeword"]] <- CreateAssayObject(counts = data$matrix[["Blank Codeword"]])
-  else
+  } else if("Unassigned Codeword" %in% names(data$matrix)) {
     xenium.obj[["BlankCodeword"]] <- CreateAssayObject(counts = data$matrix[["Unassigned Codeword"]])
+  }
   xenium.obj[["ControlCodeword"]] <- CreateAssayObject(counts = data$matrix[["Negative Control Codeword"]])
   xenium.obj[["ControlProbe"]] <- CreateAssayObject(counts = data$matrix[["Negative Control Probe"]])
 


### PR DESCRIPTION
Updates `LoadXenium` to accommodate datasets without "Blank Codeword" or "Unassigned Codeword" matrices. Relates to:
- https://github.com/satijalab/seurat/issues/8265

Cherry-picked from:
- https://github.com/satijalab/seurat/pull/8298

Big thanks to @jsicherman for implementing the fix 🙏 
