### PR TITLE
Fix SketchData Too Slow ! error by keeping VariableFeatures if Features set to Null

### DIFF
--- a/R/sketching.R
+++ b/R/sketching.R
@@ -83,7 +83,7 @@ SketchData <- function(
       over.write = over.write,
       seed = seed,
       verbose = FALSE,
-      features = features,
+      features = features %||% VariableFeatures(object),
       ...
     )
   } else if (method == 'Uniform') {


### PR DESCRIPTION
Fix SketchData to default to VariableFeatures obtained from FindVariableFeatures() when features is NULL

Previously, if the `features` argument was not set in SketchData(),
it would pass NULL to LeverageScore(), causing it to use all features,
often resulting in a Too Slow ! error due to too many features. This commit adds a safe fallback to use VariableFeatures(object) when features is NULL.