### PR TITLE
Fix ImageDimPlot & ImageFeaturePlot to allow "_" in FOV names

### DIFF
--- a/R/visualization.R
+++ b/R/visualization.R
@@ -2668,6 +2668,8 @@ ImageFeaturePlot <- function(
   combine = TRUE,
   coord.fixed = TRUE
 ) {
+  # Used internally as a seperator character.
+  unit_separator = "\x1F"
   cells <- cells %||% Cells(x = object)
   scale <- scale[[1L]]
   scale <- match.arg(arg = scale)
@@ -2696,9 +2698,6 @@ ImageFeaturePlot <- function(
   )
   if (!length(x = fov)) {
     stop("No compatible spatial coordinates present")
-  }
-  if (grepl("~",fov)){
-    stop("Cannot use '~' in FOV name")
   }
   # Identify boundaries to use
   boundaries <- boundaries %||% sapply(
@@ -2889,19 +2888,19 @@ ImageFeaturePlot <- function(
       return(if (isTRUE(x = overlap[i])) {
         fov[i]
       } else {
-        paste(fov[i], boundaries[[i]], sep = '~')
+        paste(fov[i], boundaries[[i]], sep = unit_separator)
       })
     }
   ))
   pdata <- vector(mode = 'list', length = length(x = pnames))
   names(x = pdata) <- pnames
   for (i in names(x = pdata)) {
-    ul <- unlist(x = strsplit(x = i, split = '~'))
+    ul <- unlist(x = strsplit(x = i, split = unit_separator))
     # img <- paste(ul[1:length(ul)-1], collapse = '_')
     # Apply overlap
     # lyr <- ul[length(ul)]
     if(length(ul) > 1) {
-         img <- paste(ul[1:length(ul)-1], collapse = '~')
+         img <- paste(ul[1:length(ul)-1], collapse = unit_separator)
          lyr <- ul[length(ul)]
     } else if (length(ul) == 1) {
          img <- ul[1]
@@ -3019,7 +3018,7 @@ ImageFeaturePlot <- function(
     }
     for (j in seq_along(along.with = pdata)) {
       key <- names(x = pdata)[j]
-      img <- unlist(x = strsplit(x = key, split = '~'))[1L]
+      img <- unlist(x = strsplit(x = key, split = unit_separator))[1L]
       plots[[ident]][[key]] <- vector(
         mode = 'list',
         length = length(x = features) + ifelse(

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -2443,6 +2443,9 @@ ImageDimPlot <- function(
   if (!length(x = fov)) {
     stop("No compatible spatial coordinates present")
   }
+  if (grepl("~",fov)){
+    stop("Cannot use '~' in FOV name")
+  }
   # Identify boundaries to use
   boundaries <- boundaries %||% sapply(
     X = fov,
@@ -2479,15 +2482,15 @@ ImageDimPlot <- function(
       return(if (isTRUE(x = overlap[i])) {
         fov[i]
       } else {
-        paste(fov[i], boundaries[[i]], sep = '_')
+        paste(fov[i], boundaries[[i]], sep = '~')
       })
     }
   ))
   pdata <- vector(mode = 'list', length = length(x = pnames))
   names(x = pdata) <- pnames
   for (i in names(x = pdata)) {
-    ul <- unlist(x = strsplit(x = i, split = '_'))
-    img <- paste(ul[1:length(ul)-1], collapse = '_')
+    ul <- unlist(x = strsplit(x = i, split = '~'))
+    img <- paste(ul[1:length(ul)-1], collapse = '~')
     # Apply overlap
     lyr <- ul[length(ul)]
     if (is.na(x = lyr)) {
@@ -2560,7 +2563,7 @@ ImageDimPlot <- function(
   idx <- 1L
   for (group in group.by) {
     for (i in seq_along(along.with = pdata)) {
-      img <- unlist(x = strsplit(x = names(x = pdata)[i], split = '_'))[1L]
+      img <- unlist(x = strsplit(x = names(x = pdata)[i], split = '~'))[1L]
       p <- SingleImagePlot(
         data = pdata[[i]],
         col.by = pdata[[i]] %!NA% group,
@@ -2694,6 +2697,9 @@ ImageFeaturePlot <- function(
   )
   if (!length(x = fov)) {
     stop("No compatible spatial coordinates present")
+  }
+  if (grepl("~",fov)){
+    stop("Cannot use '~' in FOV name")
   }
   # Identify boundaries to use
   boundaries <- boundaries %||% sapply(
@@ -2884,19 +2890,19 @@ ImageFeaturePlot <- function(
       return(if (isTRUE(x = overlap[i])) {
         fov[i]
       } else {
-        paste(fov[i], boundaries[[i]], sep = '_')
+        paste(fov[i], boundaries[[i]], sep = '~')
       })
     }
   ))
   pdata <- vector(mode = 'list', length = length(x = pnames))
   names(x = pdata) <- pnames
   for (i in names(x = pdata)) {
-    ul <- unlist(x = strsplit(x = i, split = '_'))
+    ul <- unlist(x = strsplit(x = i, split = '~'))
     # img <- paste(ul[1:length(ul)-1], collapse = '_')
     # Apply overlap
     # lyr <- ul[length(ul)]
     if(length(ul) > 1) {
-         img <- paste(ul[1:length(ul)-1], collapse = '_')
+         img <- paste(ul[1:length(ul)-1], collapse = '~')
          lyr <- ul[length(ul)]
     } else if (length(ul) == 1) {
          img <- ul[1]
@@ -3014,7 +3020,7 @@ ImageFeaturePlot <- function(
     }
     for (j in seq_along(along.with = pdata)) {
       key <- names(x = pdata)[j]
-      img <- unlist(x = strsplit(x = key, split = '_'))[1L]
+      img <- unlist(x = strsplit(x = key, split = '~'))[1L]
       plots[[ident]][[key]] <- vector(
         mode = 'list',
         length = length(x = features) + ifelse(

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -2428,6 +2428,8 @@ ImageDimPlot <- function(
   coord.fixed = TRUE,
   flip_xy = TRUE
 ) {
+  # Used internally as a seperator character.
+  unit_separator = "\x1F"
   cells <- cells %||% Cells(x = object)
   # Determine FOV to use
   fov <- fov %||% DefaultFOV(object = object)
@@ -2442,9 +2444,6 @@ ImageDimPlot <- function(
   )
   if (!length(x = fov)) {
     stop("No compatible spatial coordinates present")
-  }
-  if (grepl("~",fov)){
-    stop("Cannot use '~' in FOV name")
   }
   # Identify boundaries to use
   boundaries <- boundaries %||% sapply(
@@ -2482,15 +2481,15 @@ ImageDimPlot <- function(
       return(if (isTRUE(x = overlap[i])) {
         fov[i]
       } else {
-        paste(fov[i], boundaries[[i]], sep = '~')
+        paste(fov[i], boundaries[[i]], sep = unit_separator)
       })
     }
   ))
   pdata <- vector(mode = 'list', length = length(x = pnames))
   names(x = pdata) <- pnames
   for (i in names(x = pdata)) {
-    ul <- unlist(x = strsplit(x = i, split = '~'))
-    img <- paste(ul[1:length(ul)-1], collapse = '~')
+    ul <- unlist(x = strsplit(x = i, split = unit_separator))
+    img <- paste(ul[1:length(ul)-1], collapse = unit_separator)
     # Apply overlap
     lyr <- ul[length(ul)]
     if (is.na(x = lyr)) {
@@ -2563,7 +2562,7 @@ ImageDimPlot <- function(
   idx <- 1L
   for (group in group.by) {
     for (i in seq_along(along.with = pdata)) {
-      img <- unlist(x = strsplit(x = names(x = pdata)[i], split = '~'))[1L]
+      img <- unlist(x = strsplit(x = names(x = pdata)[i], split = unit_separator))[1L]
       p <- SingleImagePlot(
         data = pdata[[i]],
         col.by = pdata[[i]] %!NA% group,


### PR DESCRIPTION
This PR replaces the internal separator character used by `ImageDimPlot` and `ImageFeaturePlot` with the unit separator ASCII character ("\x1F"). The functions should work properly with FOV names containing underscores ("_") from now on 👍 
