### PR TITLE
Optimize `LeverageScore` for small BPCells inputs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: Seurat
-Version: 5.2.99.9011
+Version: 5.2.99.9012
 Title: Tools for Single Cell Genomics
 Description: A toolkit for quality control, analysis, and exploration of single cell RNA sequencing data. 'Seurat' aims to enable users to identify and interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse types of single cell data. See Satija R, Farrell J, Gennert D, et al (2015) <doi:10.1038/nbt.3192>, Macosko E, Basu A, Satija R, et al (2015) <doi:10.1016/j.cell.2015.05.002>, Stuart T, Butler A, et al (2019) <doi:10.1016/j.cell.2019.05.031>, and Hao, Hao, et al (2020) <doi:10.1101/2020.10.12.335331> for more details.
 Authors@R: c(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 ## Changes
+- Updated `LeverageScore.default` to convert `BPCells::IterableMatrix` inputs with less than 7500 cells into a sparse matrix before performing the calculation ([#9831](https://github.com/satijalab/seurat/pull/9831))
 - Dropped `VariableFeatures` setter from `SketchData` ([#9830](https://github.com/satijalab/seurat/pull/9830))
 - Extended `Cells.SCTAssay`'s `layer` argument accept slot names: `"counts"`, `"data"`, `"scale.data"`; enabled compatibility with `SketchData`/`LeverageScore`([#9830](https://github.com/satijalab/seurat/pull/9830))
 - Updated `SCTransform.StdAssay` to simplify and speed up the method ([#9828](https://github.com/satijalab/seurat/pull/9828))

--- a/R/sketching.R
+++ b/R/sketching.R
@@ -405,6 +405,9 @@ LeverageScore.default <- function(
   ncells <- ncol(x = object)
   if (ncells < nsketch * 1.5) {
     nv <- ifelse(nrow(x = object) < 50, nrow(x = object) - 1, 50)
+    if (inherits(x = object, what = 'IterableMatrix')) {
+      object <- as.sparse(x = object)
+    }
     Z <- irlba(A = object, nv = 50, nu = 0, verbose = FALSE)$v
     return(rowSums(x = Z ^ 2))
   }


### PR DESCRIPTION
Huge thanks to @yuhanH for this update 🚀 

---

Optimize the LeverageScore computation to address the long processing time for small BPCell matrices (fewer than 7,500 cells). Convert the input into a sparse matrix and then compute accurate leverage scores.  

In the current implementation, sketching pbmc3k takes approximately 100 seconds. With sparse conversion, this time is reduced to 30 seconds. For larger datasets like hcabm40k, the computation remains at 40 seconds.

```
library(Seurat)
library(SeuratData)
library(BPCells) 
data('pbmc3k')
data('hcabm40k')
 

obj <- UpdateSeuratObject(pbmc3k)
# obj <- UpdateSeuratObject(hcabm40k)

obj[['RNA']] <- as(obj[['RNA']], Class = 'Assay5')
obj[['RNA']]$counts <- write_matrix_dir(obj[['RNA']]$counts, dir = '~/test/pbmc3k_BPCells', overwrite = T)
obj <- NormalizeData(obj)
obj <- FindVariableFeatures(obj)
 
system.time(obj <- SketchData(obj))

```

---
