### PR TITLE
Add master as trigger for Integration-Checks

### DIFF
--- a/.github/workflows/integration_checks.yaml
+++ b/.github/workflows/integration_checks.yaml
@@ -6,9 +6,11 @@ on:
   push:
     branches: 
     - develop
+    - master
   pull_request:
     branches: 
     - develop
+    - master
 
 jobs:
   check-package:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-[![Build Status](https://travis-ci.com/satijalab/seurat.svg?branch=master)](https://app.travis-ci.com:443/github/satijalab/seurat)
 [![AppVeyor build status](https://ci.appveyor.com/api/projects/status/github/satijalab/seurat?branch=master&svg=true)](https://ci.appveyor.com/project/satijalab/seurat)
 [![CRAN Version](https://www.r-pkg.org/badges/version/Seurat)](https://cran.r-project.org/package=Seurat)
 [![CRAN Downloads](https://cranlogs.r-pkg.org/badges/Seurat)](https://cran.r-project.org/package=Seurat)


### PR DESCRIPTION
Picking up where #9538 left off, this PR:
1. ~~Drops the AppVeyor CI pipeline by removing the `appveyor.yml` file, per my the plan laid out [here](https://github.com/satijalab/seurat/pull/9349#issuecomment-2532256325)~~
2. Adds `master` as a push & PR trigger for the `Integration-Checks` workflow. Eventually, we'll be transitioning the repo over to using `main` and I wasn't initially sure if that would happen before or after the upcoming release, but now I'm sure it'll be in the new year.

