### PR TITLE
Fix/sketch data features docstring

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: Seurat
-Version: 5.1.0.9007
+Version: 5.1.0.9008
 Title: Tools for Single Cell Genomics
 Description: A toolkit for quality control, analysis, and exploration of single cell RNA sequencing data. 'Seurat' aims to enable users to identify and interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse types of single cell data. See Satija R, Farrell J, Gennert D, et al (2015) <doi:10.1038/nbt.3192>, Macosko E, Basu A, Satija R, et al (2015) <doi:10.1016/j.cell.2015.05.002>, Stuart T, Butler A, et al (2019) <doi:10.1016/j.cell.2019.05.031>, and Hao, Hao, et al (2020) <doi:10.1101/2020.10.12.335331> for more details.
 Authors@R: c(

--- a/R/sketching.R
+++ b/R/sketching.R
@@ -31,6 +31,8 @@ NULL
 #' @param seed A positive integer for the seed of the random number generator. Default is 123.
 #' @param cast The type to cast the resulting assay to. Default is 'dgCMatrix'.
 #' @param verbose Print progress and diagnostic messages
+#' @param features A character vector of feature names to include in the
+#' sketched assay.
 #' @param ... Arguments passed to other methods
 #'
 #' @return A Seurat object with the sketched data added as a new assay.

--- a/man/SketchData.Rd
+++ b/man/SketchData.Rd
@@ -43,6 +43,9 @@ Default is 'LeverageScore'.}
 
 \item{verbose}{Print progress and diagnostic messages}
 
+\item{features}{A character vector of feature names to include in the
+sketched assay.}
+
 \item{...}{Arguments passed to other methods}
 }
 \value{


### PR DESCRIPTION
Includes the `features` parameter in the docstring for the `SketchData` function. Currently, the missing documentation is causing the following WARNING to be thrown during CRAN checks:

```
❯ checking Rd \usage sections ... WARNING
  Undocumented arguments in Rd file 'SketchData.Rd'
    ‘features’
```

This warning also causes the [check-package](https://github.com/satijalab/seurat/actions/runs/12279192633/job/34262641364?pr=9538) workflow to fail. Once this PR is out of draft, we can update the branch rules for `develop` to require jobs to succeed for PRs to be merged.

Relates to:
- https://github.com/satijalab/seurat/pull/9538