### PR TITLE
Added the functionality of scale.factor in NormalizeData being set to "median" of counts

### DIFF
--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -3124,7 +3124,7 @@ RelativeCounts <- function(data, scale.factor = 1, verbose = TRUE) {
   #setting scale.factor to be the median of counts across all columns if scale.factor is the string "median"
   if (is.character(scale.factor) && scale.factor == "median") {
     if(verbose){
-      cat("Calculating column sums for median scale factor\n", file = stderr())
+      cat("Calculating median scale factor\n", file = stderr())
     }
     scale.factor <- median(Matrix::colSums(data))
   }
@@ -4349,7 +4349,7 @@ LogNormalize.V3Matrix <- function(
   #setting scale.factor to be the median of counts across all columns if scale.factor is the string "median"
   if (is.character(scale.factor) && scale.factor == "median") {
     if(verbose){
-      cat("Calculating column sums for median scale factor\n", file = stderr())
+      cat("Calculating median scale factor\n", file = stderr())
     }
     scale.factor <- median(Matrix::colSums(data))
   }

--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -3123,6 +3123,9 @@ RelativeCounts <- function(data, scale.factor = 1, verbose = TRUE) {
 
   #setting scale.factor to be the median of counts across all columns if scale.factor is the string "median"
   if (is.character(scale.factor) && scale.factor == "median") {
+    if(verbose){
+      cat("Calculating column sums for median scale factor\n", file = stderr())
+    }
     scale.factor <- median(Matrix::colSums(data))
   }
 
@@ -4345,6 +4348,9 @@ LogNormalize.V3Matrix <- function(
 
   #setting scale.factor to be the median of counts across all columns if scale.factor is the string "median"
   if (is.character(scale.factor) && scale.factor == "median") {
+    if(verbose){
+      cat("Calculating column sums for median scale factor\n", file = stderr())
+    }
     scale.factor <- median(Matrix::colSums(data))
   }
 

--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -4336,6 +4336,12 @@ LogNormalize.V3Matrix <- function(
   if (verbose) {
     cat("Performing log-normalization\n", file = stderr())
   }
+
+  #setting scale.factor to be the median of counts across all columns if scale.factor is the string "median"
+  if (is.character(scale.factor) && scale.factor == "median") {
+    scale.factor <- median(Matrix::colSums(data))
+  }
+
   norm.data <- LogNorm(data, scale_factor = scale.factor, display_progress = verbose)
   colnames(x = norm.data) <- colnames(x = data)
   rownames(x = norm.data) <- rownames(x = data)

--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -3120,6 +3120,12 @@ RelativeCounts <- function(data, scale.factor = 1, verbose = TRUE) {
   if (verbose) {
     cat("Performing relative-counts-normalization\n", file = stderr())
   }
+
+  #setting scale.factor to be the median of counts across all columns if scale.factor is the string "median"
+  if (is.character(scale.factor) && scale.factor == "median") {
+    scale.factor <- median(Matrix::colSums(data))
+  }
+
   norm.data <- data
   norm.data@x <- norm.data@x / rep.int(Matrix::colSums(norm.data), diff(norm.data@p)) * scale.factor
   return(norm.data)

--- a/R/preprocessing5.R
+++ b/R/preprocessing5.R
@@ -256,6 +256,17 @@ LogNormalize.default <- function(
   if (isTRUE(x = verbose)) {
     pb <- txtProgressBar(file = stderr(), style = 3)
   }
+
+  #setting scale.factor to be the median of counts across all columns if scale.factor is the string "median"
+  if (is.character(scale.factor) && scale.factor == "median") {
+    sums <- if (margin == 1L) {
+      rowSums(data)  # Sum of each row (gene) if margin is 1L
+    } else {
+      colSums(data)  # Sum of each column (cell) if margin is 2L
+    }
+    scale.factor = median(sums)
+  }
+
   for (i in seq_len(length.out = ncells)) {
     x <- if (margin == 1L) {
       data[i, ]

--- a/R/preprocessing5.R
+++ b/R/preprocessing5.R
@@ -259,6 +259,9 @@ LogNormalize.default <- function(
 
   #setting scale.factor to be the median of counts across all columns if scale.factor is the string "median"
   if (is.character(scale.factor) && scale.factor == "median") {
+    if(verbose){
+      cat("Calculating column sums for median scale factor\n", file = stderr())
+    }
     sums <- if (margin == 1L) {
       rowSums(data)  # Sum of each row (gene) if margin is 1L
     } else {
@@ -302,6 +305,9 @@ LogNormalize.IterableMatrix <- function(
 
   #setting scale.factor to be the median of counts across all columns if scale.factor is the string "median"
   if (is.character(scale.factor) && scale.factor == "median") {
+    if(verbose){
+      cat("Calculating column sums for median scale factor\n", file = stderr())
+    }
     scale.factor <- median(colSums(data))
   }
 

--- a/R/preprocessing5.R
+++ b/R/preprocessing5.R
@@ -878,6 +878,7 @@ DISP <- function(
   }
   np <- length(x = p) - 1L
 
+  #adding a progress bar for median calculation is verbose is TRUE
   if (is.character(scale.factor) && scale.factor == "median" && isTRUE(x = verbose)) {
     cat("Calculating column sums for median scale factor\n", file = stderr())
     pb_median <- txtProgressBar(style = 3L, file = stderr())

--- a/R/preprocessing5.R
+++ b/R/preprocessing5.R
@@ -877,6 +877,32 @@ DISP <- function(
     p <- p + 1L
   }
   np <- length(x = p) - 1L
+
+  if (is.character(scale.factor) && scale.factor == "median" && isTRUE(x = verbose)) {
+    cat("Calculating column sums for median scale factor\n", file = stderr())
+    pb_median <- txtProgressBar(style = 3L, file = stderr())
+  }
+
+  #setting scale.factor to be the median of counts across all columns if scale.factor is the string "median"
+  if (is.character(scale.factor) && scale.factor == "median") {
+    col_sums <- numeric(np)
+    for (i in seq_len(length.out = np)) {
+      idx <- seq.int(from = p[i], to = p[i + 1] - 1L)
+      xidx <- slot(object = data, name = entryname)[idx]
+      col_sums[i] <- sum(xidx)
+
+      if (isTRUE(x = verbose)) {
+        setTxtProgressBar(pb_median, value = i / np)
+      }
+    }
+
+    if (isTRUE(x = verbose)) {
+      close(pb_median)
+    }
+
+    scale.factor <- median(col_sums)
+  }
+
   if (isTRUE(x = verbose)) {
     pb <- txtProgressBar(style = 3L, file = stderr())
   }

--- a/R/preprocessing5.R
+++ b/R/preprocessing5.R
@@ -299,6 +299,12 @@ LogNormalize.IterableMatrix <- function(
     verbose = TRUE,
     ...
 ) {
+
+  #setting scale.factor to be the median of counts across all columns if scale.factor is the string "median"
+  if (is.character(scale.factor) && scale.factor == "median") {
+    scale.factor <- median(colSums(data))
+  }
+
   data <- BPCells::t(BPCells::t(data) / colSums(data))
   # Log normalization
   data <- log1p(data * scale.factor)

--- a/R/preprocessing5.R
+++ b/R/preprocessing5.R
@@ -260,7 +260,7 @@ LogNormalize.default <- function(
   #setting scale.factor to be the median of counts across all columns if scale.factor is the string "median"
   if (is.character(scale.factor) && scale.factor == "median") {
     if(verbose){
-      cat("Calculating column sums for median scale factor\n", file = stderr())
+      cat("Calculating median scale factor\n", file = stderr())
     }
     sums <- if (margin == 1L) {
       rowSums(data)  # Sum of each row (gene) if margin is 1L
@@ -306,7 +306,7 @@ LogNormalize.IterableMatrix <- function(
   #setting scale.factor to be the median of counts across all columns if scale.factor is the string "median"
   if (is.character(scale.factor) && scale.factor == "median") {
     if(verbose){
-      cat("Calculating column sums for median scale factor\n", file = stderr())
+      cat("Calculating median scale factor\n", file = stderr())
     }
     scale.factor <- median(colSums(data))
   }
@@ -886,7 +886,7 @@ DISP <- function(
 
   #adding a progress bar for median calculation is verbose is TRUE
   if (is.character(scale.factor) && scale.factor == "median" && isTRUE(x = verbose)) {
-    cat("Calculating column sums for median scale factor\n", file = stderr())
+    cat("Calculating median scale factor\n", file = stderr())
     pb_median <- txtProgressBar(style = 3L, file = stderr())
   }
 


### PR DESCRIPTION
# Background

The NormalizeData generic has several different implementations depending on the class of the first object passed as a parameter to the method. These are NormalizeData.Assay,  NormalizeData.default, NormalizeData.Seurat, NormalizeData.StdAssay, and NormalizeData.V3Matrix*. Each of these methods has three possible in-built normalization methods: "LogNormalize", "CLR" and "RC". Excluding "CLR", the other two methods make use of a scale.factor parameter to multiply the normalized values during the normalization process. This value is defaulted to 1e4 for LogNormalize and 1 for RelativeCounts (RC).

# Updates

I have added in the capacity for the implementations of LogNormalize, RelativeCounts and .SparseNormalize to compute the median of the counts across all columns (cells) (or rows (genes) if margin = 1L in the case of LogNormalize.default) and use this as the scale.factor, if the value passed to the scale.factor parameter is "median".

I have also tested the modifications to these functions by writing unit tests in test_preprocessing.R that make sure that the median is being computed correctly if the value passed to the scale.factor parameter is "median".