### PR TITLE
Fix incorrect box colors when `DimPlot()` with `split.by` and `label.box`

### DIFF
--- a/R/visualization.R
+++ b/R/visualization.R
@@ -5834,7 +5834,7 @@ LabelClusters <- function(
       mapping = aes_string(x = xynames['x'], y = xynames['y'], label = id, fill = id),
       show.legend = FALSE,
       ...
-    ) + scale_fill_manual(values = labels.loc$color[order(labels.loc[, id])])
+    ) + scale_fill_manual(values = labels.loc$color[!duplicated(labels.loc[, id])])
   } else {
     geom.use <- ifelse(test = repel, yes = geom_text_repel, no = geom_text)
     plot <- plot + geom.use(

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -5834,7 +5834,7 @@ LabelClusters <- function(
       mapping = aes_string(x = xynames['x'], y = xynames['y'], label = id, fill = id),
       show.legend = FALSE,
       ...
-    ) + scale_fill_manual(values = labels.loc$color[!duplicated(labels.loc[, id])])
+    ) + scale_fill_manual(values = unique(labels.loc$color[order(labels.loc[, id])]))
   } else {
     geom.use <- ifelse(test = repel, yes = geom_text_repel, no = geom_text)
     plot <- plot + geom.use(


### PR DESCRIPTION
Due to improper color vector handling with splited `DimPlot()`, the color of `label.box` can look funny with `split.by`.
Example: `SeuratObject::pbmc_small |> DimPlot(label = T, label.box = T, split.by = 'groups')`
<img width="716" height="491" alt="before_correction" src="https://github.com/user-attachments/assets/9a974256-3a28-4522-ad7e-28aadb1da959" />

It can be fixed with adding an `unique()` function to group-duplicated color vector.
<img width="716" height="491" alt="after_correction" src="https://github.com/user-attachments/assets/9595fa70-9201-47e8-9a5e-d4cf723e70ce" />

