### PR TITLE
Fix `FindTransferAnchors` to support multi-layer query

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: Seurat
-Version: 5.2.99.9012
+Version: 5.2.99.9013
 Title: Tools for Single Cell Genomics
 Description: A toolkit for quality control, analysis, and exploration of single cell RNA sequencing data. 'Seurat' aims to enable users to identify and interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse types of single cell data. See Satija R, Farrell J, Gennert D, et al (2015) <doi:10.1038/nbt.3192>, Macosko E, Basu A, Satija R, et al (2015) <doi:10.1016/j.cell.2015.05.002>, Stuart T, Butler A, et al (2019) <doi:10.1016/j.cell.2019.05.031>, and Hao, Hao, et al (2020) <doi:10.1101/2020.10.12.335331> for more details.
 Authors@R: c(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 ## Changes
+- Extended `FindTransferAnchors`'s `query` argument to accept multi-layer inputs; updated `MappingScore` to support multi-layer query inputs ([#9832](https://github.com/satijalab/seurat/pull/9832))
 - Updated `LeverageScore.default` to convert `BPCells::IterableMatrix` inputs with less than 7500 cells into a sparse matrix before performing the calculation ([#9831](https://github.com/satijalab/seurat/pull/9831))
 - Dropped `VariableFeatures` setter from `SketchData` ([#9830](https://github.com/satijalab/seurat/pull/9830))
 - Extended `Cells.SCTAssay`'s `layer` argument accept slot names: `"counts"`, `"data"`, `"scale.data"`; enabled compatibility with `SketchData`/`LeverageScore`([#9830](https://github.com/satijalab/seurat/pull/9830))

--- a/R/integration.R
+++ b/R/integration.R
@@ -1158,6 +1158,8 @@ FindTransferAnchors <- function(
     # Enable processing query.neighbors as a list for multi-layered query objects
     query.layers <- Layers(query, search = 'data')
     query.neighbors.list <- vector("list", length(query.layers))
+    query.neighbors.sub.list <- vector("list", length(query.layers))
+    
     nn.idx2.list <- vector("list", length(query.layers))
     for (layer in seq_along(query.layers)) {
       cells2.i <- Cells(
@@ -1190,11 +1192,13 @@ FindTransferAnchors <- function(
         name = "nn.dist")[, 1:(k.nn + 1)]
       
       # Adding neighbors to list 
-      query.neighbors.list[[layer]] <- query.neighbors.sub
+      query.neighbors.list[[layer]] <- query.neighbors
+      query.neighbors.sub.list[[layer]] <- query.neighbors.sub
+      
       nn.idx2.list[[layer]] <- Index(object = query.neighbors.sub)
     }
     
-    precomputed.neighbors[["query.neighbors"]] <- query.neighbors.list
+    precomputed.neighbors[["query.neighbors"]] <- query.neighbors.sub.list
     nn.idx2 <- nn.idx2.list
   }
   

--- a/R/integration.R
+++ b/R/integration.R
@@ -2702,8 +2702,6 @@ MappingScore.AnchorSet <- function(
 
   for (i in seq_along(query.neighbors.list)) {
     query.neighbors.i <- query.neighbors.list[[i]]  
-    
-    # query.cells.i <- query.cells[[i]]   
     query.cells.i <- gsub(pattern = "_query$", replacement = "", x = Cells(query.neighbors.i)) # query cells in neighbors obj have suffix _query, strip to match
     query.embeddings.i <- query.embeddings[rownames(query.embeddings) %in% query.cells.i, ] 
 

--- a/R/integration.R
+++ b/R/integration.R
@@ -2699,14 +2699,16 @@ MappingScore.AnchorSet <- function(
   
   for (i in seq_along(query.neighbors.list)) {
     query.neighbors.i <- query.neighbors.list[[i]]  
-    query.cells.i <- gsub(pattern = "_query$", replacement = "", x = Cells(query.neighbors.i)) # query cells in neighbors obj have suffix _query, strip to match
+    # query cells in neighbors obj have suffix _query, strip to match
+    query.cells.i <- gsub(pattern = "_query$", replacement = "", x = Cells(query.neighbors.i)) 
     query.embeddings.i <- query.embeddings[rownames(query.embeddings) %in% query.cells.i, ] 
     
     # subset anchors to query specific 
     anchors_data <- original_anchors_data 
     anchors_data_df <- as.data.frame(anchors_data)
     
-    query.indices.i <- which(query.cells.i %in% query.cells[anchors_data_df$cell2]) # indices of current query layer where query cells are in anchors, should < anchors obj 
+    # indices of current query layer where query cells are in anchors, should < anchors obj 
+    query.indices.i <- which(query.cells.i %in% query.cells[anchors_data_df$cell2]) 
     
     anchors_subset_df <- anchors_data_df[anchors_data_df$cell2 %in% query.indices.i, ]
     anchors_subset <- as.matrix(anchors_subset_df)
@@ -2714,7 +2716,8 @@ MappingScore.AnchorSet <- function(
     slot(anchors, "anchors") <- anchors_subset
     
     mapping_scores_list[[i]] <- MappingScore(
-      anchors = slot(object = anchors, name = "anchors"), # input subset of layer-specific anchors 
+      # input subset of layer-specific anchors
+      anchors = slot(object = anchors, name = "anchors"), 
       combined.object = combined.object,
       query.neighbors = query.neighbors.i,
       ref.embeddings = ref.embeddings,

--- a/R/integration.R
+++ b/R/integration.R
@@ -2698,14 +2698,26 @@ MappingScore.AnchorSet <- function(
   
   # Handle query layers 
   mapping_scores_list <- list()
+
   for (i in seq_along(query.neighbors.list)) {
     query.neighbors.i <- query.neighbors.list[[i]]  
-    query.cells.i <- query.cells[[i]]   
     
+    # query.cells.i <- query.cells[[i]]   
+    query.cells.i <- gsub(pattern = "_query$", replacement = "", x = Cells(query.neighbors.i)) # query cells in neighbors obj have suffix _query, strip to match
     query.embeddings.i <- query.embeddings[rownames(query.embeddings) %in% query.cells.i, ] 
     
+    # subset anchors to query specific 
+    anchors_data <- slot(anchors, "anchors") 
+    anchors_data[, "cell1_name"] <- ref.cells[anchors_data[, "cell1"]]
+    anchors_data[, "cell2_name"] <- query.cells.i[anchors_data[, "cell2"]]
+    
+    anchors_subset <- anchors_data[anchors_data[, "cell2_name"] %in% query.cells.i, ]  
+    
+    anchors_subset[, "cell1"] <- anchors_data[, "cell1_name"]
+    anchors_subset[, "cell2"] <- anchors_data[, "cell2_name"]
+    
     mapping_scores_list[[i]] <- MappingScore(
-    anchors = slot(object = anchors, name = "anchors"),
+    anchors = slot(object = anchors_subset, name = "anchors"), # input subset of layer-specific anchors 
     combined.object = combined.object,
     query.neighbors = query.neighbors.i,
     ref.embeddings = ref.embeddings,

--- a/R/integration.R
+++ b/R/integration.R
@@ -2690,12 +2690,30 @@ MappingScore.AnchorSet <- function(
   for (i in colnames(x = combined.object[[]])) {
     combined.object[[i]] <- NULL
   }
+
+  query.neighbors <- slot(object = anchors, name = "neighbors")[["query.neighbors"]]
+  if (inherits(query.neighbors, "Neighbor") || is.null(query.neighbors)) {
+    mapping_scores_list <- MappingScore(
+      anchors = slot(object = anchors, name = "anchors"),
+      combined.object = combined.object,
+      query.neighbors = query.neighbors,
+      ref.embeddings = ref.embeddings,
+      query.embeddings = query.embeddings,
+      kanchors = kanchors,
+      ndim = ndim,
+      ksmooth = ksmooth,
+      ksnn = ksnn,
+      snn.prune = snn.prune,
+      subtract.first.nn = subtract.first.nn,
+      nn.method = nn.method,
+      n.trees = n.trees,
+      query.weights = query.weights,
+      verbose = verbose
+      )
+    return(unlist(mapping_scores_list))
+  }
   
-  # If neighbors are precomputed 
-  if (length(anchors@neighbors)!=0){
-  # Handle query layers 
-  query.neighbors.list <- slot(object = anchors, 
-                                 name = "neighbors")[["query.neighbors"]]
+  query.neighbors.list <- query.neighbors
   mapping_scores_list <- list()
   original_anchors_data <- slot(object = anchors, name = "anchors")
   
@@ -2738,28 +2756,7 @@ MappingScore.AnchorSet <- function(
     slot(anchors, "anchors") <- original_anchors_data
   }
   return(unlist(mapping_scores_list))
-  }
   
-  # If no precomputed neighbors 
-  query.neighbors <- slot(object = anchors, name = "neighbors")[["query.neighbors"]]
-  mapping_scores_list <- MappingScore(
-    anchors = slot(object = anchors, name = "anchors"),
-    combined.object = combined.object,
-    query.neighbors = query.neighbors,
-    ref.embeddings = ref.embeddings,
-    query.embeddings = query.embeddings,
-    kanchors = kanchors,
-    ndim = ndim,
-    ksmooth = ksmooth,
-    ksnn = ksnn,
-    snn.prune = snn.prune,
-    subtract.first.nn = subtract.first.nn,
-    nn.method = nn.method,
-    n.trees = n.trees,
-    query.weights = query.weights,
-    verbose = verbose
-    )
-  return(unlist(mapping_scores_list)) #flatten returned mapping scores
 }
 
 #' Calculates a mixing metric

--- a/R/integration.R
+++ b/R/integration.R
@@ -2675,7 +2675,6 @@ MappingScore.AnchorSet <- function(
     x = combined.object[["pcaproject.l2"]],
     cells = ref.cells
   ))
-  # query.neighbors <- slot(object = anchors, name = "neighbors")[["query.neighbors"]]
   query.neighbors.list <- slot(object = anchors, name = "neighbors")[["query.neighbors"]]
   
   # reduce size of anchorset combined object

--- a/R/integration.R
+++ b/R/integration.R
@@ -1158,9 +1158,20 @@ FindTransferAnchors <- function(
     # Try processing list
     query.neighbors.list <- list()
     nn.idx2.list <- list()
+
+    query.layers <- Layers(query, search = 'data')
     for (layer in seq_along(query.layers)) {
-      layer_embeddings <- Embeddings(object = combined.ob[[reduction]])[colnames(x = query.layers[[layer]]), ]
+      cells2.i <- Cells(
+        x = query,
+        layer = query.layers[layer]
+      )
+      query.subset <- subset(
+        x = query,
+        cells = cells2.i
+      )
       
+      layer_embeddings <- Embeddings(object = combined.ob[[reduction]])[colnames(x = query.subset), ]
+
       # NNHelper() for current layer
       query.neighbors <- NNHelper(
         data = layer_embeddings,
@@ -1189,10 +1200,12 @@ FindTransferAnchors <- function(
     # Adding neighbors to list 
     query.neighbors.list[[layer]] <- query.neighbors.sub
     nn.idx2.list[[layer]] <- Index(object = query.neighbors.sub)
+    }
     
     precomputed.neighbors[["query.neighbors"]] <- query.neighbors.list
     nn.idx2 <- nn.idx2.list
-  }
+    }
+    
   if (!is.null(x = reference.neighbors)) {
     precomputed.neighbors[["ref.neighbors"]] <- reference[[reference.neighbors]]
   } else {

--- a/R/integration.R
+++ b/R/integration.R
@@ -2693,53 +2693,45 @@ MappingScore.AnchorSet <- function(
     combined.object[[i]] <- NULL
   }
   
-  mapping_scores_list <- lapply(
-    X   = seq_along(query.neighbors.list),
-    FUN = function(i) {
-      query.neighbors.i <- query.neighbors.list[[i]]  
-      # query cells in neighbors obj have suffix "_query", remove this
-      query.cells.i <- gsub(
-        pattern = "_query$", 
-        replacement = "", 
-        x = Cells(query.neighbors.i)
-      )
-      query.embeddings.i <- query.embeddings[rownames(query.embeddings) %in% 
-                                               query.cells.i, ] 
-      
-      # subset anchors to query-specific
-      anchors_data_df <- as.data.frame(original_anchors_data)
-      
-      # indices of current query layer where query cells are in anchors
-      query.indices.i <- which(query.cells.i %in% 
-                                 query.cells[anchors_data_df$cell2])
-      anchors_subset_df <- anchors_data_df[anchors_data_df$cell2 %in% 
-                                             query.indices.i, ]
-      anchors_subset <- as.matrix(anchors_subset_df)
-      
-      # temporarily replace anchors slot with subset for this layer
-      slot(anchors, "anchors") <- anchors_subset
-      
-      score <- MappingScore(
-        anchors = slot(object = anchors, name = "anchors"), #layer-specific 
-        combined.object = combined.object,
-        query.neighbors = query.neighbors.i,
-        ref.embeddings = ref.embeddings,
-        query.embeddings = query.embeddings.i,
-        kanchors = kanchors,
-        ndim = ndim,
-        ksmooth = ksmooth,
-        ksnn = ksnn,
-        snn.prune = snn.prune,
-        subtract.first.nn = subtract.first.nn,
-        nn.method = nn.method,
-        n.trees = n.trees,
-        query.weights = query.weights,
-        verbose = verbose
-        )
-      slot(anchors, "anchors") <- original_anchors_data
-      return(score)
-    }
-  )
+  # Handle query layers 
+  mapping_scores_list <- list()
+  original_anchors_data <- slot(object = anchors, name = "anchors")
+  
+  for (i in seq_along(query.neighbors.list)) {
+    query.neighbors.i <- query.neighbors.list[[i]]  
+    query.cells.i <- gsub(pattern = "_query$", replacement = "", x = Cells(query.neighbors.i)) # query cells in neighbors obj have suffix _query, strip to match
+    query.embeddings.i <- query.embeddings[rownames(query.embeddings) %in% query.cells.i, ] 
+    
+    # subset anchors to query specific 
+    anchors_data <- original_anchors_data 
+    anchors_data_df <- as.data.frame(anchors_data)
+    
+    query.indices.i <- which(query.cells.i %in% query.cells[anchors_data_df$cell2]) # indices of current query layer where query cells are in anchors, should < anchors obj 
+    
+    anchors_subset_df <- anchors_data_df[anchors_data_df$cell2 %in% query.indices.i, ]
+    anchors_subset <- as.matrix(anchors_subset_df)
+    
+    slot(anchors, "anchors") <- anchors_subset
+    
+    mapping_scores_list[[i]] <- MappingScore(
+      anchors = slot(object = anchors, name = "anchors"), # input subset of layer-specific anchors 
+      combined.object = combined.object,
+      query.neighbors = query.neighbors.i,
+      ref.embeddings = ref.embeddings,
+      query.embeddings = query.embeddings.i,
+      kanchors = kanchors,
+      ndim = ndim,
+      ksmooth = ksmooth,
+      ksnn = ksnn,
+      snn.prune = snn.prune,
+      subtract.first.nn = subtract.first.nn,
+      nn.method = nn.method,
+      n.trees = n.trees,
+      query.weights = query.weights,
+      verbose = verbose
+    )
+    slot(anchors, "anchors") <- original_anchors_data
+  }
   return(unlist(mapping_scores_list)) #flatten returned mapping scores
 }
 

--- a/R/integration.R
+++ b/R/integration.R
@@ -1181,14 +1181,6 @@ FindTransferAnchors <- function(
         cache.index = TRUE
       )
     
-    # query.neighbors <- NNHelper(
-    #   data = Embeddings(object = combined.ob[[reduction]])[colnames(x = query), ],
-    #   k = max(mapping.score.k, k.nn + 1),
-    #   method = nn.method,
-    #   n.trees = n.trees,
-    #   cache.index = TRUE
-    # )
-      
     query.neighbors.sub <- query.neighbors
     slot(object = query.neighbors.sub, name = "nn.idx") <- slot(
       object = query.neighbors.sub,

--- a/R/integration.R
+++ b/R/integration.R
@@ -2680,8 +2680,6 @@ MappingScore.AnchorSet <- function(
     x = combined.object[["pcaproject.l2"]],
     cells = ref.cells
   ))
-  query.neighbors.list <- slot(object = anchors, 
-                               name = "neighbors")[["query.neighbors"]]
   
   # reduce size of anchorset combined object
   combined.object <- DietSeurat(object = combined.object)
@@ -2693,7 +2691,11 @@ MappingScore.AnchorSet <- function(
     combined.object[[i]] <- NULL
   }
   
+  # If neighbors are precomputed 
+  if (length(anchors@neighbors)!=0){
   # Handle query layers 
+  query.neighbors.list <- slot(object = anchors, 
+                                 name = "neighbors")[["query.neighbors"]]
   mapping_scores_list <- list()
   original_anchors_data <- slot(object = anchors, name = "anchors")
   
@@ -2735,6 +2737,28 @@ MappingScore.AnchorSet <- function(
     )
     slot(anchors, "anchors") <- original_anchors_data
   }
+  return(unlist(mapping_scores_list))
+  }
+  
+  # If no precomputed neighbors 
+  query.neighbors <- slot(object = anchors, name = "neighbors")[["query.neighbors"]]
+  mapping_scores_list <- MappingScore(
+    anchors = slot(object = anchors, name = "anchors"),
+    combined.object = combined.object,
+    query.neighbors = query.neighbors,
+    ref.embeddings = ref.embeddings,
+    query.embeddings = query.embeddings,
+    kanchors = kanchors,
+    ndim = ndim,
+    ksmooth = ksmooth,
+    ksnn = ksnn,
+    snn.prune = snn.prune,
+    subtract.first.nn = subtract.first.nn,
+    nn.method = nn.method,
+    n.trees = n.trees,
+    query.weights = query.weights,
+    verbose = verbose
+    )
   return(unlist(mapping_scores_list)) #flatten returned mapping scores
 }
 

--- a/R/integration.R
+++ b/R/integration.R
@@ -2711,12 +2711,9 @@ MappingScore.AnchorSet <- function(
     anchors_data <- original_anchors_data 
     anchors_data_df <- as.data.frame(anchors_data)
     
-    # query.indices.i <- which(rownames(query.embeddings) %in% query.cells.i)
-    query_cell_names <- Cells(combined.object)[anchors_data_df$cell2]
-    query.indices.i <- which(query.cells.i %in% query_cell_names)
+    query.indices.i <- which(query.cells.i %in% query.cells[anchors_data_df$cell2]) # indices of current query layer where query cells are in anchors, should < anchors obj 
     
     anchors_subset_df <- anchors_data_df[anchors_data_df$cell2 %in% query.indices.i, ]
-    
     anchors_subset <- as.matrix(anchors_subset_df)
     
     slot(anchors, "anchors") <- anchors_subset

--- a/R/integration.R
+++ b/R/integration.R
@@ -1263,7 +1263,8 @@ FindTransferAnchors <- function(
   )
   if (!is.null(x = precomputed.neighbors[["query.neighbors"]])) {
     slot(object = anchor.set, name = "neighbors") <- list(
-      query.neighbors = query.neighbors.list) # return list of neighbors in anchor.set object 
+      # return list of neighbors in anchor.set object 
+      query.neighbors = query.neighbors.list) 
   }
   return(anchor.set)
 }
@@ -2726,7 +2727,7 @@ MappingScore.AnchorSet <- function(
     )
     slot(anchors, "anchors") <- original_anchors_data
   }
-  return(mapping_scores_list)
+  return(unlist(mapping_scores_list)) #flatten returned mapping scores
 }
 
 #' Calculates a mixing metric

--- a/R/integration.R
+++ b/R/integration.R
@@ -4149,7 +4149,6 @@ FindAnchors_v5 <- function(
       slot = slot,
       cells1 = cells1,
       cells2 = cells2.i,
-      # internal.neighbors = internal.neighbors,
       internal.neighbors = list(
         "ref.neighbors" = internal.neighbors[["ref.neighbors"]],
         "query.neighbors" = query.neighbors.sub  # neighbors for current layer

--- a/R/integration.R
+++ b/R/integration.R
@@ -2676,7 +2676,8 @@ MappingScore.AnchorSet <- function(
     x = combined.object[["pcaproject.l2"]],
     cells = ref.cells
   ))
-  query.neighbors.list <- slot(object = anchors, name = "neighbors")[["query.neighbors"]]
+  query.neighbors.list <- slot(object = anchors, 
+                               name = "neighbors")[["query.neighbors"]]
   
   # reduce size of anchorset combined object
   combined.object <- DietSeurat(object = combined.object)
@@ -2698,21 +2699,24 @@ MappingScore.AnchorSet <- function(
         replacement = "", 
         x = Cells(query.neighbors.i)
       )
-      query.embeddings.i <- query.embeddings[rownames(query.embeddings) %in% query.cells.i, ] 
+      query.embeddings.i <- query.embeddings[rownames(query.embeddings) %in% 
+                                               query.cells.i, ] 
       
       # subset anchors to query-specific
       anchors_data_df <- as.data.frame(original_anchors_data)
       
       # indices of current query layer where query cells are in anchors
-      query.indices.i <- which(query.cells.i %in% query.cells[anchors_data_df$cell2])
-      anchors_subset_df <- anchors_data_df[anchors_data_df$cell2 %in% query.indices.i, ]
+      query.indices.i <- which(query.cells.i %in% 
+                                 query.cells[anchors_data_df$cell2])
+      anchors_subset_df <- anchors_data_df[anchors_data_df$cell2 %in% 
+                                             query.indices.i, ]
       anchors_subset <- as.matrix(anchors_subset_df)
       
       # temporarily replace anchors slot with subset for this layer
       slot(anchors, "anchors") <- anchors_subset
       
       score <- MappingScore(
-        anchors = slot(object = anchors, name = "anchors"), #layer-specific anchors
+        anchors = slot(object = anchors, name = "anchors"), #layer-specific 
         combined.object = combined.object,
         query.neighbors = query.neighbors.i,
         ref.embeddings = ref.embeddings,
@@ -2732,46 +2736,6 @@ MappingScore.AnchorSet <- function(
       return(score)
     }
   )
-      
-  # # Handle query layers 
-  # mapping_scores_list <- list()
-  # original_anchors_data <- slot(object = anchors, name = "anchors")
-  # 
-  # for (i in seq_along(query.neighbors.list)) {
-  #   query.neighbors.i <- query.neighbors.list[[i]]  
-  #   query.cells.i <- gsub(pattern = "_query$", replacement = "", x = Cells(query.neighbors.i)) # query cells in neighbors obj have suffix _query, strip to match
-  #   query.embeddings.i <- query.embeddings[rownames(query.embeddings) %in% query.cells.i, ] 
-  # 
-  #   # subset anchors to query specific 
-  #   anchors_data <- original_anchors_data 
-  #   anchors_data_df <- as.data.frame(anchors_data)
-  #   
-  #   query.indices.i <- which(query.cells.i %in% query.cells[anchors_data_df$cell2]) # indices of current query layer where query cells are in anchors, should < anchors obj 
-  #   
-  #   anchors_subset_df <- anchors_data_df[anchors_data_df$cell2 %in% query.indices.i, ]
-  #   anchors_subset <- as.matrix(anchors_subset_df)
-  #   
-  #   slot(anchors, "anchors") <- anchors_subset
-  #   
-  #   mapping_scores_list[[i]] <- MappingScore(
-  #   anchors = slot(object = anchors, name = "anchors"), # input subset of layer-specific anchors 
-  #   combined.object = combined.object,
-  #   query.neighbors = query.neighbors.i,
-  #   ref.embeddings = ref.embeddings,
-  #   query.embeddings = query.embeddings.i,
-  #   kanchors = kanchors,
-  #   ndim = ndim,
-  #   ksmooth = ksmooth,
-  #   ksnn = ksnn,
-  #   snn.prune = snn.prune,
-  #   subtract.first.nn = subtract.first.nn,
-  #   nn.method = nn.method,
-  #   n.trees = n.trees,
-  #   query.weights = query.weights,
-  #   verbose = verbose
-  #   )
-  #   slot(anchors, "anchors") <- original_anchors_data
-  # }
   return(unlist(mapping_scores_list)) #flatten returned mapping scores
 }
 

--- a/R/integration.R
+++ b/R/integration.R
@@ -2439,22 +2439,22 @@ MapQuery <- function(
 #' @export
 #'
 MappingScore.default <- function(
-    anchors,
-    combined.object,
-    query.neighbors,
-    ref.embeddings,
-    query.embeddings,
-    kanchors = 50,
-    ndim = 50,
-    ksmooth = 100,
-    ksnn = 20,
-    snn.prune = 0,
-    subtract.first.nn = TRUE,
-    nn.method = "annoy",
-    n.trees = 50,
-    query.weights = NULL,
-    verbose = TRUE,
-    ...
+  anchors,
+  combined.object,
+  query.neighbors,
+  ref.embeddings,
+  query.embeddings,
+  kanchors = 50,
+  ndim = 50,
+  ksmooth = 100,
+  ksnn = 20,
+  snn.prune = 0,
+  subtract.first.nn = TRUE,
+  nn.method = "annoy",
+  n.trees = 50,
+  query.weights = NULL,
+  verbose = TRUE,
+  ...
 ) {
   CheckDots(...)
   # Input checks
@@ -2641,18 +2641,18 @@ MappingScore.default <- function(
 #' @method MappingScore AnchorSet
 #'
 MappingScore.AnchorSet <- function(
-    anchors,
-    kanchors = 50,
-    ndim = 50,
-    ksmooth = 100,
-    ksnn = 20,
-    snn.prune = 0,
-    subtract.first.nn = TRUE,
-    nn.method = "annoy",
-    n.trees = 50,
-    query.weights = NULL,
-    verbose = TRUE,
-    ...
+  anchors,
+  kanchors = 50,
+  ndim = 50,
+  ksmooth = 100,
+  ksnn = 20,
+  snn.prune = 0,
+  subtract.first.nn = TRUE,
+  nn.method = "annoy",
+  n.trees = 50,
+  query.weights = NULL,
+  verbose = TRUE,
+  ...
 ) {
   CheckDots(...)
   combined.object <- slot(object = anchors, name = "object.list")[[1]]

--- a/tests/testthat/test_integration.R
+++ b/tests/testthat/test_integration.R
@@ -462,45 +462,21 @@ test_that("FindTransferAnchors handles multi-layer queries when mapping.score,k 
 })
 
 # Tests for MappingScore
-# ------------------------------------------------------------------------------
-# context("MappingScore")
-# 
-# anchors <- FindTransferAnchors(
-#   reference = reference,
-#   query = multilayer_query,
-#   reference.reduction = "pca",
-#   mapping.score.k = 10
-# )
-# mappingscores <- MappingScore(anchors, 
-#                               ndim=30, 
-#                               kweight = 10,
-#                               kanchors = 100,
-#                               ksmooth = 100,
-#                               ksnn = 20)
-# 
-# # compute mapping score with precomputed neighbors (for both split and single layer queries)
-# test_that("MappingScore", {
-#   anchors <- FindTransferAnchors(
-#     reference = reference,
-#     query = multilayer_query,
-#     reference.reduction = "pca",
-#     mapping.score.k = 30
-#   )
-#   mappingscores <- MappingScore(transfer_anchors, ndim=30)
-#   co <- anchors@object.list[[1]]
-#   expect_equal(dim(co), c(230, 160))
-#   expect_equal(Reductions(co), c("pcaproject", "pcaproject.l2"))
-#   expect_equal(GetAssayData(co[["RNA"]], layer ="data")[1, 3], 0)
-#   expect_equal(GetAssayData(co[["RNA"]], layer = "counts")[1, 3], 0)
-#   expect_equal(dim(co[['pcaproject']]), c(160, 30))
-#   expect_equal(dim(co[['pcaproject.l2']]), c(160, 30))
-#   ref.cells <- paste0(Cells(ref), "_reference")
-#   query.cells <- paste0(Cells(multilayer_query), "_query")
-#   expect_equal(anchors@reference.cells, ref.cells)
-#   expect_equal(anchors@query.cells, query.cells)
-#   expect_equal(anchors@reference.objects, logical())
-#   anchor.mat <- anchors@anchors
-#   expect_true("query.neighbors" %in% names(anchors@neighbors))
-#   query_layers <- multilayer_query@assays$RNA@layers
-#   expect_equal(length(anchors@neighbors$query.neighbors), length(query_layers)/2)
-# })
+context("MappingScore")
+
+# Test whether having precomputed neighbors change mapping score for split query
+anchors <- FindTransferAnchors(
+  reference = reference,
+  query = multilayer_query,
+  reference.reduction = "pca",
+  mapping.score.k = 10
+)
+
+anchors_wo_mpsc <- FindTransferAnchors(
+  reference = reference,
+  query = multilayer_query,
+  reference.reduction = "pca"
+)
+
+# MappingScore here does not work well because num(cells) is too low
+mappingscores <- MappingScore(anchors,ndim=30, k.weight = 5)

--- a/tests/testthat/test_integration.R
+++ b/tests/testthat/test_integration.R
@@ -415,11 +415,20 @@ reference <- FindVariableFeatures(reference)
 reference <- ScaleData(reference)
 reference <- RunPCA(reference)
 
+anchors <- FindTransferAnchors(
+  reference = reference,
+  query = multilayer_query,
+  reference.reduction = "pca",
+  mapping.score.k = 10
+)
+
 test_that("FindTransferAnchors handles multi-layer queries", {
   anchors <- FindTransferAnchors(
     reference = reference,
     query = multilayer_query,
     reference.reduction = "pca",
-    mapping.score.k = 100
+    mapping.score.k = 10
   )
+  co <- anchors@object.list[[1]]
+  expect_equal(dim(co), c(220, 160))
 })


### PR DESCRIPTION
This PR enables running `FindTransferAnchors` using a `query` containing more than one layer. Since `FindTransferAnchors` is the main function underpinning `Azimuth::RunAzimuth`, this change will also mean that the latter function works with multi-layer queries too. 

When the `mapping.score.k` parameter is set, "query.neighbors" are cached for later use by the `MappingScore` method. In the multi-layer case, these query neighbors need to be calculated and cached layer by layer.  

This PR also adjusts `MappingScore` to potentially expect a _list_ of precomputed `Neighbor` objects, one for each layer. The output of `MappingScore` isn't affected since there is still just one score per query cell. 

You can verify the fix with the following snippet:

```r
library(Seurat)
library(SeuratData)


query <- LoadData("ifnb")
query <- split(query, f = query$stim)
query <- NormalizeData(query)

reference <- LoadData("pbmc3k")
reference <- NormalizeData(reference)
reference <- FindVariableFeatures(reference)
reference <- ScaleData(reference)
reference <- RunPCA(reference)

transfer_anchors <- FindTransferAnchors(
  reference = reference,
  query = query,
  reference.reduction = "pca",
  mapping.score.k = 100
)
```

And the same for `Azimuth`:

```r
library(Seurat)
library(SeuratData)
library(Azimuth)


ifnb <- LoadData("ifnb")
ifnb <- split(ifnb, f = ifnb$stim)

RunAzimuth(ifnb, reference = "pbmcref")
```