### PR TITLE
Fix/umap-learn version check

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: Seurat
-Version: 5.1.0.9010
+Version: 5.1.0.9011
 Title: Tools for Single Cell Genomics
 Description: A toolkit for quality control, analysis, and exploration of single cell RNA sequencing data. 'Seurat' aims to enable users to identify and interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse types of single cell data. See Satija R, Farrell J, Gennert D, et al (2015) <doi:10.1038/nbt.3192>, Macosko E, Basu A, Satija R, et al (2015) <doi:10.1016/j.cell.2015.05.002>, Stuart T, Butler A, et al (2019) <doi:10.1016/j.cell.2019.05.031>, and Hao, Hao, et al (2020) <doi:10.1101/2020.10.12.335331> for more details.
 Authors@R: c(

--- a/R/dimensional_reduction.R
+++ b/R/dimensional_reduction.R
@@ -1370,7 +1370,7 @@ RunUMAP.default <- function(
       umap_import <- import(module = "umap", delay_load = TRUE)
       sklearn <- import("sklearn", delay_load = TRUE)
       if (densmap &&
-          numeric_version(x = umap_import$pkg_resources$get_distribution("umap-learn")$version) <
+          numeric_version(x = umap_import$`__version__`) <
           numeric_version(x = "0.5.0")) {
         stop("densmap is only supported by versions >= 0.5.0 of umap-learn. Upgrade umap-learn (e.g. pip install --upgrade umap-learn).")
       }
@@ -1394,7 +1394,7 @@ RunUMAP.default <- function(
         angular_rp_forest = angular.rp.forest,
         verbose = verbose
       )
-      if (numeric_version(x = umap_import$pkg_resources$get_distribution("umap-learn")$version) >=
+      if (numeric_version(x = umap_import$`__version__`) >=
           numeric_version(x = "0.5.0")) {
         umap.args <- c(umap.args, list(
           densmap = densmap,
@@ -1613,7 +1613,7 @@ RunUMAP.Graph <- function(
     metric_kwds = metric.kwds,
     verbose = verbose
   )
-  if (numeric_version(x = umap$pkg_resources$get_distribution("umap-learn")$version) >=
+  if (numeric_version(x = umap$`__version__`) >=
       numeric_version(x = "0.5.0")) {
     umap.args <- c(umap.args, list(
       densmap = densmap,


### PR DESCRIPTION
Reopening #8294 after accidentally clobbering the source branch 🤦 

Please find @fspecque's original description below:

---

umap-learn >= 0.5.5 misses the pkg_resources attribute. This PR fixes the problem when checking umap-learn's version and is compatible with umap-learn v 0.5.5 and lower.

fix https://github.com/satijalab/seurat/issues/8283

---