### PR TITLE
Rename stable release branches from release/* to *-stable

### DIFF
--- a/.github/workflows/release_checks.yaml
+++ b/.github/workflows/release_checks.yaml
@@ -1,19 +1,19 @@
 name: Pre-Release Checks
 
 on:
-  # Trigger the workflow when a PR opened/updated against a release branch.
+  # Trigger the workflow when a PR opened/updated against a stable release branch.
   pull_request:
     branches:
-    - 'release/*'
-  # Trigger the workflow when commits are pushed to a release branch. 
+    - '*-stable'
+  # Trigger the workflow when commits are pushed to a stable release branch. 
   # Because they are protected branches this workflow is effectively triggered 
   # by three events:
-  # 1. When a release branch is initially created/pushed.
-  # 2. When a PR against a release branch is opened/updated.
-  # 3. When a PR against a release branch is merged.
+  # 1. When a stable branch is initially created/pushed.
+  # 2. When a PR against a stable branch is opened/updated.
+  # 3. When a PR against a stable branch is merged.
   push:
     branches:
-    - 'release/*'
+    - '*-stable'
   # Allow the workflow to be triggered manually.
   workflow_dispatch:
 


### PR DESCRIPTION
Changed my mind about branch naming conventions—going to adopt the suggestion from [Release branches with GitLab flow](https://docs.gitlab.co.jp/ee/topics/gitlab_flow.html#release-branches-with-gitlab-flow) 👌 