### PR TITLE
Fix PercentageFeatureSet to respect the `assay` parameter

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: Seurat
-Version: 5.2.99.9001
+Version: 5.2.99.9002
 Title: Tools for Single Cell Genomics
 Description: A toolkit for quality control, analysis, and exploration of single cell RNA sequencing data. 'Seurat' aims to enable users to identify and interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse types of single cell data. See Satija R, Farrell J, Gennert D, et al (2015) <doi:10.1038/nbt.3192>, Macosko E, Basu A, Satija R, et al (2015) <doi:10.1016/j.cell.2015.05.002>, Stuart T, Butler A, et al (2019) <doi:10.1016/j.cell.2019.05.031>, and Hao, Hao, et al (2020) <doi:10.1101/2020.10.12.335331> for more details.
 Authors@R: c(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 ## Changes
+- Fixed `PercentageFeatureSet` so that the `assay` parameter is always respected; fixed `PercentageFeatureSet` to raise a warning if any `features` are absent in the specified `assay` instead of throwing an error ([#9686](https://github.com/satijalab/seurat/pull/9686))
 - Fixed `GroupCorrelation` and `GroupCorrelationPlot` to be compatible with `SeuratObject` >= 5.0.0 ([#9625](https://github.com/satijalab/seurat/pull/9625))
 
 # Seurat 5.2.1 (2025-01-23)

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -1173,7 +1173,12 @@ PercentageFeatureSet <- function(
   assay <- assay %||% DefaultAssay(object = object)
   if (!is.null(x = features))  {
     if (!is.null(x = pattern)) {
-      warning("Both pattern and features provided. Pattern is being ignored.")
+      warning(
+        paste(
+          "Both `features` and `pattern` were provided;",
+          "`pattern` will be ignored."
+        )
+      )
     }
 
     available_features <- Features(object[[assay]])


### PR DESCRIPTION
This PR makes two small changes to `PercentageFeatureSet`:

1. Correctly passes `assay` to the `Layers` call on [line 1178 of utilities.R](https://github.com/satijalab/seurat/blob/9755c164d99828dbc5dd9c8364389766cd4ff7fd/R/utilities.R#L1178). 
2. Raises a warning when the `features` parameter contains values not present in the specified `assay` instead of erroring out.

My intent is to introduce a proper test for `PercentageFeatureSet`, but the following scripts can be used to verify the fixes for now. Verify that `assay` is being respected:

```R
library(testthat)
library(Seurat)

counts <- LayerData(pbmc_small, assay = "RNA", layer = "counts")
data <- LayerData(pbmc_small, assay = "RNA", layer = "data")

assay_left <- CreateAssay5Object(data = data)
assay_right <- CreateAssay5Object(counts)

test_case <- CreateSeuratObject(assay_left, assay = "LEFT")
test_case[["RIGHT"]] <- assay_right

DefaultAssay(test_case) <- "RIGHT"
expected <- PercentageFeatureSet(test_case, assay = "RIGHT", pattern = "^RP[LS]")

DefaultAssay(test_case) <- "LEFT"
result <- PercentageFeatureSet(test_case, assay = "RIGHT", pattern = "^RP[LS]")

expect_true(identical(result, expected))

```

And check that a warning (not an error) is raised when `features` contains values absent in the specified (default) assay:

```R
PercentageFeatureSet(pbmc_small, features = "not-a-gene")
```