### PR TITLE
fix LabelClusters split.by warning

### DIFF
--- a/R/visualization.R
+++ b/R/visualization.R
@@ -5758,7 +5758,7 @@ LabelClusters <- function(
     stop("Cannot find variable ", id, " in plotting data")
   }
   if (!is.null(x = split.by) && !split.by %in% colnames(x = plot$data)) {
-    warning("Cannot find splitting variable ", id, " in plotting data")
+    warning("Cannot find splitting variable ", split.by, " in plotting data")
     split.by <- NULL
   }
   data <- plot$data[, c(xynames, id, split.by)]


### PR DESCRIPTION
Just a quick fix to use the _splitting_ variable in the warning, not the _coloring_ variable, for a more accurate/useful warning message.