### PR TITLE
slot/layer & GetAssayData/LayerData fixes

### DIFF
--- a/tests/testthat/test_differential_expression.R
+++ b/tests/testthat/test_differential_expression.R
@@ -423,11 +423,11 @@ test_that("FindAllMarkers works as expected", {
 ref <- pbmc_small
 ref <- FindVariableFeatures(object = ref, verbose = FALSE, nfeatures = 100)
 query <- CreateSeuratObject(CreateAssayObject(
-  counts = as.sparse(GetAssayData(object = pbmc_small[['RNA']], layer = "counts") + rpois(n = ncol(pbmc_small), lambda = 1))
+  counts = as.sparse(LayerData(object = pbmc_small[['RNA']], layer = "counts") + rpois(n = ncol(pbmc_small), lambda = 1))
 ))
 
 query2 <- CreateSeuratObject(CreateAssayObject(
-  counts = as.sparse(GetAssayData(object = pbmc_small[['RNA']], layer = "counts")[, 1:40] + rpois(n = ncol(pbmc_small), lambda = 1))
+  counts = as.sparse(LayerData(object = pbmc_small[['RNA']], layer = "counts")[, 1:40] + rpois(n = ncol(pbmc_small), lambda = 1))
 ))
 
 

--- a/tests/testthat/test_integratedata.R
+++ b/tests/testthat/test_integratedata.R
@@ -7,7 +7,7 @@ ref <- pbmc_small
 ref <- FindVariableFeatures(object = ref, verbose = FALSE, nfeatures = 100)
 query <- CreateSeuratObject(
   counts = as.sparse(
-    GetAssayData(
+    LayerData(
       object = pbmc_small[['RNA']],
       layer = "counts") + rpois(n = ncol(pbmc_small),
       lambda = 1
@@ -82,10 +82,10 @@ test_that("IntegrateData with two objects default work", {
   expect_equal(Tool(int2), "Integration")
   expect_equal(dim(int2[["integrated"]]), c(133, 160))
   expect_equal(length(VariableFeatures(int2)), 133)
-  expect_equal(GetAssayData(int2[["integrated"]], layer = "counts"), new("dgCMatrix"))
-  expect_equal(GetAssayData(int2[['integrated']], layer = "scale.data"), matrix())
-  expect_equal(sum(GetAssayData(int2[["integrated"]], layer = "data")[1, ]), 44.97355, tolerance = 1e-3)
-  expect_equal(sum(GetAssayData(int2[["integrated"]], layer = "data")[, 1]), 78.8965706046, tolerance = 1e-6)
+  expect_equal(LayerData(int2[["integrated"]], layer = "counts"), new("dgCMatrix"))
+  expect_equal(LayerData(int2[['integrated']], layer = "scale.data"), matrix())
+  expect_equal(sum(LayerData(int2[["integrated"]], layer = "data")[1, ]), 44.97355, tolerance = 1e-3)
+  expect_equal(sum(LayerData(int2[["integrated"]], layer = "data")[, 1]), 78.8965706046, tolerance = 1e-6)
   expect_equal(Tool(object = int2, slot = "Integration")@sample.tree, matrix(c(-1, -2), nrow  = 1))
 })
 
@@ -96,10 +96,10 @@ test_that("IntegrateData with three objects default work", {
   expect_equal(Tool(int3), "Integration")
   expect_equal(dim(int3[["integrated"]]), c(169, 200))
   expect_equal(length(VariableFeatures(int3)), 169)
-  expect_equal(GetAssayData(int3[["integrated"]], layer = "counts"), new("dgCMatrix"))
-  expect_equal(GetAssayData(int3[['integrated']], layer = "scale.data"), matrix())
-  expect_equal(sum(GetAssayData(int3[["integrated"]], layer = "data")[1, ]), 372.829, tolerance = 1e-6)
-  expect_equal(sum(GetAssayData(int3[["integrated"]], layer = "data")[, 1]), 482.5009, tolerance = 1e-6)
+  expect_equal(LayerData(int3[["integrated"]], layer = "counts"), new("dgCMatrix"))
+  expect_equal(LayerData(int3[['integrated']], layer = "scale.data"), matrix())
+  expect_equal(sum(LayerData(int3[["integrated"]], layer = "data")[1, ]), 372.829, tolerance = 1e-6)
+  expect_equal(sum(LayerData(int3[["integrated"]], layer = "data")[, 1]), 482.5009, tolerance = 1e-6)
   expect_equal(Tool(object = int3, slot = "Integration")@sample.tree, matrix(c(-2, -3, 1, -1), nrow  = 2, byrow = TRUE))
 })
 

--- a/tests/testthat/test_integration.R
+++ b/tests/testthat/test_integration.R
@@ -6,7 +6,7 @@ pbmc_small <- suppressWarnings(UpdateSeuratObject(pbmc_small))
 ref <- pbmc_small
 query <- CreateSeuratObject(
   counts = as.sparse(
-    GetAssayData(
+    LayerData(
       object = pbmc_small[['RNA']],
       layer = "counts") + rpois(n = ncol(pbmc_small),
       lambda = 1
@@ -26,8 +26,8 @@ test_that("FindTransferAnchors defaults work", {
   co <- anchors@object.list[[1]]
   expect_equal(dim(co), c(100, 160))
   expect_equal(Reductions(co), c("pcaproject", "pcaproject.l2"))
-  expect_equal(GetAssayData(co[["RNA"]], layer ="data")[1, 3], 0)
-  expect_equal(GetAssayData(co[["RNA"]], layer = "counts")[1, 3], 0)
+  expect_equal(LayerData(co[["RNA"]], layer ="data")[1, 3], 0)
+  expect_equal(LayerData(co[["RNA"]], layer = "counts")[1, 3], 0)
   expect_equal(dim(co[['pcaproject']]), c(160, 30))
   expect_equal(Embeddings(co[['pcaproject']])[1, 1], 0.4840944592, tolerance = 1e-7)
   expect_equal(Loadings(co[['pcaproject']], projected = T)[1, 1], 0.2103563963, tolerance = 1e-7)
@@ -78,8 +78,8 @@ test_that("FindTransferAnchors allows reference.reduction to be precomputed", {
   co <- anchors@object.list[[1]]
   expect_equal(dim(co), c(100, 160))
   expect_equal(Reductions(co), c("pcaproject", "pcaproject.l2"))
-  expect_equal(GetAssayData(co[["RNA"]])[1, 3], 0)
-  expect_equal(GetAssayData(co[["RNA"]], layer = "counts")[1, 3], 0)
+  expect_equal(LayerData(co[["RNA"]])[1, 3], 0)
+  expect_equal(LayerData(co[["RNA"]], layer = "counts")[1, 3], 0)
   expect_equal(dim(co[['pcaproject']]), c(160, 30))
   expect_equal(Embeddings(co[['pcaproject']])[1, 1], 0.4840944592, tolerance = 1e-7)
   expect_equal(Loadings(co[['pcaproject']], projected = T)[1, 1], 0.2103563963, tolerance = 1e-7)
@@ -107,10 +107,10 @@ test_that("FindTransferAnchors with cca defaults work", {
   co <- anchors@object.list[[1]]
   expect_equal(dim(co), c(100, 160))
   expect_equal(Reductions(co), c("cca", "cca.l2"))
-  expect_equal(GetAssayData(co[["RNA"]])["PPBP", 3], 0)
-  expect_equal(GetAssayData(co[["RNA"]])["PPBP", 1], 0)
-  expect_equal(GetAssayData(co[["RNA"]], layer = "counts")["PPBP", 3], 0)
-  expect_equal(GetAssayData(co[["RNA"]], layer = "counts")["PPBP", 1], 0)
+  expect_equal(LayerData(co[["RNA"]])["PPBP", 3], 0)
+  expect_equal(LayerData(co[["RNA"]])["PPBP", 1], 0)
+  expect_equal(LayerData(co[["RNA"]], layer = "counts")["PPBP", 3], 0)
+  expect_equal(LayerData(co[["RNA"]], layer = "counts")["PPBP", 1], 0)
   expect_equal(dim(co[['cca']]), c(160, 30))
   expect_equal(Embeddings(co[['cca']])[1, 1], 0.04611130861, tolerance = 1e-7)
   expect_equal(Loadings(co[['cca']], projected = T)["PPBP", 1], 12.32379661, tolerance = 1e-7)
@@ -138,10 +138,10 @@ test_that("FindTransferAnchors with project.query defaults work", {
   co <- anchors@object.list[[1]]
   expect_equal(dim(co), c(100, 160))
   expect_equal(Reductions(co), c("pcaproject", "pcaproject.l2"))
-  expect_equal(GetAssayData(co[["RNA"]], layer = "data")["PPBP", 3], 0)
-  expect_equal(GetAssayData(co[["RNA"]], layer = "data")["PPBP", 1], 0)
-  expect_equal(GetAssayData(co[["RNA"]], layer = "counts")["PPBP", 3], 0)
-  expect_equal(GetAssayData(co[["RNA"]], layer = "counts")["PPBP", 1], 0)
+  expect_equal(LayerData(co[["RNA"]], layer = "data")["PPBP", 3], 0)
+  expect_equal(LayerData(co[["RNA"]], layer = "data")["PPBP", 1], 0)
+  expect_equal(LayerData(co[["RNA"]], layer = "counts")["PPBP", 3], 0)
+  expect_equal(LayerData(co[["RNA"]], layer = "counts")["PPBP", 1], 0)
   expect_equal(dim(co[['pcaproject']]), c(160, 30))
   expect_equal(Embeddings(co[['pcaproject']])[1, 1], 1.577959404, tolerance = 1e-7)
   expect_equal(Loadings(co[['pcaproject']], projected = T)["PPBP", 1], 0.1145472305, tolerance = 1e-7)
@@ -172,10 +172,10 @@ test_that("FindTransferAnchors with project.query and reference.reduction works"
   co <- anchors@object.list[[1]]
   expect_equal(dim(co), c(100, 160))
   expect_equal(Reductions(co), c("pcaproject", "pcaproject.l2"))
-  expect_equal(GetAssayData(co[["RNA"]])["PPBP", 3], 0)
-  expect_equal(GetAssayData(co[["RNA"]])["PPBP", 1], 0)
-  expect_equal(GetAssayData(co[["RNA"]], layer = "counts")["PPBP", 3], 0)
-  expect_equal(GetAssayData(co[["RNA"]], layer = "counts")["PPBP", 1], 0)
+  expect_equal(LayerData(co[["RNA"]])["PPBP", 3], 0)
+  expect_equal(LayerData(co[["RNA"]])["PPBP", 1], 0)
+  expect_equal(LayerData(co[["RNA"]], layer = "counts")["PPBP", 3], 0)
+  expect_equal(LayerData(co[["RNA"]], layer = "counts")["PPBP", 1], 0)
   expect_equal(dim(co[['pcaproject']]), c(160, 30))
   expect_equal(Embeddings(co[['pcaproject']])[1, 1], 1.577959404, tolerance = 1e-7)
   expect_equal(Loadings(co[['pcaproject']], projected = T)["PPBP", 1], 0.1145472305, tolerance = 1e-7)
@@ -207,8 +207,8 @@ test_that("FindTransferAnchors with reference.neighbors precomputed works", {
   co <- anchors@object.list[[1]]
   expect_equal(dim(co), c(100, 160))
   expect_equal(Reductions(co), c("pcaproject", "pcaproject.l2"))
-  expect_equal(GetAssayData(co[["RNA"]])[1, 3], 0)
-  expect_equal(GetAssayData(co[["RNA"]], layer = "counts")[1, 3], 0)
+  expect_equal(LayerData(co[["RNA"]])[1, 3], 0)
+  expect_equal(LayerData(co[["RNA"]], layer = "counts")[1, 3], 0)
   expect_equal(dim(co[['pcaproject']]), c(160, 30))
   expect_equal(Embeddings(co[['pcaproject']])[1, 1], 0.4840944592, tolerance = 1e-7)
   expect_equal(Loadings(co[['pcaproject']], projected = T)[1, 1], 0.2103563963, tolerance = 1e-7)
@@ -236,8 +236,8 @@ test_that("FindTransferAnchors with no l2 works", {
   co <- anchors@object.list[[1]]
   expect_equal(dim(co), c(100, 160))
   expect_equal(Reductions(co), c("pcaproject"))
-  expect_equal(GetAssayData(co[["RNA"]])[1, 3], 0)
-  expect_equal(GetAssayData(co[["RNA"]], layer = "counts")[1, 3], 0)
+  expect_equal(LayerData(co[["RNA"]])[1, 3], 0)
+  expect_equal(LayerData(co[["RNA"]], layer = "counts")[1, 3], 0)
   expect_equal(dim(co[['pcaproject']]), c(160, 30))
   expect_equal(Embeddings(co[['pcaproject']])[1, 1], 0.4840944592, tolerance = 1e-7)
   expect_equal(Loadings(co[['pcaproject']], projected = T)[1, 1], 0.2103563963, tolerance = 1e-7)
@@ -267,8 +267,8 @@ test_that("FindTransferAnchors with default SCT works", {
   expect_equal(dim(co), c(220, 160))
   expect_equal(Reductions(co), c("pcaproject", "pcaproject.l2"))
   expect_equal(DefaultAssay(co), "SCT")
-  expect_equal(GetAssayData(co[["SCT"]], layer = "scale.data"), new(Class = "matrix"))
-  expect_equal(GetAssayData(co[["SCT"]])[1, 1], 0)
+  expect_equal(LayerData(co[["SCT"]], layer = "scale.data"), new(Class = "matrix"))
+  expect_equal(LayerData(co[["SCT"]])[1, 1], 0)
   expect_equal(dim(co[['pcaproject']]), c(160, 30))
   expect_equal(Embeddings(co[['pcaproject']])[1, 1], -1.852491719, tolerance = 1e-7)
   expect_equal(Loadings(co[['pcaproject']], projected = T)[1, 1], -0.1829401539, tolerance = 1e-7)
@@ -309,7 +309,7 @@ test_that("FindTransferAnchors with default SCT works", {
   expect_equal(dim(co), c(220, 160))
   expect_equal(Reductions(co), c("cca", "cca.l2"))
   expect_equal(DefaultAssay(co), "SCT")
-  expect_equal(GetAssayData(co[["SCT"]])[1, 1], 0)
+  expect_equal(LayerData(co[["SCT"]])[1, 1], 0)
   expect_equal(dim(co[['cca']]), c(160, 30))
   expect_equal(Embeddings(co[['cca']])[1, 1], 0.0459135444, tolerance = 1e-7)
   expect_equal(Loadings(co[['cca']], projected = T)["NKG7", 1], 8.51477973, tolerance = 1e-7)
@@ -338,8 +338,8 @@ test_that("FindTransferAnchors with SCT and project.query work", {
   expect_equal(dim(co), c(220, 160))
   expect_equal(Reductions(co), c("pcaproject", "pcaproject.l2"))
   expect_equal(DefaultAssay(co), "SCT")
-  expect_equal(GetAssayData(co[["SCT"]])[1, 1], 0)
-  expect_equal(GetAssayData(co[["SCT"]], slot = "scale.data"), new("matrix"))
+  expect_equal(LayerData(co[["SCT"]])[1, 1], 0)
+  expect_equal(LayerData(co[["SCT"]], layer =  "scale.data"), new("matrix"))
   expect_equal(dim(co[['pcaproject']]), c(160, 30))
   expect_equal(Embeddings(co[['pcaproject']])[1, 1], 0.3049308, tolerance = 1e-7)
   expect_equal(Loadings(co[['pcaproject']], projected = T)[1, 1], 0.05788217444, tolerance = 1e-7)
@@ -368,8 +368,8 @@ test_that("FindTransferAnchors with SCT and l2.norm FALSE work", {
   expect_equal(dim(co), c(220, 160))
   expect_equal(Reductions(co), c("pcaproject"))
   expect_equal(DefaultAssay(co), "SCT")
-  expect_equal(GetAssayData(co[["SCT"]])[1, 1], 0)
-  expect_equal(GetAssayData(co[["SCT"]], layer = "scale.data"), new("matrix"))
+  expect_equal(LayerData(co[["SCT"]])[1, 1], 0)
+  expect_equal(LayerData(co[["SCT"]], layer = "scale.data"), new("matrix"))
   expect_equal(dim(co[['pcaproject']]), c(160, 30))
   expect_equal(Embeddings(co[['pcaproject']])[1, 1], -1.852491719, tolerance = 1e-7)
   expect_equal(Loadings(co[['pcaproject']], projected = T)[1, 1], -0.1829401539, tolerance = 1e-7)
@@ -388,7 +388,7 @@ test_that("FindTransferAnchors with SCT and l2.norm FALSE work", {
   expect_equal(anchors@neighbors, list())
 })
 
-# Added test for multi-layer query 
+# Added test for multi-layer query
 pbmc_small <- suppressWarnings(UpdateSeuratObject(pbmc_small))
 reference <- pbmc_small
 reference <- NormalizeData(reference, verbose = FALSE)
@@ -398,7 +398,7 @@ reference <- suppressWarnings(RunPCA(reference, npcs = 30, verbose = FALSE))
 
 query <- CreateSeuratObject(
   counts = as.sparse(
-    GetAssayData(
+    LayerData(
       object = pbmc_small[['RNA']],
       layer = "counts"
     ) + rpois(n = ncol(pbmc_small), lambda = 1)
@@ -423,8 +423,8 @@ test_that("FindTransferAnchors handles multi-layer queries when mapping.score,k 
   co <- anchors@object.list[[1]]
   expect_equal(dim(co), c(230, 160))
   expect_equal(Reductions(co), c("pcaproject", "pcaproject.l2"))
-  expect_equal(GetAssayData(co[["RNA"]], layer ="data")[1, 3], 0)
-  expect_equal(GetAssayData(co[["RNA"]], layer = "counts")[1, 3], 0)
+  expect_equal(LayerData(co[["RNA"]], layer ="data")[1, 3], 0)
+  expect_equal(LayerData(co[["RNA"]], layer = "counts")[1, 3], 0)
   expect_equal(dim(co[['pcaproject']]), c(160, 30))
   expect_equal(dim(co[['pcaproject.l2']]), c(160, 30))
   ref.cells <- paste0(Cells(ref), "_reference")
@@ -447,8 +447,8 @@ test_that("FindTransferAnchors handles multi-layer queries when mapping.score,k 
   co <- anchors@object.list[[1]]
   expect_equal(dim(co), c(230, 160))
   expect_equal(Reductions(co), c("pcaproject", "pcaproject.l2"))
-  expect_equal(GetAssayData(co[["RNA"]], layer ="data")[1, 3], 0)
-  expect_equal(GetAssayData(co[["RNA"]], layer = "counts")[1, 3], 0)
+  expect_equal(LayerData(co[["RNA"]], layer ="data")[1, 3], 0)
+  expect_equal(LayerData(co[["RNA"]], layer = "counts")[1, 3], 0)
   expect_equal(dim(co[['pcaproject']]), c(160, 30))
   expect_equal(dim(co[['pcaproject.l2']]), c(160, 30))
   ref.cells <- paste0(Cells(ref), "_reference")

--- a/tests/testthat/test_preprocessing.R
+++ b/tests/testthat/test_preprocessing.R
@@ -72,11 +72,11 @@ test_that("NormalizeData scales properly", {
   expect_equal(Command(object = object, command = "NormalizeData.RNA", value = "normalization.method"), "LogNormalize")
 })
 
-normalized.data <- LogNormalize(data = GetAssayData(object = object[["RNA"]], layer = "counts"), verbose = FALSE)
+normalized.data <- LogNormalize(data = LayerData(object = object[["RNA"]], layer = "counts"), verbose = FALSE)
 test_that("LogNormalize normalizes properly", {
   expect_equal(
-    as.matrix(LogNormalize(data = GetAssayData(object = object[["RNA"]], layer = "counts"), verbose = FALSE)),
-    as.matrix(LogNormalize(data = as.data.frame(as.matrix(GetAssayData(object = object[["RNA"]], layer = "counts"))), verbose = FALSE))
+    as.matrix(LogNormalize(data = LayerData(object = object[["RNA"]], layer = "counts"), verbose = FALSE)),
+    as.matrix(LogNormalize(data = as.data.frame(as.matrix(LayerData(object = object[["RNA"]], layer = "counts"))), verbose = FALSE))
   )
 })
 
@@ -165,8 +165,8 @@ test_that("LogNormalize normalizes properly for BPCells", {
   object <- NormalizeData(object = object, verbose = FALSE, scale.factor = 1e6, assay = "RNAbp")
   object <- NormalizeData(object = object, verbose = FALSE, scale.factor = 1e6, assay = "RNA")
 
-  normalized.data.bp <- LogNormalize(data = GetAssayData(object = object[["RNAbp"]], layer = "counts"), verbose = FALSE)
-  normalized.data <- LogNormalize(data = GetAssayData(object = object[["RNA"]], layer = "counts"), verbose = FALSE)
+  normalized.data.bp <- LogNormalize(data = LayerData(object = object[["RNAbp"]], layer = "counts"), verbose = FALSE)
+  normalized.data <- LogNormalize(data = LayerData(object = object[["RNA"]], layer = "counts"), verbose = FALSE)
 
   expect_equal(
     as.matrix(normalized.data.bp),
@@ -180,32 +180,32 @@ test_that("LogNormalize normalizes properly for BPCells", {
 context("ScaleData")
 object <- ScaleData(object, verbose = FALSE)
 test_that("ScaleData returns expected values when input is a sparse matrix", {
-  expect_equal(GetAssayData(object = object[["RNA"]], layer = "scale.data")[1, 1], -0.4148587, tolerance = 1e-6)
-  expect_equal(GetAssayData(object = object[["RNA"]], layer = "scale.data")[75, 25], -0.2562305, tolerance = 1e-6)
-  expect_equal(GetAssayData(object = object[["RNA"]], layer = "scale.data")[162, 59], -0.4363939, tolerance = 1e-6)
+  expect_equal(LayerData(object = object[["RNA"]], layer = "scale.data")[1, 1], -0.4148587, tolerance = 1e-6)
+  expect_equal(LayerData(object = object[["RNA"]], layer = "scale.data")[75, 25], -0.2562305, tolerance = 1e-6)
+  expect_equal(LayerData(object = object[["RNA"]], layer = "scale.data")[162, 59], -0.4363939, tolerance = 1e-6)
 })
 
-new.data <- as.matrix(GetAssayData(object = object[["RNA"]], layer = "data"))
+new.data <- as.matrix(LayerData(object = object[["RNA"]], layer = "data"))
 new.data[1, ] <- rep(x = 0, times = ncol(x = new.data))
 object2 <- object
 
 object2 <- SetAssayData(
   object = object,
   assay = "RNA",
-  slot = "data",
+  layer = "data",
   new.data = new.data
 )
 object2 <- ScaleData(object = object2, verbose = FALSE)
 
 object <- ScaleData(object = object, verbose = FALSE)
 test_that("ScaleData returns expected values when input is not sparse", {
-  expect_equal(GetAssayData(object = object[["RNA"]], layer = "scale.data")[75, 25], -0.2562305, tolerance = 1e-6)
-  expect_equal(GetAssayData(object = object[["RNA"]], layer = "scale.data")[162, 59], -0.4363939, tolerance = 1e-6)
+  expect_equal(LayerData(object = object[["RNA"]], layer = "scale.data")[75, 25], -0.2562305, tolerance = 1e-6)
+  expect_equal(LayerData(object = object[["RNA"]], layer = "scale.data")[162, 59], -0.4363939, tolerance = 1e-6)
 })
 
 test_that("ScaleData handles zero variance features properly", {
-  expect_equal(GetAssayData(object = object2[["RNA"]], layer = "scale.data")[1, 1], 0)
-  expect_equal(GetAssayData(object = object2[["RNA"]], layer = "scale.data")[1, 80], 0)
+  expect_equal(LayerData(object = object2[["RNA"]], layer = "scale.data")[1, 1], 0)
+  expect_equal(LayerData(object = object2[["RNA"]], layer = "scale.data")[1, 80], 0)
 })
 
 ng1 <- rep(x = "g1", times = round(x = ncol(x = object) / 2))
@@ -218,10 +218,10 @@ object <- ScaleData(object = object, features = rownames(x = object), verbose = 
 
 #move to SeuratObject
 # test_that("split.by option works", {
-#   expect_equal(GetAssayData(object = object, layer = "scale.data")[, Cells(x = g1)],
-#                GetAssayData(object = g1, layer = "scale.data"))
-#   expect_equal(GetAssayData(object = object, layer = "scale.data")[, Cells(x = g2)],
-#                GetAssayData(object = g2, layer = "scale.data"))
+#   expect_equal(LayerData(object = object, layer = "scale.data")[, Cells(x = g1)],
+#                LayerData(object = g1, layer = "scale.data"))
+#   expect_equal(LayerData(object = object, layer = "scale.data")[, Cells(x = g2)],
+#                LayerData(object = g2, layer = "scale.data"))
 # })
 
 g1 <- ScaleData(object = g1, features = rownames(x = g1), vars.to.regress = "nCount_RNA", verbose = FALSE)
@@ -248,10 +248,10 @@ suppressWarnings({
   })
 
 test_that("Linear regression works as expected", {
-  expect_equal(dim(x = GetAssayData(object = object[["RNA"]], layer = "scale.data")), c(10, 80))
-  expect_equal(GetAssayData(object = object[["RNA"]], layer = "scale.data")[1, 1], -0.6436435, tolerance = 1e-6)
-  expect_equal(GetAssayData(object = object[["RNA"]], layer = "scale.data")[5, 25], -0.09035383, tolerance = 1e-6)
-  expect_equal(GetAssayData(object = object[["RNA"]], layer = "scale.data")[10, 80], -0.2723782, tolerance = 1e-6)
+  expect_equal(dim(x = LayerData(object = object[["RNA"]], layer = "scale.data")), c(10, 80))
+  expect_equal(LayerData(object = object[["RNA"]], layer = "scale.data")[1, 1], -0.6436435, tolerance = 1e-6)
+  expect_equal(LayerData(object = object[["RNA"]], layer = "scale.data")[5, 25], -0.09035383, tolerance = 1e-6)
+  expect_equal(LayerData(object = object[["RNA"]], layer = "scale.data")[10, 80], -0.2723782, tolerance = 1e-6)
 })
 
 object <- ScaleData(
@@ -262,10 +262,10 @@ object <- ScaleData(
   model.use = "negbinom")
 
 test_that("Negative binomial regression works as expected", {
-  expect_equal(dim(x = GetAssayData(object = object[["RNA"]], layer = "scale.data")), c(10, 80))
-  expect_equal(GetAssayData(object = object[["RNA"]], layer = "scale.data")[1, 1], -0.5888811, tolerance = 1e-6)
-  expect_equal(GetAssayData(object = object[["RNA"]], layer = "scale.data")[5, 25], -0.2553394, tolerance = 1e-6)
-  expect_equal(GetAssayData(object = object[["RNA"]], layer = "scale.data")[10, 80], -0.1921429, tolerance = 1e-6)
+  expect_equal(dim(x = LayerData(object = object[["RNA"]], layer = "scale.data")), c(10, 80))
+  expect_equal(LayerData(object = object[["RNA"]], layer = "scale.data")[1, 1], -0.5888811, tolerance = 1e-6)
+  expect_equal(LayerData(object = object[["RNA"]], layer = "scale.data")[5, 25], -0.2553394, tolerance = 1e-6)
+  expect_equal(LayerData(object = object[["RNA"]], layer = "scale.data")[10, 80], -0.1921429, tolerance = 1e-6)
 })
 
 test_that("Regression error handling checks out", {
@@ -280,10 +280,10 @@ object <- ScaleData(
   model.use = "poisson")
 
 test_that("Poisson regression works as expected", {
-  expect_equal(dim(x = GetAssayData(object = object[["RNA"]], layer = "scale.data")), c(10, 80))
-  expect_equal(GetAssayData(object = object[["RNA"]], layer = "scale.data")[1, 1], -1.011717, tolerance = 1e-6)
-  expect_equal(GetAssayData(object = object[["RNA"]], layer = "scale.data")[5, 25], 0.05575307, tolerance = 1e-6)
-  expect_equal(GetAssayData(object = object[["RNA"]], layer = "scale.data")[10, 80], -0.1662119, tolerance = 1e-6)
+  expect_equal(dim(x = LayerData(object = object[["RNA"]], layer = "scale.data")), c(10, 80))
+  expect_equal(LayerData(object = object[["RNA"]], layer = "scale.data")[1, 1], -1.011717, tolerance = 1e-6)
+  expect_equal(LayerData(object = object[["RNA"]], layer = "scale.data")[5, 25], 0.05575307, tolerance = 1e-6)
+  expect_equal(LayerData(object = object[["RNA"]], layer = "scale.data")[10, 80], -0.1662119, tolerance = 1e-6)
 })
 
 
@@ -382,12 +382,12 @@ object <- suppressWarnings(SCTransform(object = object, verbose = FALSE, vst.fla
 
 test_that("SCTransform v1 works as expected", {
   expect_true("SCT" %in% names(object))
-  expect_equal(as.numeric(colSums(GetAssayData(object = object[["SCT"]], layer = "scale.data"))[1]), 11.40288448)
-  expect_equal(as.numeric(rowSums(GetAssayData(object = object[["SCT"]], layer = "scale.data"))[5]), 0)
-  expect_equal(as.numeric(colSums(GetAssayData(object = object[["SCT"]], layer = "data"))[1]), 57.7295742, tolerance = 1e-6)
-  expect_equal(as.numeric(rowSums(GetAssayData(object = object[["SCT"]], layer = "data"))[5]), 11.74403719, tolerance = 1e-6)
-  expect_equal(as.numeric(colSums(GetAssayData(object = object[["SCT"]], layer = "counts"))[1]), 129)
-  expect_equal(as.numeric(rowSums(GetAssayData(object = object[["SCT"]], layer = "counts"))[5]), 28)
+  expect_equal(as.numeric(colSums(LayerData(object = object[["SCT"]], layer = "scale.data"))[1]), 11.40288448)
+  expect_equal(as.numeric(rowSums(LayerData(object = object[["SCT"]], layer = "scale.data"))[5]), 0)
+  expect_equal(as.numeric(colSums(LayerData(object = object[["SCT"]], layer = "data"))[1]), 57.7295742, tolerance = 1e-6)
+  expect_equal(as.numeric(rowSums(LayerData(object = object[["SCT"]], layer = "data"))[5]), 11.74403719, tolerance = 1e-6)
+  expect_equal(as.numeric(colSums(LayerData(object = object[["SCT"]], layer = "counts"))[1]), 129)
+  expect_equal(as.numeric(rowSums(LayerData(object = object[["SCT"]], layer = "counts"))[5]), 28)
   expect_equal(length(VariableFeatures(object[["SCT"]])), 220)
   fa <- SCTResults(object = object, assay = "SCT", slot = "feature.attributes")
   expect_equal(fa["MS4A1", "detection_rate"], 0.15)
@@ -401,12 +401,12 @@ suppressWarnings(RNGversion(vstr = "3.5.0"))
 object <- suppressWarnings(SCTransform(object = object, vst.flavor = "v1", ncells = 80, verbose = FALSE, seed.use =  42))
 test_that("SCTransform ncells param works", {
   expect_true("SCT" %in% names(object))
-  expect_equal(as.numeric(colSums(GetAssayData(object = object[["SCT"]], layer = "scale.data"))[1]), 11.40288, tolerance = 1e-6)
-  expect_equal(as.numeric(rowSums(GetAssayData(object = object[["SCT"]], layer = "scale.data"))[5]), 0)
-  expect_equal(as.numeric(colSums(GetAssayData(object = object[["SCT"]], layer = "data"))[1]), 57.72957, tolerance = 1e-6)
-  expect_equal(as.numeric(rowSums(GetAssayData(object = object[["SCT"]], layer = "data"))[5]), 11.74404, tolerance = 1e-6)
-  expect_equal(as.numeric(colSums(GetAssayData(object = object[["SCT"]], layer = "counts"))[1]), 129)
-  expect_equal(as.numeric(rowSums(GetAssayData(object = object[["SCT"]], layer = "counts"))[5]), 28)
+  expect_equal(as.numeric(colSums(LayerData(object = object[["SCT"]], layer = "scale.data"))[1]), 11.40288, tolerance = 1e-6)
+  expect_equal(as.numeric(rowSums(LayerData(object = object[["SCT"]], layer = "scale.data"))[5]), 0)
+  expect_equal(as.numeric(colSums(LayerData(object = object[["SCT"]], layer = "data"))[1]), 57.72957, tolerance = 1e-6)
+  expect_equal(as.numeric(rowSums(LayerData(object = object[["SCT"]], layer = "data"))[5]), 11.74404, tolerance = 1e-6)
+  expect_equal(as.numeric(colSums(LayerData(object = object[["SCT"]], layer = "counts"))[1]), 129)
+  expect_equal(as.numeric(rowSums(LayerData(object = object[["SCT"]], layer = "counts"))[5]), 28)
   expect_equal(length(VariableFeatures(object[["SCT"]])), 220)
   fa <- SCTResults(object = object, assay = "SCT", slot = "feature.attributes")
   expect_equal(fa["MS4A1", "detection_rate"], 0.15)
@@ -417,13 +417,13 @@ test_that("SCTransform ncells param works", {
 })
 
 suppressWarnings(object[["SCT_SAVE"]] <- object[["SCT"]])
-object[["SCT"]] <- suppressWarnings({SetAssayData(object = object[["SCT"]], slot = "scale.data", new.data = GetAssayData(object = object[["SCT"]], layer = "scale.data")[1:100, ])})
+object[["SCT"]] <- suppressWarnings({SetAssayData(object = object[["SCT"]], layer = "scale.data", new.data = LayerData(object = object[["SCT"]], layer = "scale.data")[1:100, ])})
 object <- GetResidual(object = object, features = rownames(x = object), verbose = FALSE)
 test_that("GetResidual works", {
-  expect_equal(dim(GetAssayData(object = object[["SCT"]], layer = "scale.data")), c(220, 80))
+  expect_equal(dim(LayerData(object = object[["SCT"]], layer = "scale.data")), c(220, 80))
   expect_equal(
-    GetAssayData(object = object[["SCT"]], layer = "scale.data"),
-    GetAssayData(object = object[["SCT_SAVE"]], layer = "scale.data")
+    LayerData(object = object[["SCT"]], layer = "scale.data"),
+    LayerData(object = object[["SCT_SAVE"]], layer = "scale.data")
   )
   expect_warning(GetResidual(object, features = "asd"))
 })
@@ -435,12 +435,12 @@ test_that("SCTransform v2 works as expected", {
   object <- suppressWarnings(SCTransform(object = object, verbose = FALSE, vst.flavor = "v2",  seed.use = 1448145))
 
   expect_true("SCT" %in% names(object))
-  expect_equal(as.numeric(colSums(GetAssayData(object = object[["SCT"]], layer = "scale.data"))[1]), 24.5813, tolerance = 1e-4)
-  expect_equal(as.numeric(rowSums(GetAssayData(object = object[["SCT"]], layer = "scale.data"))[5]), 0)
-  expect_equal(as.numeric(colSums(GetAssayData(object = object[["SCT"]], layer = "data"))[1]), 58.65829, tolerance = 1e-6)
-  expect_equal(as.numeric(rowSums(GetAssayData(object = object[["SCT"]], layer = "data"))[5]), 13.75449, tolerance = 1e-6)
-  expect_equal(as.numeric(colSums(GetAssayData(object = object[["SCT"]], layer = "counts"))[1]), 141)
-  expect_equal(as.numeric(rowSums(GetAssayData(object = object[["SCT"]], layer = "counts"))[5]), 40)
+  expect_equal(as.numeric(colSums(LayerData(object = object[["SCT"]], layer = "scale.data"))[1]), 24.5813, tolerance = 1e-4)
+  expect_equal(as.numeric(rowSums(LayerData(object = object[["SCT"]], layer = "scale.data"))[5]), 0)
+  expect_equal(as.numeric(colSums(LayerData(object = object[["SCT"]], layer = "data"))[1]), 58.65829, tolerance = 1e-6)
+  expect_equal(as.numeric(rowSums(LayerData(object = object[["SCT"]], layer = "data"))[5]), 13.75449, tolerance = 1e-6)
+  expect_equal(as.numeric(colSums(LayerData(object = object[["SCT"]], layer = "counts"))[1]), 141)
+  expect_equal(as.numeric(rowSums(LayerData(object = object[["SCT"]], layer = "counts"))[5]), 40)
   expect_equal(length(VariableFeatures(object[["SCT"]])), 220)
   fa <- SCTResults(object = object, assay = "SCT", slot = "feature.attributes")
   expect_equal(fa["MS4A1", "detection_rate"], 0.15)
@@ -472,7 +472,7 @@ test_that("SCTransform `clip.range` param works as expected", {
   expect_true(min(scale.data) >= clip.min)
   expect_true(max(scale.data) <= (clip.max + clip.max.tolerance))
 
-  # when `ncells` is less than the size of the dataset the residuals will get 
+  # when `ncells` is less than the size of the dataset the residuals will get
   # re-clipped in batches, make sure this clipping is done correctly as well
   test.result <- suppressWarnings(
     SCTransform(
@@ -499,8 +499,8 @@ test_that("SCTransform `vars.to.regress` param works as expected", {
     pattern="^MT-"
   )
 
-  # make sure that `ncells` is smaller than the datset being transformed 
-  # so tha the regression model is trained on a subset of the data - make sure 
+  # make sure that `ncells` is smaller than the datset being transformed
+  # so tha the regression model is trained on a subset of the data - make sure
   # the regression is applied to the entire dataset
   left <- suppressWarnings(
       SCTransform(
@@ -558,19 +558,19 @@ object2 <- CreateSeuratObject(counts = pbmc.test,
 
 test_that("`SCTransform` is consistent for multi-layer inputs", {
   clip.range = c(-1.632993, 1.632993)
-  
+
   test_case_v3 <- SplitObject(object2, split.by = "Condition")
   result_v3_list <- lapply(test_case_v3, SCTransform, clip.range = clip.range)
   result_v3 <- merge(result_v3_list[[1]], result_v3_list[[2]])
-  
+
   test_case_v5 <- object2
   test_case_v5 <- split(object2, f = object2$Condition)
   result_v5 <- SCTransform(test_case_v5, clip.range = clip.range)
-  
+
   expected <- result_v3[["SCT"]]@data[,colnames(object2)]
   result <- result_v5[["SCT"]]@data[,colnames(object2)]
   expect_true(all.equal(expected, result))
-  
+
   expected <- result_v3[["SCT"]]@scale.data[,colnames(object2)]
   result <- result_v5[["SCT"]]@scale.data[,colnames(object2)]
   expect_true(all.equal(expected[rownames(result), ], result))

--- a/tests/testthat/test_transferdata.R
+++ b/tests/testthat/test_transferdata.R
@@ -6,7 +6,7 @@ pbmc_small <- suppressWarnings(UpdateSeuratObject(pbmc_small))
 ref <- pbmc_small
 query <- CreateSeuratObject(
   counts = as.sparse(
-    GetAssayData(
+    LayerData(
       object = pbmc_small[['RNA']],
       layer = "counts") + rpois(n = ncol(pbmc_small),
       lambda = 1
@@ -34,14 +34,14 @@ test_that("TransferData default work", {
   expect_equal(as.vector(rowSums(as.matrix(preds.standard[, 2:4]))), rep(1, times = ncol(query)))
   expect_true(inherits(preds.standard, "data.frame"))
   # continuous assay data
-  pred.assay <- TransferData(anchorset = anchors, refdata = GetAssayData(ref[["RNA"]]), verbose = FALSE)
+  pred.assay <- TransferData(anchorset = anchors, refdata = LayerData(ref[["RNA"]]), verbose = FALSE)
   expect_equal(dim(pred.assay), c(230, 80))
-  expect_equal(GetAssayData(pred.assay, layer = "counts"), new("matrix"))
-  expect_equal(GetAssayData(pred.assay, layer = "scale.data"), new("matrix"))
+  expect_equal(LayerData(pred.assay, layer = "counts"), new("matrix"))
+  expect_equal(LayerData(pred.assay, layer = "scale.data"), new("matrix"))
   expect_equal(colnames(pred.assay), Cells(query))
   expect_equal(rownames(pred.assay), rownames(ref[["RNA"]]))
-  expect_equal(sum(GetAssayData(pred.assay)[1, ]), 64.46388, tolerance = 1e-6)
-  expect_equal(sum(GetAssayData(pred.assay)[, 1]), 281.0306, tolerance = 1e-6)
+  expect_equal(sum(LayerData(pred.assay)[1, ]), 64.46388, tolerance = 1e-6)
+  expect_equal(sum(LayerData(pred.assay)[, 1]), 281.0306, tolerance = 1e-6)
   expect_true(inherits(pred.assay, "Assay"))
   expect_equal(pred.assay@var.features, logical(0))
   expect_equal(ncol(pred.assay@meta.features), 0)
@@ -51,14 +51,14 @@ test_that("TransferData can return predictions assay, ", {
   pred.assay <- TransferData(anchorset = anchors, refdata = ref$RNA_snn_res.1, prediction.assay = TRUE, verbose = FALSE)
   expect_true(inherits(pred.assay, "Assay"))
   expect_equal(dim(pred.assay), c(4, 80))
-  expect_equal(GetAssayData(pred.assay, layer = "counts"), new("matrix"))
-  expect_equal(GetAssayData(pred.assay, layer = "scale.data"), new("matrix"))
+  expect_equal(LayerData(pred.assay, layer = "counts"), new("matrix"))
+  expect_equal(LayerData(pred.assay, layer = "scale.data"), new("matrix"))
   expect_equal(colnames(pred.assay), Cells(query))
   expect_equal(pred.assay@var.features, logical(0))
   expect_equal(ncol(pred.assay@meta.features), 0)
-  expect_equal(sum(GetAssayData(pred.assay)[1, ]), 26.59365, tolerance = 1e-6)
-  expect_equal(sum(GetAssayData(pred.assay)[, 1]), 1.428075, tolerance = 1e-6)
-  expect_equal(as.vector(colSums(GetAssayData(pred.assay)[1:3, ])), rep(1, ncol(query)))
+  expect_equal(sum(LayerData(pred.assay)[1, ]), 26.59365, tolerance = 1e-6)
+  expect_equal(sum(LayerData(pred.assay)[, 1]), 1.428075, tolerance = 1e-6)
+  expect_equal(as.vector(colSums(LayerData(pred.assay)[1:3, ])), rep(1, ncol(query)))
 })
 
 test_that("TransferData handles weight.reduction properly, ", {
@@ -76,7 +76,7 @@ test_that("TransferData handles weight.reduction properly, ", {
   # weight.reduction = "pca
   pca.preds <- suppressWarnings(TransferData(anchorset = anchors, refdata = ref$RNA_snn_res.1, query = query, weight.reduction = "pca", verbose = FALSE))
   expect_true(inherits(pca.preds, "Seurat"))
-  expect_equal(sum(GetAssayData(pca.preds[['prediction.score.id']])[1, ]), 27.83330252, tolerance = 1e-6)
+  expect_equal(sum(LayerData(pca.preds[['prediction.score.id']])[1, ]), 27.83330252, tolerance = 1e-6)
   # weight.reduction = "cca"
   anchors.cca <- FindTransferAnchors(reference = ref, query = query, k.filter = 50, reduction = "cca")
   cca.preds <- TransferData(anchorset = anchors.cca, refdata = ref$RNA_snn_res.1, weight.reduction = "cca", verbose = FALSE)
@@ -127,7 +127,7 @@ test_that("TransferData throws expected errors ", {
 test_that("TransferData with multiple items to transfer works ", {
   skip_on_cran()
   preds <- TransferData(anchorset = anchors, refdata = list(
-    ids = ref$RNA_snn_res.1, groups = ref$groups, dat = GetAssayData(ref[["RNA"]])),
+    ids = ref$RNA_snn_res.1, groups = ref$groups, dat = LayerData(ref[["RNA"]])),
     verbose = FALSE)
   expect_equal(length(preds), 3)
   expect_equal(preds[[1]], preds.standard)


### PR DESCRIPTION
Hi Seurat Team (@YoukaiFromAccounting),

Sorry for the mess of canceled PRs here.  But this one should be good.

This is slimmed down update to #9905 based on comments from @YoukaiFromAccounting.  The changes here are only to replace `GetAssayData`/`SetAssayData` with `LayerData` and to replace slot parameter with layer in `FetchData` while avoiding any top-level parameter changes.  

If it is of interest I'm also happy to take stab at doing the top-level changes and updating the vignettes/tutorials in future update after v5.3.1 is released, so just let me know.

Best,
Sam
