### PR TITLE
Fixup smoke test for FindClusters

### DIFF
--- a/tests/testthat/test_find_clusters.R
+++ b/tests/testthat/test_find_clusters.R
@@ -34,13 +34,17 @@ context("FindClusters")
 test_that("Smoke test for `FindClusters`", {
   test_case <- get_test_data()
 
-  # Spot check cluster assignments with using defaults.
+  # Validate cluster assignments using default parameters.
   results <- FindClusters(test_case)$seurat_clusters
-  expect_equal(results[[1]], factor(3, levels=0:5))
-  expect_equal(results[[15]], factor(4, levels=0:5))
-  expect_equal(results[[24]], factor(0, levels=0:5))
-  expect_equal(results[[72]], factor(5, levels=0:5))
-  expect_equal(results[[length(results)]], factor(2, levels=0:5))
+  # Check that every cell was assigned to a cluster label.
+  expect_false(any(is.na(results)))
+  # Check that the expected cluster labels were assigned.
+  expect_equal(as.numeric(levels(results)), c(0, 1, 2, 3, 4, 5))
+  # Check that the cluster sizes match the expected distribution.
+  expect_equal(
+    as.numeric(sort(table(results))),
+    c(9, 10, 10, 11, 20, 20)
+  )
 
   # Check that every clustering algorithm can be run without errors.
   expect_no_error(FindClusters(test_case, algorithm = 1))


### PR DESCRIPTION
Updates the smoke test in `test_find_clusters.R` to accommodate variability in label assignments given by `FindClusters` across different systems. 

On 14/01/2024, the maintainers of Seurat were contacted by CRAN with the following message:

---

Dear maintainer,

Please see the problems shown on
<https://cran.r-project.org/web/checks/check_results_Seurat.html>.

Please correct before 2025-01-28 to safely retain your package on CRAN.

There is a check service for M1mac issues: see
https://www.stats.ox.ac.uk/pub/bdr/M1mac/README.txt .
However, it is running a much older version of the OS
and toolchain -- and the latter often matters.

The CRAN Team

---

tl;dr—we have until 2025/01/28 to resolve the [M1mac](https://www.stats.ox.ac.uk/pub/bdr/M1mac/Seurat.out) errors currently being thrown by the [CRAN package checks for Seurat](https://cran.r-project.org/web/checks/check_results_Seurat.html):

```
Failure (test_find_clusters.R:39:3): Smoke test for `FindClusters`
results[[1]] not equal to factor(3, levels = 0:5).
1 string mismatch

Failure (test_find_clusters.R:40:3): Smoke test for `FindClusters`
results[[15]] not equal to factor(4, levels = 0:5).
1 string mismatch

Failure (test_find_clusters.R:41:3): Smoke test for `FindClusters`
results[[24]] not equal to factor(0, levels = 0:5).
1 string mismatch
```

I'm not totally sure what's causing the difference but I _was_ able to reproduce the error on my local machine (M3mac) after adjusting my environment some. If we're unhappy with this variability I can try to investigate further but for now, I'm pretty confident that this update will resolve the issue. The fix is simple enough, instead of spot-checking the cluster labels for specific cells, the test now checks:

- That every cell was assigned a cluster label (no null values)
- That the correct cluster labels were assigned (but not to which cells)
- That the distribution of cluster sizes matches the expected output

Do we think it's worth introducing a tolerance onto the cluster size check? 🤔 

Once it has been approved and merged I will immediately start the process of releasing Seurat 5.2.1 to CRAN 🚀  