### PR TITLE
Change default value of verbose parameter for LeverageScore within sketchdata

### DIFF
--- a/R/sketching.R
+++ b/R/sketching.R
@@ -82,7 +82,7 @@ SketchData <- function(
       var.name = var.name,
       over.write = over.write,
       seed = seed,
-      verbose = FALSE,
+      verbose = verbose,
       features = features,
       ...
     )


### PR DESCRIPTION
Change default value of verbose parameter for LeverageScore to use the supplied verbose. Otherwise, user will have no idea of the process especially when the sample size is large.

<!--
Thanks for your interest in contributing! 

Please refer the contributor's guide for instructions on submitting a pull request:
https://github.com/satijalab/seurat/wiki#contributors-guide
-->
