### PR TITLE
Fix/CRAN NOTE

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,7 @@ Authors@R: c(
 License: MIT + file LICENSE
 URL: https://satijalab.org/seurat, https://github.com/satijalab/seurat
 BugReports: https://github.com/satijalab/seurat/issues
-Additional_repositories: https://satijalab.r-universe.dev, https://bnprks.r-universe.dev
+Additional_repositories: https://satijalab.r-universe.dev, https://bnprks.r-universe.dev, https://cran.r-universe.dev
 Depends:
     R (>= 4.0.0),
     methods,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: Seurat
-Version: 5.1.0.9018
+Version: 5.1.0.9019
 Title: Tools for Single Cell Genomics
 Description: A toolkit for quality control, analysis, and exploration of single cell RNA sequencing data. 'Seurat' aims to enable users to identify and interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse types of single cell data. See Satija R, Farrell J, Gennert D, et al (2015) <doi:10.1038/nbt.3192>, Macosko E, Basu A, Satija R, et al (2015) <doi:10.1016/j.cell.2015.05.002>, Stuart T, Butler A, et al (2019) <doi:10.1016/j.cell.2019.05.031>, and Hao, Hao, et al (2020) <doi:10.1101/2020.10.12.335331> for more details.
 Authors@R: c(

--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -850,7 +850,7 @@ LoadCurioSeeker <- function(data.dir, assay = "Spatial") {
 #' @export
 #' @concept preprocessing
 #'
-#' @references \url{https://doi.org/10.1038/s41592-019-0433-8}
+#' @references \doi{10.1038/s41592-019-0433-8}
 #'
 #' @examples
 #' \dontrun{

--- a/man/MULTIseqDemux.Rd
+++ b/man/MULTIseqDemux.Rd
@@ -42,6 +42,6 @@ object <- MULTIseqDemux(object)
 
 }
 \references{
-\url{https://doi.org/10.1038/s41592-019-0433-8}
+\doi{10.1038/s41592-019-0433-8}
 }
 \concept{preprocessing}


### PR DESCRIPTION
This PR implements two quick fixes to address the following NOTE currently being thrown by `R CMD check`:

```
❯ checking CRAN incoming feasibility ... [10s/64s] NOTE
  Maintainer: ‘Rahul Satija <seurat@nygenome.org>’
  
  Version contains large components (5.1.0.9017)
  
  Suggests or Enhances not in mainstream repositories:
    BPCells, enrichR, presto
  Availability using Additional_repositories specification:
    BPCells   yes   https://bnprks.r-universe.dev/   
    presto    yes   https://satijalab.r-universe.dev/
    enrichR    no   ?                               
  
  Found the following URLs which should use \doi (with the DOI name only):
    File ‘MULTIseqDemux.Rd’:
      https://doi.org/10.1038/s41592-019-0433-8
```

`enrichR` was dropped from CRAN on 2024-11-04. Thankfully, it is available from https://cran.r-universe.dev, so we can just add that as an additional repo for now. The only other alternative would be completely deprecating `DEenrichRPlot` so that we can drop the dependency, but I'd rather not introduce a breaking change during a minor release if we don't have to. 

The `MULTIseqDemux` reference link was recently updated in #8180—I missed the change during my review but it was probably trying to address previous flakiness in CRAN checks caused by the old link. Hopefully, using the DOI name only will cause fewer issues for us in the future. 

