### PR TITLE
Add stroke.size to FeaturePlot

### DIFF
--- a/R/visualization.R
+++ b/R/visualization.R
@@ -1021,6 +1021,7 @@ DimPlot <- function(
 #' }
 #' @param min.cutoff,max.cutoff Vector of minimum and maximum cutoff values for each feature,
 #'  may specify quantile in the form of 'q##' where '##' is the quantile (eg, 'q1', 'q10')
+#' @param stroke.size Adjust stroke (outline) size of points
 #' @param split.by A factor in object metadata to split the plot by, pass 'ident'
 #' to split by cell identity
 #' @param keep.scale How to handle the color scale across multiple plots. Options are:
@@ -1085,6 +1086,7 @@ FeaturePlot <- function(
   },
   pt.size = NULL,
   alpha = 1,
+  stroke.size = NULL,
   order = FALSE,
   min.cutoff = NA,
   max.cutoff = NA,
@@ -1347,6 +1349,7 @@ FeaturePlot <- function(
         order = order,
         pt.size = pt.size,
         alpha = alpha,
+        stroke.size = stroke.size,
         cols = cols.use,
         shape.by = shape.by,
         label = FALSE,

--- a/man/FeaturePlot.Rd
+++ b/man/FeaturePlot.Rd
@@ -18,6 +18,7 @@ FeaturePlot(
  },
   pt.size = NULL,
   alpha = 1,
+  stroke.size = NULL,
   order = FALSE,
   min.cutoff = NA,
   max.cutoff = NA,
@@ -71,6 +72,8 @@ When blend is \code{TRUE}, takes anywhere from 1-3 colors:
 \item{pt.size}{Adjust point size for plotting}
 
 \item{alpha}{Alpha value for plotting (default is 1)}
+
+\item{stroke.size}{Adjust stroke (outline) size of points}
 
 \item{order}{Boolean determining whether to plot cells in order of expression. Can be useful if
 cells expressing given feature are getting buried.}


### PR DESCRIPTION
## Summary

This PR adds support for the `stroke.size` parameter in `FeaturePlot`, consistent with its existing use in `DimPlot`. This enhancement allows finer control over point outlines, which is especially useful when visualizing datasets with a large number of cells — in such cases, points can appear cluttered or difficult to distinguish when strokes are applied.

### Example

Below is a comparison demonstrating how setting `stroke.size = 0` works on practice:

```R
fp1 <- FeaturePlot(pbmc, features = c("MS4A1", "GNLY", "CD3E", "CD14"), stroke.size = 0)
fp2 <- FeaturePlot(pbmc, features = c("MS4A1", "GNLY", "CD3E", "CD14"))

fp1 | fp2
```

<img width="1247" height="744" alt="image" src="https://github.com/user-attachments/assets/05615b49-b4b6-4a37-912b-4b5eff99b1c4" />

This PR addresses #7087 

Let me know if you want me to put the argument in different order