### PR TITLE
Fix for #10074 providing multiple resolutions to `FindClusters`

### DIFF
--- a/R/clustering.R
+++ b/R/clustering.R
@@ -497,7 +497,7 @@ FindClusters.Seurat <- function(
 
   # If cluster name is NULL, default cluster name is used (seurat_clusters) when assigning factor levels
   # Otherwise, use cluster name provided by user
-  if (all(cluster.name %in% default.cluster.name)) {
+  if (isTRUE(x = all(cluster.name %in% default.cluster.name))) {
     object[['seurat_clusters']] <- Idents(object = object)
   } else {
     object[[cluster.name]] <- Idents(object = object)


### PR DESCRIPTION
Hi Seurat Team,

This is quick fix for issue #10074.  Changes in the 5.3.1 dev branch resulted in error when providing multiple resolutions to `FindClusters`.  Just a simple swap to account for number of names being length greater than 1:

```
if (cluster.name == default.cluster.name)
```
for
```
if (isTRUE(x = all(cluster.name %in% default.cluster.name)))
```

Thanks as always!
Best,
Sam