### PR TITLE
Fix/merge sct assay

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: Seurat
-Version: 5.2.99.9010
+Version: 5.2.99.9011
 Title: Tools for Single Cell Genomics
 Description: A toolkit for quality control, analysis, and exploration of single cell RNA sequencing data. 'Seurat' aims to enable users to identify and interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse types of single cell data. See Satija R, Farrell J, Gennert D, et al (2015) <doi:10.1038/nbt.3192>, Macosko E, Basu A, Satija R, et al (2015) <doi:10.1016/j.cell.2015.05.002>, Stuart T, Butler A, et al (2019) <doi:10.1016/j.cell.2019.05.031>, and Hao, Hao, et al (2020) <doi:10.1101/2020.10.12.335331> for more details.
 Authors@R: c(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 ## Changes
+- Fixed `merge.SCTAssay` to accept assays containing more than one model ([#9828](https://github.com/satijalab/seurat/pull/9828))
 - Updated `SCTransform.StdAssay` to simplify and speed up the method ([#9828](https://github.com/satijalab/seurat/pull/9828))
 - Updated `AddModuleScore` to support multi-layer inputs ([#9826](https://github.com/satijalab/seurat/pull/9826))
 - Fixed `PseudobulkExpression` to work with `Seurat` inputs containing more than one assay ([9824](https://github.com/satijalab/seurat/pull/9824))

--- a/R/objects.R
+++ b/R/objects.R
@@ -2329,6 +2329,9 @@ merge.SCTAssay <- function(
     X = assays,
     FUN = function(assay.i) inherits(x = assay.i, what = "Assay5")
   ))) {
+    warn(
+      message = "Attempting to merge an SCTAssay with Assay5, converting to Assay5"
+    )
     return(merge(x = as(x, "Assay5"), y, ...))
   }
   parent.call <- grep(pattern = "merge.Seurat", x = sys.calls())
@@ -2357,7 +2360,7 @@ merge.SCTAssay <- function(
             assay = parent.environ$assay,
             slot = "scale.data",
             new.data = residuals
-          )                                                                
+          )
           return(seurat.object[[parent.environ$assay]])
         }
         return(assays[[assay]])

--- a/R/objects.R
+++ b/R/objects.R
@@ -2325,6 +2325,7 @@ merge.SCTAssay <- function(
   ...
 ) {
   assays <- c(x, y)
+  # check if any assays are Assay5, and then use merge.Assay5 if so
   if (any(sapply(
     X = assays,
     FUN = function(assay.i) inherits(x = assay.i, what = "Assay5")
@@ -2367,6 +2368,8 @@ merge.SCTAssay <- function(
       })
     }
   }
+  # this check takes place after backfilling of residuals so that for a v3 assay,
+  # we avoid dropping features as much as possible.
   sct.check <- sapply(X = assays, FUN = function(x) inherits(x = x, what = "SCTAssay"))
   if (any(!sct.check)) {
     warning("Attempting to merge an SCTAssay with another Assay type \n",

--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -1263,8 +1263,8 @@ Read10X_Image <- function(
       image = image
     )
 
-    # As of v5.1.0 `Radius.VisiumV1` no longer returns the value of the 
-    # `spot.radius` slot and instead calculates the value on the fly, but we 
+    # As of v5.1.0 `Radius.VisiumV1` no longer returns the value of the
+    # `spot.radius` slot and instead calculates the value on the fly, but we
     # can populate the static slot in case it's depended on.
     visium.v1@spot.radius <- Radius(visium.v1)
 
@@ -3518,10 +3518,30 @@ SampleUMI <- function(
 #' This function calls sctransform::vst. The sctransform package is available at
 #' https://github.com/satijalab/sctransform.
 #' Use this function as an alternative to the NormalizeData,
-#' FindVariableFeatures, ScaleData workflow. Results are saved in a new assay
-#' (named SCT by default) with counts being (corrected) counts, data being log1p(counts),
-#' scale.data being pearson residuals; sctransform::vst intermediate results are saved
-#' in misc slot of new assay.
+#' FindVariableFeatures, ScaleData workflow.
+#' \itemize{
+#'  \item Results are saved in a new assay
+#' (named SCT by default) with pearson residuals saved in \code{scale.data}.
+#'  \item Corrected counts are saved in \code{counts} (representing if each cell had
+#' uniform sequencing depth),
+#'  \item \code{data} contains log1p(corrected counts);
+#'  \item sctransform::vst intermediate results are saved in \code{misc} slot of new assay.
+#' }
+#' In the case that multiple \code{counts} layers are present (i.e. after running \code{split}), SCTransform is run separately
+#' for each counts layer.
+#' \itemize{
+#'  \item To obtain a consensus set of variable features across layers,
+#' each feature is ranked by how frequently it is classified as variable across
+#' layers. Ties are broken using the median ranks of features across layers.
+#' \item \code{scale.data} is then populated by calculating residuals for the consensus
+#' feature set using the appropriate model for each layer. In some cases
+#' (such as if each feature is not present across all layers), \code{VariableFeatures}
+#'  and the features present in \code{scale.data} may differ by a small amount.
+#'  \item The resulting \code{SCTAssay} contains one \code{counts}, \code{data},
+#'  and \code{scale.data} layer, but uses the appropriate model for each cell based on
+#'  the input counts layers.
+#'  }
+#
 #'
 #' @param object UMI counts matrix
 #' @param cell.attr A metadata with cell attributes

--- a/R/preprocessing5.R
+++ b/R/preprocessing5.R
@@ -1169,6 +1169,9 @@ CreateSCTAssay <- function(vst.out,  do.correct.umi, residual.type, clip.range){
 #' LayerData LayerData<- as.sparse
 #'
 #' @method SCTransform StdAssay
+#' @return In the multi-layer case, this returns an assay with residuals calculated
+#' using a separate model for each layer (counts and data are then derived from this,
+#' as described above). `VariableFeatures`
 #' @export
 #'
 SCTransform.StdAssay <- function(
@@ -1237,7 +1240,7 @@ SCTransform.StdAssay <- function(
   # Merge output assays into one, or take the single result.
   if (length(output_list) > 1) {
     assay_out <- merge(
-      output_list[[1]], 
+      output_list[[1]],
       output_list[-1]
     )
   } else {
@@ -1286,7 +1289,7 @@ SCTransform.StdAssay <- function(
   # the outputs scaled.data slot.
   residuals <- suppressWarnings(
     FetchResiduals(
-      object = assay_out, 
+      object = assay_out,
       umi.object = object,
       features = scale_data_features,
       verbose = FALSE

--- a/R/preprocessing5.R
+++ b/R/preprocessing5.R
@@ -1169,9 +1169,6 @@ CreateSCTAssay <- function(vst.out,  do.correct.umi, residual.type, clip.range){
 #' LayerData LayerData<- as.sparse
 #'
 #' @method SCTransform StdAssay
-#' @return In the multi-layer case, this returns an assay with residuals calculated
-#' using a separate model for each layer (counts and data are then derived from this,
-#' as described above). `VariableFeatures`
 #' @export
 #'
 SCTransform.StdAssay <- function(

--- a/man/SCTransform.Rd
+++ b/man/SCTransform.Rd
@@ -170,10 +170,29 @@ slot of the new assay.
 This function calls sctransform::vst. The sctransform package is available at
 https://github.com/satijalab/sctransform.
 Use this function as an alternative to the NormalizeData,
-FindVariableFeatures, ScaleData workflow. Results are saved in a new assay
-(named SCT by default) with counts being (corrected) counts, data being log1p(counts),
-scale.data being pearson residuals; sctransform::vst intermediate results are saved
-in misc slot of new assay.
+FindVariableFeatures, ScaleData workflow.
+\itemize{
+ \item Results are saved in a new assay
+(named SCT by default) with pearson residuals saved in \code{scale.data}.
+ \item Corrected counts are saved in \code{counts} (representing if each cell had
+uniform sequencing depth),
+ \item \code{data} contains log1p(corrected counts);
+ \item sctransform::vst intermediate results are saved in \code{misc} slot of new assay.
+}
+In the case that multiple \code{counts} layers are present (i.e. after running \code{split}), SCTransform is run separately
+for each counts layer.
+\itemize{
+ \item To obtain a consensus set of variable features across layers,
+each feature is ranked by how frequently it is classified as variable across
+layers. Ties are broken using the median ranks of features across layers.
+\item \code{scale.data} is then populated by calculating residuals for the consensus
+feature set using the appropriate model for each layer. In some cases
+(such as if each feature is not present across all layers), \code{VariableFeatures}
+ and the features present in \code{scale.data} may differ by a small amount.
+ \item The resulting \code{SCTAssay} contains one \code{counts}, \code{data},
+ and \code{scale.data} layer, but uses the appropriate model for each cell based on
+ the input counts layers.
+ }
 }
 \seealso{
 \code{\link[sctransform]{correct_counts}} \code{\link[sctransform]{get_residuals}}

--- a/tests/testthat/test_objects.R
+++ b/tests/testthat/test_objects.R
@@ -47,3 +47,16 @@ test_that("merge.SCTAssay works for multi-layer objects",  {
   m2 <- merge(pbmc_small_sct, m1)
   expect_equal(length(m2[['SCT']]@SCTModel.list), 3)
 })
+
+
+# Tests for VariableFeatures.SCTAssay
+# ------------------------------------------------------------------------------
+
+test_that("VariableFeatures can return more or less features than originally called",  {
+  pbmc_small_sct <- SCTransform(pbmc_small_sct,
+                                variable.features.n = 50)
+  #expect_equal(VariableFeatures(pbmc_small_sct, nfeatures = 100), 100)
+  expect_equal(length(VariableFeatures(pbmc_small_sct, nfeatures = 10)), 10)
+  }
+)
+

--- a/tests/testthat/test_objects.R
+++ b/tests/testthat/test_objects.R
@@ -23,3 +23,27 @@ test_that("as.SingleCellExperiment works", {
     # expect_equal(SingleCellExperiment::mainExpName(sce), 'RNA')
   }
 })
+
+
+# Tests for merge SCT
+# ------------------------------------------------------------------------------
+
+pbmc_small_sct <- pbmc_small
+pbmc_small_sct[['RNA']] <- CreateAssay5Object(counts = LayerData(pbmc_small_sct[['RNA']], layer = "counts"))
+pbmc_small_sct <- SCTransform(pbmc_small)
+test_that("merge.SCTAssay throws as a warning if attempting to merge with an non-SCT assay",  {
+  expect_warning(merge(pbmc_small_sct[['SCT']], pbmc_small[['RNA']]))
+})
+
+test_that("merge.SCTAssay works for multi-layer objects",  {
+  g1 <- LayerData(subset(pbmc_small, groups=="g1"), layer="counts")
+  colnames(g1) <- paste0(colnames(g1), "-g1")
+  g1 <- CreateSeuratObject(counts = g1)
+  g2 <- LayerData(subset(pbmc_small, groups=="g2"), layer="counts")
+  colnames(g2) <- paste0(colnames(g2), "-g2")
+  g2 <- CreateSeuratObject(counts = g2)
+  m1 <- merge(g1, g2)
+  m1 <- SCTransform(m1)
+  m2 <- merge(pbmc_small_sct, m1)
+  expect_equal(length(m2[['SCT']]@SCTModel.list), 3)
+})


### PR DESCRIPTION
As a follow-up to #9828, this PR further refines `merge.SCTAssay` with better documentation, more informative warnings, and some tests. The bug in question is encountered when running merge on `SCTAssay`s containing multiple models. An `SCTAssay` will contain multiple models if:

a. It has already been merged with another `SCTAssay`.
b. `SCTransform` was called on a multi-layer assay.

The following script can be used to verify that it has been resolved:

```
library(Seurat)
library(SeuratData)


ifnb <- LoadData("ifnb")
ifnb[["RNA"]] <- split(ifnb[["RNA"]], f = ifnb$stim)
ifnb <- SCTransform(ifnb)

pbmc <- LoadData("pbmc3k")
pbmc <- SCTransform(pbmc)


merge(ifnb, pbmc)
```