### PR TITLE
Fix incorrect alpha parameter being used for SpatialFeature plots

### DIFF
--- a/R/visualization.R
+++ b/R/visualization.R
@@ -9501,73 +9501,63 @@ SingleSpatialPlot <- function(
       #Plot (currently independently of switch/case)
       if(!plot_segmentations){
         #If plot_segmentations FALSE, then plot just the centroids from sf data
-        if(is.null(pt.alpha)){
+        
+        if (is.null(pt.alpha)) {
           #If pt.alpha not provided, then alpha parameter is derived from group/cluster data
           #Use alpha.by instead of pt.alpha
-          ggplot(sf.cleaned, aes(x = x, y = y)) +
-            annotation_custom(
-                grob = image.grob,
-                xmin = 0,
-                xmax = image.width,
-                ymin = 0,
-                ymax = image.height
-              ) +
-            geom_point(
-                shape = 21, 
-                stroke = stroke, 
-                size=pt.size.factor, 
-                aes_string(fill = col.by, alpha = alpha.by)
-              ) +
-            coord_fixed() +
-            xlab("x") +
-            ylab("y") +
-            theme_minimal()
-        }else{
+          geom_point_layer <- geom_point(
+            shape = 21, 
+            stroke = stroke, 
+            size = pt.size.factor, 
+            aes_string(fill = col.by, alpha = alpha.by)
+          )
+        } else {
           #If pt.alpha is indeed provided, then use that to define alpha
-          ggplot(sf.cleaned, aes(x = x, y = y)) +
-            annotation_custom(
-                grob = image.grob,
-                xmin = 0,
-                xmax = image.width,
-                ymin = 0,
-                ymax = image.height
-              ) +
-              geom_point(shape = 21, 
-              stroke = stroke, 
-              size=pt.size.factor, 
-              aes_string(fill = col.by), 
-              alpha = if (is.null(pt.alpha)) 1 else pt.alpha
-            ) +
-            coord_fixed() +
-            xlab("x") +
-            ylab("y") +
-            theme_minimal()
+          geom_point_layer <- geom_point(
+            shape = 21,
+            stroke = stroke,
+            size = pt.size.factor,
+            aes_string(fill = col.by), 
+            alpha = if (is.null(pt.alpha)) 1 else pt.alpha
+          )
         }
+        ggplot(sf.cleaned, aes(x = x, y = y)) +
+          annotation_custom(
+              grob = image.grob,
+              xmin = 0,
+              xmax = image.width,
+              ymin = 0,
+              ymax = image.height
+            ) +
+          geom_point_layer +
+          coord_fixed() +
+          xlab("x") +
+          ylab("y") +
+          theme_minimal()
+      
       }else{
         #If plot_segmentations TRUE, then use geometry data stored in sf to plot cell polygons
-        if(is.null(pt.alpha)){
+        
+        if (is.null(pt.alpha)) {
           #If pt.alpha not provided, then alpha parameter is derived from group/cluster data
           #Use alpha.by instead of pt.alpha
-          ggplot() +
-            annotation_custom(
-              grob = image.grob,
-              xmin = 0,
-              xmax = image.width,
-              ymin = 0,
-              ymax = image.height
-            ) +
-            geom_sf(
-              data = sf.cleaned,
-              aes_string(fill = col.by, alpha = alpha.by),
-              color = "black",
-              linewidth = stroke
-            ) +
-            scale_fill_viridis_d(option = "plasma") +
-            coord_sf() +
-            theme_void()
-        }else{
+          geom_sf_layer <- geom_sf(
+            data = sf.cleaned,
+            aes_string(fill = col.by, alpha = alpha.by),
+            color = "black",
+            linewidth = stroke
+          )
+        } else {
           #If pt.alpha is indeed provided, then use that to define alpha
-          ggplot() +
+          geom_sf_layer <- geom_sf(
+            data = sf.cleaned,
+            aes_string(fill = col.by),
+            alpha = if (is.null(pt.alpha)) 1 else pt.alpha,
+            color = "black",
+            linewidth = stroke
+          ) 
+        }
+        ggplot() +
             annotation_custom(
               grob = image.grob,
               xmin = 0,
@@ -9575,17 +9565,10 @@ SingleSpatialPlot <- function(
               ymin = 0,
               ymax = image.height
             ) +
-            geom_sf(
-              data = sf.cleaned,
-              aes_string(fill = col.by),
-              alpha = if (is.null(pt.alpha)) 1 else pt.alpha,
-              color = "black",
-              linewidth = stroke
-            ) +
+            geom_sf_layer +
             scale_fill_viridis_d(option = "plasma") +
             coord_sf() +
             theme_void()
-        }
       }
     },
     'poly' = {

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -9512,7 +9512,12 @@ SingleSpatialPlot <- function(
                 ymin = 0,
                 ymax = image.height
               ) +
-            geom_point(shape = 21, stroke = stroke, size=pt.size.factor, aes_string(fill = col.by, alpha = alpha.by)) +
+            geom_point(
+                shape = 21, 
+                stroke = stroke, 
+                size=pt.size.factor, 
+                aes_string(fill = col.by, alpha = alpha.by)
+              ) +
             coord_fixed() +
             xlab("x") +
             ylab("y") +
@@ -9527,7 +9532,12 @@ SingleSpatialPlot <- function(
                 ymin = 0,
                 ymax = image.height
               ) +
-            geom_point(shape = 21, stroke = stroke, size=pt.size.factor, aes_string(fill = col.by), alpha = if (is.null(pt.alpha)) 1 else pt.alpha) +
+              geom_point(shape = 21, 
+              stroke = stroke, 
+              size=pt.size.factor, 
+              aes_string(fill = col.by), 
+              alpha = if (is.null(pt.alpha)) 1 else pt.alpha
+            ) +
             coord_fixed() +
             xlab("x") +
             ylab("y") +
@@ -9552,7 +9562,7 @@ SingleSpatialPlot <- function(
               color = "black",
               linewidth = stroke
             ) +
-            scale_fill_viridis_d(option = "plasma", alpha = 0.5) +
+            scale_fill_viridis_d(option = "plasma") +
             coord_sf() +
             theme_void()
         }else{
@@ -9572,7 +9582,7 @@ SingleSpatialPlot <- function(
               color = "black",
               linewidth = stroke
             ) +
-            scale_fill_viridis_d(option = "plasma", alpha = 0.5) +
+            scale_fill_viridis_d(option = "plasma") +
             coord_sf() +
             theme_void()
         }

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -9500,39 +9500,82 @@ SingleSpatialPlot <- function(
       sf.cleaned <- st_sf(sf.cleaned %>% st_drop_geometry(), geometry = st_sfc(geom_flipped, crs = st_crs(NA)))
       #Plot (currently independently of switch/case)
       if(!plot_segmentations){
-        #Plot just the centroids as points
-        ggplot(sf.cleaned, aes(x = x, y = y)) +
-          annotation_custom(
+        #If plot_segmentations FALSE, then plot just the centroids from sf data
+        if(is.null(pt.alpha)){
+          #If pt.alpha not provided, then alpha parameter is derived from group/cluster data
+          #Use alpha.by instead of pt.alpha
+          ggplot(sf.cleaned, aes(x = x, y = y)) +
+            annotation_custom(
+                grob = image.grob,
+                xmin = 0,
+                xmax = image.width,
+                ymin = 0,
+                ymax = image.height
+              ) +
+            geom_point(shape = 21, stroke = stroke, size=pt.size.factor, aes_string(fill = col.by, alpha = alpha.by)) +
+            coord_fixed() +
+            xlab("x") +
+            ylab("y") +
+            theme_minimal()
+        }else{
+          #If pt.alpha is indeed provided, then use that to define alpha
+          ggplot(sf.cleaned, aes(x = x, y = y)) +
+            annotation_custom(
+                grob = image.grob,
+                xmin = 0,
+                xmax = image.width,
+                ymin = 0,
+                ymax = image.height
+              ) +
+            geom_point(shape = 21, stroke = stroke, size=pt.size.factor, aes_string(fill = col.by), alpha = if (is.null(pt.alpha)) 1 else pt.alpha) +
+            coord_fixed() +
+            xlab("x") +
+            ylab("y") +
+            theme_minimal()
+        }
+      }else{
+        #If plot_segmentations TRUE, then use geometry data stored in sf to plot cell polygons
+        if(is.null(pt.alpha)){
+          #If pt.alpha not provided, then alpha parameter is derived from group/cluster data
+          #Use alpha.by instead of pt.alpha
+          ggplot() +
+            annotation_custom(
               grob = image.grob,
               xmin = 0,
               xmax = image.width,
               ymin = 0,
               ymax = image.height
             ) +
-          geom_point(shape = 21, stroke = stroke, size=pt.size.factor, aes_string(fill = col.by), alpha = if (is.null(pt.alpha)) 1 else pt.alpha) +
-          coord_fixed() +
-          xlab("x") +
-          ylab("y") +
-          theme_minimal()
-      }else{
-        ggplot() +
-          annotation_custom(
-            grob = image.grob,
-            xmin = 0,
-            xmax = image.width,
-            ymin = 0,
-            ymax = image.height
-          ) +
-          geom_sf(
-            data = sf.cleaned,
-            aes_string(fill = col.by),
-            alpha = if (is.null(pt.alpha)) 1 else pt.alpha,
-            color = "black",
-            linewidth = stroke
-          ) +
-          scale_fill_viridis_d(option = "plasma", alpha = 0.5) +
-          coord_sf() +
-          theme_void()
+            geom_sf(
+              data = sf.cleaned,
+              aes_string(fill = col.by, alpha = alpha.by),
+              color = "black",
+              linewidth = stroke
+            ) +
+            scale_fill_viridis_d(option = "plasma", alpha = 0.5) +
+            coord_sf() +
+            theme_void()
+        }else{
+          #If pt.alpha is indeed provided, then use that to define alpha
+          ggplot() +
+            annotation_custom(
+              grob = image.grob,
+              xmin = 0,
+              xmax = image.width,
+              ymin = 0,
+              ymax = image.height
+            ) +
+            geom_sf(
+              data = sf.cleaned,
+              aes_string(fill = col.by),
+              alpha = if (is.null(pt.alpha)) 1 else pt.alpha,
+              color = "black",
+              linewidth = stroke
+            ) +
+            scale_fill_viridis_d(option = "plasma", alpha = 0.5) +
+            coord_sf() +
+            theme_void()
+        }
       }
     },
     'poly' = {


### PR DESCRIPTION
# Issues

The following issues have been reported at:
- https://github.com/satijalab/seurat/issues/10076

## Issue 1

SingleSpatialPlot plots transparency in cells using the _alpha_ parameter. This parameter is derived in two different ways:

For DimPlots, alpha is set to be equal to pt.alpha, which is a number between 0 and 1. 

For FeaturePlots, alpha is set to be equal to alpha.by, which is set to be name of a feature (ie: alpha.by = "rho"). Then, when plotting feature plots, ggplot uses the actual values in this feature column (ie: rho expression levels), scaled between the alpha range provided (0-1) to plot the alphas. 

For objects containing sf.data, plotting was previously done only using pt.alpha. This meant that for FeaturePlots, it was not possible to set the alpha levels of cells. This fix addresses this issue by adding a check for alpha.by for plotting of objects containing sf.data; if alpha.by is found, then the plot is a FeaturePlot and ggplot will use alpha.by instead of pt.alpha to define cell transparency. 

<img width="337" height="375" alt="image" src="https://github.com/user-attachments/assets/6c3aa852-b90d-479a-ab72-50ec37cb82a5" />

With this fix, the following should work:
- SpatialDimPlot with alpha range defined (ie: c(0.2-0.6)), plot_segmentations = TRUE
- SpatialDimPlot with alpha range defined, plot_segmentations = FALSE
- SpatialFeaturePlot with alpha range defined, plot_segmentations = TRUE
- SpatialFeaturePlot with alpha range defined, plot_segmentations = FALSE
