### PR TITLE
Fix PseudobulkExpression to forward NormalizeData args

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: Seurat
-Version: 5.2.99.9018
+Version: 5.2.99.9019
 Title: Tools for Single Cell Genomics
 Description: A toolkit for quality control, analysis, and exploration of single cell RNA sequencing data. 'Seurat' aims to enable users to identify and interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse types of single cell data. See Satija R, Farrell J, Gennert D, et al (2015) <doi:10.1038/nbt.3192>, Macosko E, Basu A, Satija R, et al (2015) <doi:10.1016/j.cell.2015.05.002>, Stuart T, Butler A, et al (2019) <doi:10.1016/j.cell.2019.05.031>, and Hao, Hao, et al (2020) <doi:10.1101/2020.10.12.335331> for more details.
 Authors@R: c(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,8 @@
 # Unreleased
 
 ## Changes
-- Fixed bugs in `FindSpatiallyVariableFeatures` ([#9836](https://github.com/satijalab/seurat/pull/9836))
+- Fixed `PseudobulkExpression` to forward relevant arguments to `NormalizeData` ([#9840](https://github.com/satijalab/seurat/pull/9840))
+- Fixed bugs in `FindSpatiallyVariableFeatures`; deprecated the `slot` parameter in favor of `layer` ([#9836](https://github.com/satijalab/seurat/pull/9836))
 - Extended `FindTransferAnchors`'s `reference` argument to accept SCT inputs containing more than one SCT model; in this case, the reference model that was fit against the largest number of cells is used ([#9833](https://github.com/satijalab/seurat/pull/9833))
 - Extended `FindTransferAnchors`'s `query` argument to accept multi-layer inputs; updated `MappingScore` to support multi-layer query inputs ([#9832](https://github.com/satijalab/seurat/pull/9832))
 - Updated `LeverageScore.default` to convert `BPCells::IterableMatrix` inputs with less than 7500 cells into a sparse matrix before performing the calculation ([#9831](https://github.com/satijalab/seurat/pull/9831))

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -1314,7 +1314,7 @@ PercentageFeatureSet <- function(
 #' @param object Seurat object
 #' @param method Whether to 'average' (default) or 'aggregate' expression levels
 #' @param assay  The name of the passed assay - used primarily for warning/error messages
-#' @param category.matrix A matrix defining groupings for pseudobulk expression 
+#' @param category.matrix A matrix defining groupings for pseudobulk expression
 #' calculations; each column represents an identity class, and each row a sample
 #' @param features Features to analyze. Default is all features in the assay
 #' @param layer Layer(s) to user; if multiple are given, assumed to follow
@@ -1460,10 +1460,10 @@ PseudobulkExpression.StdAssay <- function(
 
 #' @param assays Which assays to use. Default is all assays
 #' @param return.seurat Whether to return the data as a Seurat object. Default is FALSE
-#' @param group.by Categories for grouping (e.g, "ident", "replicate", 
+#' @param group.by Categories for grouping (e.g, "ident", "replicate",
 #' "celltype"); "ident" by default
 #' @param add.ident (Deprecated) See group.by
-#' @param method The method used for calculating pseudobulk expression; one of: 
+#' @param method The method used for calculating pseudobulk expression; one of:
 #' "average" or "aggregate"
 #' @param normalization.method Method for normalization, see \code{\link{NormalizeData}}
 #' @param scale.factor Scale factor for normalization, see \code{\link{NormalizeData}}
@@ -1636,6 +1636,8 @@ PseudobulkExpression.Seurat <- function(
         ) <- NormalizeData(
           as.matrix(x = data.return[[1]]),
           normalization.method = normalization.method,
+          scale.factor = scale.factor,
+          margin = margin,
           verbose = verbose
         )
       }
@@ -3051,7 +3053,7 @@ BuildNicheAssay <- function(
   )
   rownames(cell.type.mtx) <- cells
   colnames(cell.type.mtx) <- groups
-  # populate the binary matrix 
+  # populate the binary matrix
   cells.idx <- seq_along(cells)
   group.idx <- match(group.labels, groups)
   cell.type.mtx[cbind(cells.idx, group.idx)] <- 1

--- a/man/PseudobulkExpression.Rd
+++ b/man/PseudobulkExpression.Rd
@@ -55,7 +55,7 @@ PseudobulkExpression(object, ...)
 
 \item{assay}{The name of the passed assay - used primarily for warning/error messages}
 
-\item{category.matrix}{A matrix defining groupings for pseudobulk expression 
+\item{category.matrix}{A matrix defining groupings for pseudobulk expression
 calculations; each column represents an identity class, and each row a sample}
 
 \item{features}{Features to analyze. Default is all features in the assay}
@@ -71,12 +71,12 @@ the order of 'assays' (if specified) or object's assays}
 
 \item{return.seurat}{Whether to return the data as a Seurat object. Default is FALSE}
 
-\item{group.by}{Categories for grouping (e.g, "ident", "replicate", 
+\item{group.by}{Categories for grouping (e.g, "ident", "replicate",
 "celltype"); "ident" by default}
 
 \item{add.ident}{(Deprecated) See group.by}
 
-\item{method}{The method used for calculating pseudobulk expression; one of: 
+\item{method}{The method used for calculating pseudobulk expression; one of:
 "average" or "aggregate"}
 
 \item{normalization.method}{Method for normalization, see \code{\link{NormalizeData}}}


### PR DESCRIPTION
Big thanks to @mhkowalski for the fix

---
As reported in https://github.com/satijalab/seurat/issues/9756, we don't actually pass the `margin` or `scale.factor` arguments to `NormalizeData` in the single assay case. 

This is a minor fix. While I was there, I also added some test coverage for `AggregateExpression`, which ensures that 

1. We sum counts correctly
2. We return correctly return normalized data (with parameter options) in the single and multi-assay case.
3. We return an object with `group.by` variables correctly added to the meta.data
4. We pass arguments correctly to `CreateSeuratObject` using `...`. 
---