### PR TITLE
Fix colouring by cells.highlight in SingleSpatialPlot

### DIFF
--- a/R/visualization.R
+++ b/R/visualization.R
@@ -9463,13 +9463,7 @@ SingleSpatialPlot <- function(
     warning("Cannot find '", col.by, "' in data, not coloring", call. = FALSE, immediate. = TRUE)
     col.by <- NULL
   }
-  col.by.plot <- col.by %iff% data_sym(col.by) #had to create second variable to safely use tidyeval in plotting but not effect subsetting in gsub call later in function
-  col.by <- col.by %iff% paste0("`", col.by, "`")
 
-  # Store unquoted col.by name for easier access
-  col.by.clean <- gsub("`", "", col.by)
-
-  alpha.by <- alpha.by %iff% data_sym(alpha.by)
   if (!is.null(x = cells.highlight)) {
     highlight.info <- SetHighlight(
       cells.highlight = cells.highlight,
@@ -9484,6 +9478,14 @@ SingleSpatialPlot <- function(
     levels(x = data$ident) <- c(order, setdiff(x = levels(x = data$ident), y = order))
     data <- data[order(data$ident), ]
   }
+  col.by.plot <- col.by %iff% data_sym(col.by) #had to create second variable to safely use tidyeval in plotting but not effect subsetting in gsub call later in function
+  col.by <- col.by %iff% paste0("`", col.by, "`")
+
+  # Store unquoted col.by name for easier access
+  col.by.clean <- gsub("`", "", col.by)
+
+  alpha.by <- alpha.by %iff% data_sym(alpha.by)
+
   plot <- ggplot(data = data, aes(
     x = .data[[colnames(x = data)[2]]],
     y = .data[[colnames(x = data)[1]]],


### PR DESCRIPTION
Minor fix in SingleSpatialPlot logic; previously, the variable **col.by.plot** was created from the original col.by value (variable critical for determining which data column is used for colouring cell points). However, with the shift of plotting functions to support ggplot2 v4.0.0 (https://github.com/satijalab/seurat/pull/10116), col.by.plot was introduced to safely use tidyeval syntax in ggplot aesthetics without affecting downstream string operations.

### Error

Previously, when cells.highlight is specified in plotting, the function SingleSpatialPlot creates a new "highlight" column in the data and updates col.by <- "highlight". However, since col.by.plot was already created from the original col.by value, it never reflected this change. This would result in cryptic plotting errors like:
```{R}
Error in `palette()`:
! Insufficient values in manual scale. 14 needed but only 2 provided.
```

### Fix 
Moved the cells.highlight handling block to execute before creating col.by.plot, ensuring both variables reference the same column name and synchronizing plot aesthetics and color scales.