### PR TITLE
Fix a typo in `DietSeurat`

### DIFF
--- a/R/objects.R
+++ b/R/objects.R
@@ -652,7 +652,7 @@ DietSeurat <- function(
     cells.keep[[assay]] <- colnames(x = object[[assay]] )
   }
   cells.keep <- intersect(colnames(x = object), unlist(cells.keep))
-  if (length(cells.keep) <- ncol(x = object)) {
+  if (length(cells.keep) < ncol(x = object)) {
     object <- subset(object, cells = cells.keep)
   }
   return(object)


### PR DESCRIPTION
Hello, I checked the code of `R/objects.R` and found a typo on line 655:
https://github.com/satijalab/seurat/blob/95ed7691a25365338848e3532733454915b475da/R/objects.R#L655-L657

This segment of code checks if `cells.keep` is lower than the number of columns in `object`; however, the assignment operator `<-` is used here. It may have unintended effects on the final Seurat object when the assays you wish to retain contain fewer cells than the total, since if you assign a number greater than the current length of the `cells.keep` vector, it will be extended with NA at the end.