### PR TITLE
Add arguments to kmeans call in BuildNicheAssay function

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -3076,6 +3076,7 @@ BuildNicheAssay <- function(
   results <- kmeans(
     x = t(object[[assay]]@scale.data),
     centers = niches.k,
+    nstart = 30,
     ...
   )
   object[[cluster.name]] <- results[["cluster"]]

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -3027,6 +3027,10 @@ CreateCategoryMatrix <- function(
 #' @param cluster.name Name of output clusters
 #' @param neighbors.k Number of neighbors to consider for each cell
 #' @param niches.k Number of clusters to return based on the niche assay
+#' @param iter.max The maximum number of iterations allowed (see \code{\link[stats]{kmeans}})
+#' @param nstart If centers is a number, how many random sets should be chosen (see \code{\link[stats]{kmeans}})
+#' @param algorithm Character string: may be abbreviated.
+#' Note that "Lloyd" and "Forgy" are alternative names (see \code{\link[stats]{kmeans}})
 #'
 #' @importFrom stats kmeans
 #' @return Seurat object containing a new assay
@@ -3040,7 +3044,10 @@ BuildNicheAssay <- function(
   assay = "niche",
   cluster.name = "niches",
   neighbors.k = 20,
-  niches.k = 4
+  niches.k = 4,
+  iter.max = 10,
+  nstart = 30,
+  algorithm = c("Hartigan-Wong", "Lloyd", "Forgy", "MacQueen")
 ) {
   # initialize an empty cells x groups binary matrix
   cells <- Cells(object[[fov]])
@@ -3075,7 +3082,9 @@ BuildNicheAssay <- function(
   results <- kmeans(
     x = t(object[[assay]]@scale.data),
     centers = niches.k,
-    nstart = 30
+    nstart = nstart,
+    iter.max = iter.max,
+    algorithm = algorithm
   )
   object[[cluster.name]] <- results[["cluster"]]
 

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -3026,11 +3026,7 @@ CreateCategoryMatrix <- function(
 #' @param assay Name for spatial neighborhoods assay
 #' @param cluster.name Name of output clusters
 #' @param neighbors.k Number of neighbors to consider for each cell
-#' @param niches.k Number of clusters to return based on the niche assay
-#' @param iter.max The maximum number of iterations allowed (see \code{\link[stats]{kmeans}})
-#' @param nstart If centers is a number, how many random sets should be chosen (see \code{\link[stats]{kmeans}})
-#' @param algorithm Character string: may be abbreviated.
-#' Note that "Lloyd" and "Forgy" are alternative names (see \code{\link[stats]{kmeans}})
+#' @param ... Extra parameters passed to \code{\link{kmeans}}
 #'
 #' @importFrom stats kmeans
 #' @return Seurat object containing a new assay
@@ -3045,9 +3041,7 @@ BuildNicheAssay <- function(
   cluster.name = "niches",
   neighbors.k = 20,
   niches.k = 4,
-  iter.max = 10,
-  nstart = 30,
-  algorithm = c("Hartigan-Wong", "Lloyd", "Forgy", "MacQueen")
+  ...
 ) {
   # initialize an empty cells x groups binary matrix
   cells <- Cells(object[[fov]])
@@ -3082,9 +3076,7 @@ BuildNicheAssay <- function(
   results <- kmeans(
     x = t(object[[assay]]@scale.data),
     centers = niches.k,
-    nstart = nstart,
-    iter.max = iter.max,
-    algorithm = algorithm
+    ...
   )
   object[[cluster.name]] <- results[["cluster"]]
 

--- a/man/BuildNicheAssay.Rd
+++ b/man/BuildNicheAssay.Rd
@@ -11,7 +11,8 @@ BuildNicheAssay(
   assay = "niche",
   cluster.name = "niches",
   neighbors.k = 20,
-  niches.k = 4
+  niches.k = 4,
+  ...
 )
 }
 \arguments{
@@ -28,13 +29,15 @@ BuildNicheAssay(
 \item{neighbors.k}{Number of neighbors to consider for each cell}
 
 \item{niches.k}{Number of clusters to return based on the niche assay}
+
+\item{...}{Extra parameters passed to \code{\link{kmeans}}}
 }
 \value{
 Seurat object containing a new assay
 }
 \description{
 This function will construct a new assay where each feature is a
-cell label The values represents the sum of a particular cell label
+cell label. The values represent the sum of a particular cell label
 neighboring a given cell.
 }
 \concept{clustering}

--- a/man/BuildNicheAssay.Rd
+++ b/man/BuildNicheAssay.Rd
@@ -11,7 +11,10 @@ BuildNicheAssay(
   assay = "niche",
   cluster.name = "niches",
   neighbors.k = 20,
-  niches.k = 4
+  niches.k = 4,
+  iter.max = 10,
+  nstart = 30,
+  algorithm = c("Hartigan-Wong", "Lloyd", "Forgy", "MacQueen")
 )
 }
 \arguments{
@@ -28,6 +31,13 @@ BuildNicheAssay(
 \item{neighbors.k}{Number of neighbors to consider for each cell}
 
 \item{niches.k}{Number of clusters to return based on the niche assay}
+
+\item{iter.max}{The maximum number of iterations allowed (see \code{\link[stats]{kmeans}})}
+
+\item{nstart}{If centers is a number, how many random sets should be chosen (see \code{\link[stats]{kmeans}})}
+
+\item{algorithm}{Character string: may be abbreviated.
+Note that "Lloyd" and "Forgy" are alternative names (see \code{\link[stats]{kmeans}})}
 }
 \value{
 Seurat object containing a new assay

--- a/man/BuildNicheAssay.Rd
+++ b/man/BuildNicheAssay.Rd
@@ -11,8 +11,7 @@ BuildNicheAssay(
   assay = "niche",
   cluster.name = "niches",
   neighbors.k = 20,
-  niches.k = 4,
-  ...
+  niches.k = 4
 )
 }
 \arguments{
@@ -28,7 +27,7 @@ BuildNicheAssay(
 
 \item{neighbors.k}{Number of neighbors to consider for each cell}
 
-\item{...}{Extra parameters passed to \code{\link{kmeans}}}
+\item{niches.k}{Number of clusters to return based on the niche assay}
 }
 \value{
 Seurat object containing a new assay

--- a/man/BuildNicheAssay.Rd
+++ b/man/BuildNicheAssay.Rd
@@ -12,9 +12,7 @@ BuildNicheAssay(
   cluster.name = "niches",
   neighbors.k = 20,
   niches.k = 4,
-  iter.max = 10,
-  nstart = 30,
-  algorithm = c("Hartigan-Wong", "Lloyd", "Forgy", "MacQueen")
+  ...
 )
 }
 \arguments{
@@ -30,14 +28,7 @@ BuildNicheAssay(
 
 \item{neighbors.k}{Number of neighbors to consider for each cell}
 
-\item{niches.k}{Number of clusters to return based on the niche assay}
-
-\item{iter.max}{The maximum number of iterations allowed (see \code{\link[stats]{kmeans}})}
-
-\item{nstart}{If centers is a number, how many random sets should be chosen (see \code{\link[stats]{kmeans}})}
-
-\item{algorithm}{Character string: may be abbreviated.
-Note that "Lloyd" and "Forgy" are alternative names (see \code{\link[stats]{kmeans}})}
+\item{...}{Extra parameters passed to \code{\link{kmeans}}}
 }
 \value{
 Seurat object containing a new assay


### PR DESCRIPTION
### Summary

This PR adds support for passing additional arguments to the `kmeans` function within `BuildNicheAssay`. The goal is to help address convergence issues such as the warning:

```
Warning: did not converge in 10 iterations
```

In some cases, the default settings of `kmeans` may not be sufficient for convergence, particularly with complex or noisy datasets. By allowing users to specify parameters like `iter.max`, `nstart`, and `algorithm`, the clustering behavior can be tuned for better performance.

With the added flexibility, I was able to resolve the convergence warning using the following code:

```r
set.seed(1)
xobj <- BuildNicheAssay(
    xobj,
    fov = "fov",
    group.by = "cell_type_res_l2",
    niches.k = 10, neighbors.k = 10,
    algorithm = "Lloyd", iter.max = 1000, 
    nstart = 1
)
```

Addresses #9543
