### PR TITLE
Fix FindTransferAnchor for integrated SCT references

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: Seurat
-Version: 5.2.99.9014
+Version: 5.2.99.9015
 Title: Tools for Single Cell Genomics
 Description: A toolkit for quality control, analysis, and exploration of single cell RNA sequencing data. 'Seurat' aims to enable users to identify and interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse types of single cell data. See Satija R, Farrell J, Gennert D, et al (2015) <doi:10.1038/nbt.3192>, Macosko E, Basu A, Satija R, et al (2015) <doi:10.1016/j.cell.2015.05.002>, Stuart T, Butler A, et al (2019) <doi:10.1016/j.cell.2019.05.031>, and Hao, Hao, et al (2020) <doi:10.1101/2020.10.12.335331> for more details.
 Authors@R: c(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 ## Changes
+- Extended `FindTransferAnchors`'s `reference` argument to accept SCT inputs containing more than one SCT model; in this case, the reference model that was fit against the largest number of cells is used ([#9833](https://github.com/satijalab/seurat/pull/9833))
 - Extended `FindTransferAnchors`'s `query` argument to accept multi-layer inputs; updated `MappingScore` to support multi-layer query inputs ([#9832](https://github.com/satijalab/seurat/pull/9832))
 - Updated `LeverageScore.default` to convert `BPCells::IterableMatrix` inputs with less than 7500 cells into a sparse matrix before performing the calculation ([#9831](https://github.com/satijalab/seurat/pull/9831))
 - Dropped `VariableFeatures` setter from `SketchData` ([#9830](https://github.com/satijalab/seurat/pull/9830))

--- a/R/integration.R
+++ b/R/integration.R
@@ -745,7 +745,7 @@ ReciprocalProject <- function(
 #' }
 #'
 
- <- function(
+FindTransferAnchors <- function(
   reference,
   query,
   normalization.method = "LogNormalize",

--- a/R/integration.R
+++ b/R/integration.R
@@ -803,27 +803,6 @@ FindTransferAnchors <- function(
     verbose = verbose
   )
   
-  # Select one SCT model if multiple detected in the reference
-  model_list <- ref[["SCT"]]@SCTModel.list
-  if (length(x = model_list) > 1) {
-    model_cell_counts <- sapply(
-      X = model_list,
-      FUN = function(model) {
-        length(x = Cells(x = model))
-      }
-    )
-    best_model_index <- which.max(model_cell_counts)
-    chosen_model <- model_list[[best_model_index]]
-    ref[["SCT"]] <- CreateSCTAssayObject(
-      data = GetAssayData(object = ref[["SCT"]], slot = "data"),
-      scale.data = GetAssayData(object = ref[["SCT"]], slot = "scale.data"),
-      SCTModel.list = chosen_model
-    )
-    message("Selected the SCT model fitted on the most cells.")
-  } else {
-    message("Only one SCT model detected; no need to select.")
-  }
-  
   projected <- ifelse(test = reduction == "pcaproject", yes = TRUE, no = FALSE)
   reduction.2 <- character()
   feature.mean <- NULL
@@ -902,6 +881,28 @@ FindTransferAnchors <- function(
     object = reference,
     new.names = paste0(Cells(x = reference), "_", "reference")
   )
+  
+  # Select one SCT model if multiple detected in the reference
+  model_list <- reference[["SCT"]]@SCTModel.list
+  if (length(x = model_list) > 1) {
+    model_cell_counts <- sapply(
+      X = model_list,
+      FUN = function(model) {
+        length(x = Cells(x = model))
+      }
+    )
+    best_model_index <- which.max(model_cell_counts)
+    chosen_model <- model_list[[best_model_index]]
+    reference[["SCT"]] <- CreateSCTAssayObject(
+      data = GetAssayData(object = reference[["SCT"]], slot = "data"),
+      scale.data = GetAssayData(object = reference[["SCT"]], slot = "scale.data"),
+      SCTModel.list = chosen_model
+    )
+    message("Selected the SCT model fitted on the most cells.")
+  } else {
+    message("Only one SCT model detected; no need to select.")
+  }
+  
   # Perform PCA projection
   if (reduction == 'pcaproject') {
     if (project.query) {
@@ -930,6 +931,7 @@ FindTransferAnchors <- function(
           approx = approx.pca
         )
       }
+      
       projected.pca <- ProjectCellEmbeddings(
         reference = query,
         reduction = reference.reduction,

--- a/R/integration.R
+++ b/R/integration.R
@@ -744,7 +744,8 @@ ReciprocalProject <- function(
 #' pbmc.query <- AddMetaData(object = pbmc.query, metadata = predictions)
 #' }
 #'
-FindTransferAnchors <- function(
+
+ <- function(
   reference,
   query,
   normalization.method = "LogNormalize",
@@ -6056,8 +6057,7 @@ ValidateParams_FindTransferAnchors <- function(
     reference.model.num <- length(x = slot(object = reference[[reference.assay]], name = "SCTModel.list"))
     if (reference.model.num > 1) {
       # Enable compatibility with integrated reference with mutliple SCT models
-      print("Given reference assay has multiple sct models, 
-            selecting model with most cells for finding transfer anchors")
+      print("Given reference assay has multiple sct models, selecting model with most cells for finding transfer anchors")
       # stop("Given reference assay (", reference.assay, ") has ", reference.model.num ,
       #      " reference sct models. Please provide a reference assay with a ",
       #      " single reference sct model.", call. = FALSE)


### PR DESCRIPTION
This PR enables `FindTransferAnchors` to work with `SCTransform` references that have been preprocessed using `IntegrateLayers`. Handing an integrated reference to `FindTransferAnchors` is a routine operation and represents the core of the `Azimuth` package's workflow. Unfortunately, it has not been possible to use an SCT reference from `IntegrateLayers` since (as opposed to the v3 `FindIntegrationAnchors` + `IntegrateData` workflow) it does not generate an integrated assay. When starting from multiple SCT references, `FindTransferAnchors` assumes that `IntegrateData` has already picked a single model and outputted it in the integrated assay, so the function throws an error if multiple models are present. 

This PR resolves the issue by teaching `FindTransferAnchors` to pick the biggest SCT model (i.e., the one with the most cells) when given a reference with more than one. 



