### PR TITLE
Fix SpecificDimPlot when call includes Seurat::

### DIFF
--- a/R/convenience.R
+++ b/R/convenience.R
@@ -442,6 +442,8 @@ SpecificDimPlot <- function(object, ...) {
   funs <- sys.calls()
   name <- as.character(x = funs[[length(x = funs) - 1]])[1]
   name <- tolower(x = gsub(pattern = 'Plot', replacement = '', x = name))
+  # add second gsub to check if Seurat:: is called
+  name <- gsub(pattern = "^seurat::", replacement = "", x = name)
   args <- list('object' = object)
   args <- c(args, list(...))
   reduc <- grep(


### PR DESCRIPTION
Hi Seurat Team,

This is one line fix to address #9909.  It just adds a second `gsub` call to check if function call is being passed with `Seurat::`.

I merged this with fix/5.3.1 per previous PRs since this is quick and easy one but can change to main if preferable.

Thanks as always!
Sam
