### PR TITLE
Add InteractiveSpatialPlot functionality to select clusters/visualize sf objects correctly

### DIFF
--- a/R/visualization.R
+++ b/R/visualization.R
@@ -4038,7 +4038,7 @@ InteractiveSpatialPlot <- function(
     "Cell: ", coords$cell,
     "<br>x: ", round(coords$x_raw, 1),
     ", y: ", round(coords$y_raw, 1),
-    if(group.by != "all") paste0("<br>Cluster: ", coords$group) else ""
+    if (group.by != "all") paste0("<br>Cluster: ", coords$group) else ""
   )
 
   # Prepare background tissue image as a base64-encoded PNG (if available and enabled)


### PR DESCRIPTION
# Issues

The following issues have been reported at:
- https://github.com/satijalab/seurat/issues/10070

## Issue 1

Currently, 10x spatial objects loaded in from a segmented_outputs folder contain cellular coordinates that are in a different coordinate space than those loaded in from a binned_outputs folder. These objects would be plotted incorrectly within InteractiveSpatialPlot, which has lead to confusion when trying to subset cells about the actual position of cellular regions.

Example of InteractiveSpatialPlot on segmented_outputs-loaded Visium objects:

<img width="372" height="349" alt="image" src="https://github.com/user-attachments/assets/17bab783-d5ed-4d96-bac7-b1d90b07e131" />

This fix addresses this issue by simply swapping the x and y plotting axes when detecting an object with a non-empty sf_data slot, which should ensure that all objects that are loaded using segmented_outputs use their correct coordinate systems when plotting interactively.

## Enhancement 1

Previously, users could use the "Interactive" flag on the SpatialDimPlot and SpatialFeaturePlot functions to obtain a selectable spatial object, from which they could select all the cells from a cluster by double-clicking a cell from that cluster. We have extended this functionality to InteractiveSpatialPlot, allowing users to both lasso cells of interest or double-click on cells within a cluster to automatically select all cells within that cluster. 


**Reproducible Example** (this example should allow you to test interactively selecting all cells from within a cluster)
<img width="433" height="374" alt="image" src="https://github.com/user-attachments/assets/84af653b-1dcc-4a3c-83b8-987578f8fa86" />

```{R}
obj <- SeuratData::LoadData("stxBrain", type = "anterior1")
obj <- SCTransform(obj, assay = "Spatial", verbose = FALSE)

obj <- RunPCA(obj, assay = "SCT", verbose = FALSE)
obj <- FindNeighbors(obj, reduction = "pca", dims = 1:30)
obj <- FindClusters(obj, verbose = FALSE)
obj <- RunUMAP(obj, reduction = "pca", dims = 1:30)

cluster_of_interest <- InteractiveSpatialPlot(obj, pt.size.factor = 3, alpha=0.7)
```

With this fix, the following should work:
- Correctly visualizing Seurat objects loaded in from segmented_outputs in InteractiveSpatialPlot
- Selecting all cells from a cluster using InteractiveSpatialPlot
- Previous InteractiveSpatialPlots involving other datasets (ie: Visium V2, Xenium) are unchanged