### PR TITLE
Fix GroupCorrelation and GroupCorrelationPlot for Seurat V5 compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: Seurat
-Version: 5.2.99.9000
+Version: 5.2.99.9001
 Title: Tools for Single Cell Genomics
 Description: A toolkit for quality control, analysis, and exploration of single cell RNA sequencing data. 'Seurat' aims to enable users to identify and interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse types of single cell data. See Satija R, Farrell J, Gennert D, et al (2015) <doi:10.1038/nbt.3192>, Macosko E, Basu A, Satija R, et al (2015) <doi:10.1016/j.cell.2015.05.002>, Stuart T, Butler A, et al (2019) <doi:10.1016/j.cell.2019.05.031>, and Hao, Hao, et al (2020) <doi:10.1101/2020.10.12.335331> for more details.
 Authors@R: c(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+## Changes
+- Fixed `GroupCorrelation` and `GroupCorrelationPlot` to be compatible with `SeuratObject` >= 5.0.0 ([#9625](https://github.com/satijalab/seurat/pull/9625))
+
 # Seurat 5.2.1 (2025-01-23)
 
 ## Changes

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -986,7 +986,8 @@ GroupCorrelation <- function(
   grp.cors <- as.data.frame(x = grp.cors[which(x = !is.na(x = grp.cors))])
   grp.cors$gene_grp <- gene.grp[rownames(x = grp.cors)]
   colnames(x = grp.cors) <- c(paste0(var, "_cor"), "feature.grp")
-  object[[assay]][] <- grp.cors
+  try(object[[assay]]@meta.data <- grp.cors, silent = T)
+  try(object[[assay]]@meta.features <- grp.cors, silent = T)
   if (isTRUE(x = do.plot)) {
     print(GroupCorrelationPlot(
       object = object,

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -986,8 +986,7 @@ GroupCorrelation <- function(
   grp.cors <- as.data.frame(x = grp.cors[which(x = !is.na(x = grp.cors))])
   grp.cors$gene_grp <- gene.grp[rownames(x = grp.cors)]
   colnames(x = grp.cors) <- c(paste0(var, "_cor"), "feature.grp")
-  try(object[[assay]]@meta.data <- grp.cors, silent = T)
-  try(object[[assay]]@meta.features <- grp.cors, silent = T)
+  object[[assay]] <- AddMetaData(object[[assay]], grp.cors)
   if (isTRUE(x = do.plot)) {
     print(GroupCorrelationPlot(
       object = object,

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -4700,7 +4700,8 @@ GroupCorrelationPlot <- function(
   cor = "nCount_RNA_cor"
 ) {
   assay <- assay %||% DefaultAssay(object = object)
-  data <- object[[assay]][c(feature.group, cor)]
+  try(data <- object[[assay]]@meta.data[, c(feature.group, cor)], silent=T)
+  try(data <- object[[assay]]@meta.features[, c(feature.group, cor)], silent=T)
   data <- data[complete.cases(data), ]
   colnames(x = data) <- c('grp', 'cor')
   data$grp <- as.character(data$grp)

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -4700,8 +4700,7 @@ GroupCorrelationPlot <- function(
   cor = "nCount_RNA_cor"
 ) {
   assay <- assay %||% DefaultAssay(object = object)
-  try(data <- object[[assay]]@meta.data[, c(feature.group, cor)], silent=T)
-  try(data <- object[[assay]]@meta.features[, c(feature.group, cor)], silent=T)
+  data <- object[[assay]][[c(feature.group, cor)]]
   data <- data[complete.cases(data), ]
   colnames(x = data) <- c('grp', 'cor')
   data$grp <- as.character(data$grp)


### PR DESCRIPTION
Discussed in issue #9483

# Problem
In spatial_vignette.Rmd, GroupCorrelation() and GroupCorrelationPlot() would both generate the following error:

```"Error in object[[assay]][] <- grp.cors: object of type 'S4' is not subsettable"```

This is because the correlation was being stored in metafeatures, which is no longer an element of the assay in V5.

# Solution

Insert 2 ```try()``` statements to make it compatible for previous and most recent versions of Seurat