### PR TITLE
Fix FindSpatiallyVariableFeatures

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: Seurat
-Version: 5.2.99.9016
+Version: 5.2.99.9017
 Title: Tools for Single Cell Genomics
 Description: A toolkit for quality control, analysis, and exploration of single cell RNA sequencing data. 'Seurat' aims to enable users to identify and interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse types of single cell data. See Satija R, Farrell J, Gennert D, et al (2015) <doi:10.1038/nbt.3192>, Macosko E, Basu A, Satija R, et al (2015) <doi:10.1016/j.cell.2015.05.002>, Stuart T, Butler A, et al (2019) <doi:10.1016/j.cell.2019.05.031>, and Hao, Hao, et al (2020) <doi:10.1101/2020.10.12.335331> for more details.
 Authors@R: c(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 ## Changes
+- Fixed bugs in `FindSpatiallyVariableFeatures` ([#9836](https://github.com/satijalab/seurat/pull/9836))
 - Extended `FindTransferAnchors`'s `reference` argument to accept SCT inputs containing more than one SCT model; in this case, the reference model that was fit against the largest number of cells is used ([#9833](https://github.com/satijalab/seurat/pull/9833))
 - Extended `FindTransferAnchors`'s `query` argument to accept multi-layer inputs; updated `MappingScore` to support multi-layer query inputs ([#9832](https://github.com/satijalab/seurat/pull/9832))
 - Updated `LeverageScore.default` to convert `BPCells::IterableMatrix` inputs with less than 7500 cells into a sparse matrix before performing the calculation ([#9831](https://github.com/satijalab/seurat/pull/9831))

--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -4500,7 +4500,8 @@ FindSpatiallyVariableFeatures.Assay <- function(
 FindSpatiallyVariableFeatures.Seurat <- function(
   object,
   assay = NULL,
-  slot = "scale.data",
+  layer = "scale.data",
+  slot = deprecated(),
   features = NULL,
   image = NULL,
   selection.method = c('markvariogram', 'moransi'),
@@ -4511,12 +4512,20 @@ FindSpatiallyVariableFeatures.Seurat <- function(
   verbose = TRUE,
   ...
 ) {
+  if (is_present(slot)) {
+    deprecate_soft(
+      when = '5.3.0',
+      what = 'FindSpatiallyVariableFeatures(slot = )',
+      with = 'FindSpatiallyVariableFeatures(layer = )'
+    )
+    layer <- slot %||% layer
+  }
+
   assay <- assay %||% DefaultAssay(object = object)
-  features <- features %||% rownames(x = object[[assay]])
   image <- image %||% DefaultImage(object = object)
+  features <- features %||% Features(object, assay = assay, layer = layer)
   tc <- GetTissueCoordinates(object = object[[image]])
-  # check if markvariogram has been run on necessary features
-  # only run for new ones
+
   object[[assay]] <- FindSpatiallyVariableFeatures(
     object = object[[assay]],
     slot = slot,
@@ -4530,7 +4539,10 @@ FindSpatiallyVariableFeatures.Seurat <- function(
     verbose = verbose,
     ...
   )
-  object <- LogSeuratCommand(object = object)
+  
+  object <- LogSeuratCommand(object)
+
+  return(object)
 }
 
 #' @rdname LogNormalize

--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -4501,7 +4501,9 @@ FindSpatiallyVariableFeatures.Seurat <- function(
   object,
   assay = NULL,
   layer = "scale.data",
-  slot = deprecated(),
+  # Using `deprecated()` as the default for any arguments will break the
+  # `LogSeuratCommand` call at the end of this method.
+  slot = NULL,
   features = NULL,
   image = NULL,
   selection.method = c('markvariogram', 'moransi'),
@@ -4512,7 +4514,7 @@ FindSpatiallyVariableFeatures.Seurat <- function(
   verbose = TRUE,
   ...
 ) {
-  if (is_present(slot)) {
+  if (!is.null(slot)) {
     deprecate_soft(
       when = '5.3.0',
       what = 'FindSpatiallyVariableFeatures(slot = )',

--- a/R/preprocessing5.R
+++ b/R/preprocessing5.R
@@ -168,72 +168,13 @@ FindVariableFeatures.StdAssay <- function(
   return(object)
 }
 
-#' @param layer Layer in the Assay5 to pull data from
-#' @param features If provided, only compute on given features. Otherwise,
-#' compute for all features.
-#' @param nfeatures Number of features to mark as the top spatially variable.
-#'
 #' @method FindSpatiallyVariableFeatures StdAssay
 #' @rdname FindSpatiallyVariableFeatures
 #' @concept preprocessing
 #' @concept spatial
 #' @export
 #'
-FindSpatiallyVariableFeatures.StdAssay <- function(
-  object,
-  layer = "scale.data",
-  spatial.location,
-  selection.method = c('markvariogram', 'moransi'),
-  features = NULL,
-  r.metric = 5,
-  x.cuts = NULL,
-  y.cuts = NULL,
-  nfeatures = nfeatures,
-  verbose = TRUE,
-  ...
-) {
-  features <- features %||% rownames(x = object)
-  if (selection.method == "markvariogram" && "markvariogram" %in% names(x = Misc(object = object))) {
-    features.computed <- names(x = Misc(object = object, slot = "markvariogram"))
-    features <- features[! features %in% features.computed]
-  }
-  data <- GetAssayData(object = object, layer = layer)
-  data <- as.matrix(x = data[features, ])
-  data <- data[RowVar(x = data) > 0, ]
-  if (nrow(x = data) != 0) {
-    svf.info <- FindSpatiallyVariableFeatures(
-      object = data,
-      spatial.location = spatial.location,
-      selection.method = selection.method,
-      r.metric = r.metric,
-      x.cuts = x.cuts,
-      y.cuts = y.cuts,
-      verbose = verbose,
-      ...
-    )
-  } else {
-    svf.info <- c()
-  }
-  if (selection.method == "markvariogram") {
-    if ("markvariogram" %in% names(x = Misc(object = object))) {
-      svf.info <- c(svf.info, Misc(object = object, slot = "markvariogram"))
-    }
-    suppressWarnings(expr = Misc(object = object, slot = "markvariogram") <- svf.info)
-    svf.info <- ComputeRMetric(mv = svf.info, r.metric)
-    svf.info <- svf.info[order(svf.info[, 1]), , drop = FALSE]
-  }
-  if (selection.method == "moransi") {
-    colnames(x = svf.info) <- paste0("MoransI_", colnames(x = svf.info))
-    svf.info <- svf.info[order(svf.info[, 2], -abs(svf.info[, 1])), , drop = FALSE]
-  }
-  var.name <- paste0(selection.method, ".spatially.variable")
-  var.name.rank <- paste0(var.name, ".rank")
-  svf.info[[var.name]] <- FALSE
-  svf.info[[var.name]][1:(min(nrow(x = svf.info), nfeatures))] <- TRUE
-  svf.info[[var.name.rank]] <- 1:nrow(x = svf.info)
-  object[names(x = svf.info)] <- svf.info
-  return(object)
-}
+FindSpatiallyVariableFeatures.StdAssay <- FindSpatiallyVariableFeatures.Assay
 
 
 #' @rdname LogNormalize

--- a/man/FindSpatiallyVariableFeatures.Rd
+++ b/man/FindSpatiallyVariableFeatures.Rd
@@ -24,7 +24,8 @@ FindSpatiallyVariableFeatures(object, ...)
 
 \method{FindSpatiallyVariableFeatures}{Assay}(
   object,
-  slot = "scale.data",
+  layer = "scale.data",
+  slot = deprecated(),
   spatial.location,
   selection.method = c("markvariogram", "moransi"),
   features = NULL,
@@ -39,7 +40,8 @@ FindSpatiallyVariableFeatures(object, ...)
 \method{FindSpatiallyVariableFeatures}{Seurat}(
   object,
   assay = NULL,
-  slot = "scale.data",
+  layer = "scale.data",
+  slot = NULL,
   features = NULL,
   image = NULL,
   selection.method = c("markvariogram", "moransi"),
@@ -54,6 +56,7 @@ FindSpatiallyVariableFeatures(object, ...)
 \method{FindSpatiallyVariableFeatures}{StdAssay}(
   object,
   layer = "scale.data",
+  slot = deprecated(),
   spatial.location,
   selection.method = c("markvariogram", "moransi"),
   features = NULL,
@@ -89,7 +92,9 @@ the grid over which binning is performed}
 
 \item{verbose}{Print messages and progress}
 
-\item{slot}{Slot in the Assay to pull data from}
+\item{layer}{The layer in the specified assay to pull data from.}
+
+\item{slot}{Deprecated, use `layer`.}
 
 \item{features}{If provided, only compute on given features. Otherwise,
 compute for all features.}
@@ -99,8 +104,6 @@ compute for all features.}
 \item{assay}{Assay to pull the features (marks) from}
 
 \item{image}{Name of image to pull the coordinates from}
-
-\item{layer}{Layer in the Assay5 to pull data from}
 }
 \description{
 Identify features whose variability in expression can be explained to some


### PR DESCRIPTION
This PR updates `FindSpatiallyVariableFeatures` to get the method working again by:

- Updating `FindSpatiallyVariableFeatures.StdAssay` to point to `FindSpatiallyVariableFeatures.Assay`
- Deprecating the `slot` parameter in favor of `layer`
- Making sure that the matrix (typically `scale.data`) used by the underlying svf method contains only the relevant cells/features for the specified assay, image, and layer
