### PR TITLE
Fix ssl problem in bioc_install command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ env:
     - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
     - HDF5_VERSION=1.8.17
     - HDF5_RELEASE_URL="https://support.hdfgroup.org/ftp/HDF5/releases"
+    - R_LIBCURL_SSL_REVOKE_BEST_EFFORT=TRUE
 
 before_install:
   - chmod +x travis_setup.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ env:
     - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
     - HDF5_VERSION=1.8.17
     - HDF5_RELEASE_URL="https://support.hdfgroup.org/ftp/HDF5/releases"
-    - R_LIBCURL_SSL_REVOKE_BEST_EFFORT=TRUE
 
 before_install:
   - chmod +x travis_setup.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,8 +22,8 @@ environment:
     PYTHON: "C:\\Python36-x64"
     RETICULATE_PYTHON: "C:\\Python36-x64"
     CRAN: "https://cloud.r-project.org"
-  R_LIBCURL_SSL_REVOKE_BEST_EFFORT: "TRUE"
-  CURL_SSL_BACKEND: "openssl"
+    R_LIBCURL_SSL_REVOKE_BEST_EFFORT: "TRUE"
+    CURL_SSL_BACKEND: "openssl"
 
 build_script:
   - env

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ environment:
     PYTHON: "C:\\Python36-x64"
     RETICULATE_PYTHON: "C:\\Python36-x64"
     CRAN: "https://cloud.r-project.org"
-    R_LIBCURL_SSL_REVOKE_BEST_EFFORT: "TRUE"
+  R_LIBCURL_SSL_REVOKE_BEST_EFFORT: "TRUE"
 
 build_script:
   - travis-tool.sh install_deps

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,6 +23,7 @@ environment:
     RETICULATE_PYTHON: "C:\\Python36-x64"
     CRAN: "https://cloud.r-project.org"
   R_LIBCURL_SSL_REVOKE_BEST_EFFORT: "TRUE"
+  CURL_SSL_BACKEND=openssl
 
 build_script:
   - env

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,6 +25,7 @@ environment:
   R_LIBCURL_SSL_REVOKE_BEST_EFFORT: "TRUE"
 
 build_script:
+  - env
   - travis-tool.sh install_deps
   - travis-tool.sh r_binary_install curl
   - travis-tool.sh bioc_install GenomeInfoDbData

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ environment:
     PYTHON: "C:\\Python36-x64"
     RETICULATE_PYTHON: "C:\\Python36-x64"
     CRAN: "https://cloud.r-project.org"
-    R_LIBCURL_SSL_REVOKE_BEST_EFFORT: true
+    R_LIBCURL_SSL_REVOKE_BEST_EFFORT: "TRUE"
 
 build_script:
   - travis-tool.sh install_deps

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ environment:
     RETICULATE_PYTHON: "C:\\Python36-x64"
     CRAN: "https://cloud.r-project.org"
   R_LIBCURL_SSL_REVOKE_BEST_EFFORT: "TRUE"
-  CURL_SSL_BACKEND=openssl
+  CURL_SSL_BACKEND: "openssl"
 
 build_script:
   - env

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,6 @@ environment:
 build_script:
   - travis-tool.sh install_deps
   - travis-tool.sh r_binary_install curl
-  - travis-tool.sh bioc_install TestTestTest
   - travis-tool.sh bioc_install GenomeInfoDbData
   - travis-tool.sh bioc_install DESeq2
   - travis-tool.sh bioc_install MAST

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,7 @@ environment:
     PYTHON: "C:\\Python36-x64"
     RETICULATE_PYTHON: "C:\\Python36-x64"
     CRAN: "https://cloud.r-project.org"
+    R_LIBCURL_SSL_REVOKE_BEST_EFFORT: true
 
 build_script:
   - travis-tool.sh install_deps

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,6 @@ environment:
     CURL_SSL_BACKEND: "openssl"
 
 build_script:
-  - env
   - travis-tool.sh install_deps
   - travis-tool.sh r_binary_install curl
   - travis-tool.sh bioc_install GenomeInfoDbData

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,6 +27,7 @@ environment:
 build_script:
   - travis-tool.sh install_deps
   - travis-tool.sh r_binary_install curl
+  - travis-tool.sh bioc_install TestTestTest
   - travis-tool.sh bioc_install GenomeInfoDbData
   - travis-tool.sh bioc_install DESeq2
   - travis-tool.sh bioc_install MAST


### PR DESCRIPTION
# Problem 
Currently, the tests fail at the first `bioc_install` command because of SSL error 

For example:
```
package 'BiocManager' successfully unpacked and MD5 sums checked
The downloaded binary packages are in
	C:\Users\appveyor\AppData\Local\Temp\1\RtmpSQSWPh\downloaded_packages
Error: Bioconductor version cannot be validated; no internet connection?  See
  #troubleshooting section in vignette
In addition: Warning messages:
1: In file(con, "r") :
  URL 'https://bioconductor.org/config.yaml': status was 'SSL connect error'
2: In file(con, "r") :
  URL 'https://bioconductor.org/config.yaml': status was 'SSL connect error'
Execution halted
Command exited with code 1
7z a failure.zip *.Rcheck\*
7-Zip 19.00 (x64) : Copyright (c) 1999-2018 Igor Pavlov : 2019-02-21
```

# Fix 
Set R_LIBCURL_SSL_REVOKE_BEST_EFFORT to TRUE (see https://stat.ethz.ch/R-manual/R-devel/library/utils/html/download.file.html for details) 