### PR TITLE
Add support for Xenium protein data

### DIFF
--- a/R/convenience.R
+++ b/R/convenience.R
@@ -260,7 +260,8 @@ LoadXenium <- function(
     `Unassigned Codeword` = 'BlankCodeword',
     `Negative Control Codeword` = 'ControlCodeword',
     `Negative Control Probe` = 'ControlProbe',
-    `Genomic Control` = 'GenomicControl'
+    `Genomic Control` = 'GenomicControl',
+    `Protein Expression` = 'ProteinExpression'
   )
 
   xenium.obj <- CreateSeuratObject(counts = data$matrix[["Gene Expression"]], assay = assay)


### PR DESCRIPTION
- Xenium 4.0 will produce a new feature type called "Protein Expression"
- In order to limit breakage of downstream tools, it stores values as integers multiplied by 10 (essentially fixed point).
- This scaling factor is stored in the HDF5 file as an attribute called `protein_scaling_factor`
- This PR loads the new feature type and applies the scaling factor when it is available.

<!--
Thanks for your interest in contributing! 

Please refer the contributor's guide for instructions on submitting a pull request:
https://github.com/satijalab/seurat/wiki#contributors-guide
-->
