### PR TITLE
Fix/run slsi.std assay no npcs binding

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: Seurat
-Version: 5.1.0.9009
+Version: 5.1.0.9010
 Title: Tools for Single Cell Genomics
 Description: A toolkit for quality control, analysis, and exploration of single cell RNA sequencing data. 'Seurat' aims to enable users to identify and interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse types of single cell data. See Satija R, Farrell J, Gennert D, et al (2015) <doi:10.1038/nbt.3192>, Macosko E, Basu A, Satija R, et al (2015) <doi:10.1016/j.cell.2015.05.002>, Stuart T, Butler A, et al (2019) <doi:10.1016/j.cell.2019.05.031>, and Hao, Hao, et al (2020) <doi:10.1101/2020.10.12.335331> for more details.
 Authors@R: c(

--- a/R/dimensional_reduction.R
+++ b/R/dimensional_reduction.R
@@ -2770,7 +2770,6 @@ RunSLSI.StdAssay <- function(
   reduction.data <- RunSLSI(
     object = data.use,
     assay = assay,
-    npcs = npcs,
     reduction.key = reduction.key,
     graph = graph,
     verbose = verbose,


### PR DESCRIPTION
Drops reference to `npcs` variable from `RunSLSI.StdAssay`. Since `npcs` is not defined, the following NOTE to be thrown during CRAN checks:

```
❯ checking R code for possible problems ... [40s/40s] NOTE
  RunSLSI.StdAssay: no visible binding for global variable ‘npcs’
  Undefined global functions or variables:
    npcs
```

In lieu of any tests, the following script can be used to quickly verify `RunSLSI` is still working as expected:

```R
library(Seurat)
library(Signac)
library(BPCells)

# Convert "peaks" to an `Assay5` instance.
atac_small[["peaks"]] <- as(atac_small[["peaks"]], Class = "Assay5")
# `RunSLSI` should not raise any errors when passed a `StdAssay`.
atac_small <- RunSLSI(
  atac_small,
  graph = "peaks_snn",
  assay = "peaks"
)

# The same should be true for an `Assay5` instance holding a
# `BPCells::IterableMatrix`.
atac_small[["peaks"]]$data <- as(
  atac_small[["peaks"]]$data,
  Class = "IterableMatrix"
)
atac_small <- RunSLSI(
  atac_small,
  graph = "peaks_snn",
  assay = "peaks"
)
```

Relates to:
- https://github.com/satijalab/seurat/pull/9538