### PR TITLE
Fix `Cells.SCTAssay` for `LeverageScore`/`SketchData`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: Seurat
-Version: 5.2.99.9010
+Version: 5.2.99.9011
 Title: Tools for Single Cell Genomics
 Description: A toolkit for quality control, analysis, and exploration of single cell RNA sequencing data. 'Seurat' aims to enable users to identify and interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse types of single cell data. See Satija R, Farrell J, Gennert D, et al (2015) <doi:10.1038/nbt.3192>, Macosko E, Basu A, Satija R, et al (2015) <doi:10.1016/j.cell.2015.05.002>, Stuart T, Butler A, et al (2019) <doi:10.1016/j.cell.2019.05.031>, and Hao, Hao, et al (2020) <doi:10.1101/2020.10.12.335331> for more details.
 Authors@R: c(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # Unreleased
 
 ## Changes
+- Dropped `VariableFeatures` setter from `SketchData` ([#9830](https://github.com/satijalab/seurat/pull/9830))
+- Extended `Cells.SCTAssay`'s `layer` argument accept slot names: `"counts"`, `"data"`, `"scale.data"`; enabled compatibility with `SketchData`/`LeverageScore`([#9830](https://github.com/satijalab/seurat/pull/9830))
 - Updated `SCTransform.StdAssay` to simplify and speed up the method ([#9828](https://github.com/satijalab/seurat/pull/9828))
 - Updated `AddModuleScore` to support multi-layer inputs ([#9826](https://github.com/satijalab/seurat/pull/9826))
 - Fixed `PseudobulkExpression` to work with `Seurat` inputs containing more than one assay ([9824](https://github.com/satijalab/seurat/pull/9824))

--- a/R/objects.R
+++ b/R/objects.R
@@ -1462,11 +1462,26 @@ Cells.SCTModel <- function(x, ...) {
 #' @export
 #'
 Cells.SCTAssay <- function(x, layer = NA, ...) {
-  layer <- layer %||% levels(x = x)[1L]
-  if (rlang::is_na(x = layer)) {
-    return(colnames(x = x))
+  # If `layer` is `NA` return all cells in the assay via `colnames`.
+  if (rlang::is_na(layer)) {
+    return(colnames(x))
   }
-  return(Cells(x = components(object = x, model = layer)))
+
+  # If `layer` is `NULL` take the name of the first model in the 
+  # assay's `SCTModel.list`.
+  layer <- layer %||% levels(x)[1L]
+
+  # If `layer` is one of the standard layer names, use the underlying matrix
+  # to get the requested cell names.
+  if (layer %in% Layers(x)) {
+    data <- LayerData(x, layer=layer)
+    cells <- colnames(data)
+  } else {
+    # Otherwise, assume that `layer` is the name of an element in `SCTModel.list`.
+    cells <- Cells(components(x, model = layer))  
+  }
+
+  return(cells)
 }
 
 #' @rdname Cells

--- a/R/sketching.R
+++ b/R/sketching.R
@@ -130,13 +130,6 @@ SketchData <- function(
     cells = unlist(cells),
     layers = Layers(object = object[[assay]], search = c('counts', 'data'))
   ))
-  for (layer.name in layer.names) {
-    try(
-      expr = VariableFeatures(object = sketched, method = "sketch", layer = layer.name) <-
-        VariableFeatures(object = object[[assay]], layer = layer.name),
-      silent = TRUE
-    )
-  }
   if (!is.null(x = cast) && inherits(x = sketched, what = 'Assay5')) {
     sketched <- CastAssay(object = sketched, to = cast, ...)
   }


### PR DESCRIPTION
This PR makes two changes:
1. Updates the `Cells.SCTAssay` method to allow "regular" layer names (i.e., `"counts"`, `"data"`, and `"scale.data"`).
2. Drops the call to the `VariableFeatures` setter at the end of `SketchData`.

The first update makes `SCTAssay` inputs compatible with `SketchData` and `LeverageScore`. The second change is mostly a speedup, but in this context also avoids a warning from `VariableFeatures.SCTAssay` about unused arguments. 

Resolves:
- https://github.com/satijalab/seurat/issues/8428