### PR TITLE
Fix to have Load10X_Spatial recognize use.names for segmented data

### DIFF
--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -693,7 +693,7 @@ Load10X_Spatial <- function (
     }
 
     # Read raw counts matrix
-    segmentation.counts <- Read10X_h5(seg.counts.path)
+    segmentation.counts <- Read10X_h5(seg.counts.path, ...)
 
     # Holds barcode names
     segmentation.counts.cell.ids <- colnames(segmentation.counts)


### PR DESCRIPTION
Currently, Load10X_Spatial will not pass the use.names argument when loading segmented data.   The result is that feature IDs are always gene symbols regardless if use.names is set or not.  This fix updates the Load10X_Spatial function so that use.names will be passed to Read10X_h5 when loading segmented data.