### PR TITLE
Fix Issue #10152: aes_string associated

### DIFF
--- a/R/visualization.R
+++ b/R/visualization.R
@@ -4502,7 +4502,7 @@ SpatialPlot <- function(
       )
 
       #Check if object contains a sf slot (attached via Load10X_Spatial)
-      #If so, use sf-geometry based rendering 
+      #If so, use sf-geometry based rendering
       use_geom_sf <- (inherits(image.use, "VisiumV2") &&
                       !is.null(image.use@boundaries$segmentation) &&
                       "sf.data" %in% slotNames(image.use@boundaries$segmentation))
@@ -8918,7 +8918,7 @@ SingleExIPlot <- function(
   switch(
     EXPR = type,
     'violin' = {
-      x <- 'ident'
+      x <- data_sym("ident")
       y <- data_sym(feature)
       xlab <- 'Identity'
       ylab <- axis.label
@@ -8954,7 +8954,7 @@ SingleExIPlot <- function(
     },
     'ridge' = {
       x <- data_sym(feature)
-      y <- 'ident'
+      y <- data_sym("ident")
       xlab <- axis.label
       ylab <- 'Identity'
       geom <- list(
@@ -9557,9 +9557,9 @@ SingleSpatialPlot <- function(
       # Retrieve image dimensions for later use (flipping image)
       image.height <- dim(image@image)[1]
       image.width <- dim(image@image)[2]
-      
-      # Retrieve the sf data stored in the Visium V2 object 
-      # Merge it with data dataframe which contains ident and gene expression information 
+
+      # Retrieve the sf data stored in the Visium V2 object
+      # Merge it with data dataframe which contains ident and gene expression information
       sf.data = image@boundaries$segmentation@sf.data
 
       # Scale geometry to match image scale
@@ -9614,14 +9614,14 @@ SingleSpatialPlot <- function(
       #Plot (currently independently of switch/case)
       if(!plot_segmentations){
         #If plot_segmentations FALSE, then plot just the centroids from sf data
-        
+
         if (is.null(pt.alpha)) {
           #If pt.alpha not provided, then alpha parameter is derived from group/cluster data
           #Use alpha.by instead of pt.alpha
           geom_point_layer <- geom_point(
-            shape = 21, 
-            stroke = stroke, 
-            size = pt.size.factor, 
+            shape = 21,
+            stroke = stroke,
+            size = pt.size.factor,
             aes_string(fill = col.by, alpha = alpha.by)
           )
         } else {
@@ -9630,7 +9630,7 @@ SingleSpatialPlot <- function(
             shape = 21,
             stroke = stroke,
             size = pt.size.factor,
-            aes_string(fill = col.by), 
+            aes_string(fill = col.by),
             alpha = if (is.null(pt.alpha)) 1 else pt.alpha
           )
         }
@@ -9647,10 +9647,10 @@ SingleSpatialPlot <- function(
           xlab("x") +
           ylab("y") +
           theme_minimal()
-      
+
       }else{
         #If plot_segmentations TRUE, then use geometry data stored in sf to plot cell polygons
-        
+
         if (is.null(pt.alpha)) {
           #If pt.alpha not provided, then alpha parameter is derived from group/cluster data
           #Use alpha.by instead of pt.alpha
@@ -9668,7 +9668,7 @@ SingleSpatialPlot <- function(
             alpha = if (is.null(pt.alpha)) 1 else pt.alpha,
             color = "black",
             linewidth = stroke
-          ) 
+          )
         }
         ggplot() +
             annotation_custom(


### PR DESCRIPTION
Hi Seurat Team (tagging @anashen here),

This is quick fix for the issue reported in #10152.  That bug is not associated with integration but the labeling of x-axis regardless of the pipeline when supplying value to `group.by`.

This fixes that issue (see repress below).

Best,
Sam

``` r
library(patchwork)
library(Seurat)
#> Loading required package: SeuratObject
#> Loading required package: sp
#> 'SeuratObject' was built with package 'Matrix' 1.7.3 but the current
#> version is 1.7.4; it is recomended that you reinstall 'SeuratObject' as
#> the ABI for 'Matrix' may have changed
#> 
#> Attaching package: 'SeuratObject'
#> The following objects are masked from 'package:base':
#> 
#>     intersect, t
library(SeuratData)
#> ── Installed datasets ──────────────────────────────── SeuratData v0.2.2.9002 ──
#> ✔ bmcite         0.3.0                  ✔ pbmcsca        3.0.0
#> ✔ hcabm40k       3.0.0                  ✔ ssHippo        3.1.4
#> ✔ ifnb           3.1.0                  ✔ stxBrain       0.1.2
#> ✔ mousecortexref 1.0.0                  ✔ stxKidney      0.1.0
#> ✔ pbmc3k         3.1.4                  ✔ thp1.eccite    3.1.5
#> ✔ pbmcMultiome   0.1.4
#> ────────────────────────────────────── Key ─────────────────────────────────────
#> ✔ Dataset loaded successfully
#> ❯ Dataset built with a newer version of Seurat than installed
#> ❓ Unknown version of Seurat installed

pbmc <- pbmc3k.SeuratData::pbmc3k.final
pbmc <- UpdateSeuratObject(pbmc)
#> Validating object structure
#> Updating object slots
#> Ensuring keys are in the proper structure
#> Updating matrix keys for DimReduc 'pca'
#> Updating matrix keys for DimReduc 'umap'
#> Warning: Assay RNA changing from Assay to Assay
#> Warning: Graph RNA_nn changing from Graph to Graph
#> Warning: Graph RNA_snn changing from Graph to Graph
#> Warning: DimReduc pca changing from DimReduc to DimReduc
#> Warning: DimReduc umap changing from DimReduc to DimReduc
#> Ensuring keys are in the proper structure
#> Ensuring feature names don't have underscores or pipes
#> Updating slots in RNA
#> Updating slots in RNA_nn
#> Setting default assay of RNA_nn to RNA
#> Updating slots in RNA_snn
#> Setting default assay of RNA_snn to RNA
#> Updating slots in pca
#> Updating slots in umap
#> Setting umap DimReduc to global
#> Setting assay used for NormalizeData.RNA to RNA
#> Setting assay used for FindVariableFeatures.RNA to RNA
#> Setting assay used for ScaleData.RNA to RNA
#> Setting assay used for RunPCA.RNA to RNA
#> Setting assay used for JackStraw.RNA.pca to RNA
#> No assay information could be found for ScoreJackStraw
#> Warning: Adding a command log without an assay associated with it
#> Setting assay used for FindNeighbors.RNA.pca to RNA
#> No assay information could be found for FindClusters
#> Warning: Adding a command log without an assay associated with it
#> Setting assay used for RunUMAP.RNA.pca to RNA
#> Validating object structure for Assay 'RNA'
#> Validating object structure for Graph 'RNA_nn'
#> Validating object structure for Graph 'RNA_snn'
#> Validating object structure for DimReduc 'pca'
#> Validating object structure for DimReduc 'umap'
#> Object representation is consistent with the most current Seurat version

pbmc$sample_id <- sample(c("sample1", "sample2", "sample3", "sample4", "sample5", "sample6"), size = ncol(pbmc), replace = TRUE)

# InstallData("ifnb")
ifnb <- LoadData("ifnb")
#> Validating object structure
#> Updating object slots
#> Ensuring keys are in the proper structure
#> Warning: Assay RNA changing from Assay to Assay
#> Ensuring keys are in the proper structure
#> Ensuring feature names don't have underscores or pipes
#> Updating slots in RNA
#> Validating object structure for Assay 'RNA'
#> Object representation is consistent with the most current Seurat version
#> Warning: Assay RNA changing from Assay to Assay5

# Standard integration workflow
ifnb[["RNA"]] <- split(ifnb[["RNA"]], f = ifnb$stim)
ifnb <- NormalizeData(ifnb)
#> Normalizing layer: counts.CTRL
#> Normalizing layer: counts.STIM
ifnb <- FindVariableFeatures(ifnb)
#> Finding variable features for layer counts.CTRL
#> Finding variable features for layer counts.STIM
ifnb <- ScaleData(ifnb)
#> Centering and scaling data matrix
ifnb <- RunPCA(ifnb, npcs = 50)
#> PC_ 1 
#> Positive:  TYROBP, C15orf48, FCER1G, CST3, SOD2, ANXA5, FTL, TYMP, TIMP1, CD63 
#>     LGALS1, CTSB, S100A4, LGALS3, KYNU, PSAP, FCN1, NPC2, ANXA2, S100A11 
#>     IGSF6, LYZ, SPI1, APOBEC3A, CD68, CTSL, SDCBP, NINJ1, HLA-DRA, CCL2 
#> Negative:  NPM1, CCR7, GIMAP7, LTB, CD7, SELL, CD2, TMSB4X, TRAT1, IL7R 
#>     IL32, RHOH, ITM2A, RGCC, LEF1, CD3G, ALOX5AP, CREM, NHP2, PASK 
#>     MYC, SNHG8, TSC22D3, GPR171, BIRC3, NOP58, RARRES3, CD27, SRM, CD8B 
#> PC_ 2 
#> Positive:  ISG15, ISG20, IFIT3, IFIT1, LY6E, TNFSF10, IFIT2, MX1, IFI6, RSAD2 
#>     CXCL10, OAS1, CXCL11, IFITM3, MT2A, OASL, TNFSF13B, IDO1, IL1RN, APOBEC3A 
#>     GBP1, CCL8, HERC5, FAM26F, GBP4, HES4, WARS, VAMP5, DEFB1, XAF1 
#> Negative:  IL8, CLEC5A, CD14, VCAN, S100A8, IER3, MARCKSL1, IL1B, PID1, CD9 
#>     GPX1, PHLDA1, INSIG1, PLAUR, PPIF, THBS1, OSM, SLC7A11, GAPDH, CTB-61M7.2 
#>     LIMS1, S100A9, GAPT, CXCL3, ACTB, C19orf59, CEBPB, OLR1, MGST1, FTH1 
#> PC_ 3 
#> Positive:  HLA-DQA1, CD83, HLA-DQB1, CD74, HLA-DPA1, HLA-DRA, HLA-DRB1, HLA-DPB1, SYNGR2, IRF8 
#>     CD79A, MIR155HG, HERPUD1, REL, HLA-DMA, MS4A1, HSP90AB1, FABP5, TVP23A, ID3 
#>     CCL22, EBI3, TSPAN13, PMAIP1, TCF4, PRMT1, NME1, HSPE1, HSPD1, CD70 
#> Negative:  ANXA1, GIMAP7, TMSB4X, CD7, CD2, RARRES3, MT2A, IL32, GNLY, PRF1 
#>     NKG7, CCL5, TRAT1, RGCC, S100A9, KLRD1, CCL2, GZMH, GZMA, CD3G 
#>     S100A8, CTSW, CCL7, ITM2A, HPSE, FGFBP2, CTSL, GPR171, CCL8, OASL 
#> PC_ 4 
#> Positive:  NKG7, GZMB, GNLY, CST7, CCL5, PRF1, CLIC3, KLRD1, GZMH, GZMA 
#>     APOBEC3G, CTSW, FGFBP2, KLRC1, FASLG, C1orf21, HOPX, CXCR3, SH2D1B, LINC00996 
#>     TNFRSF18, SPON2, RARRES3, GCHFR, SH2D2A, IGFBP7, ID2, C12orf75, XCL2, RAMP1 
#> Negative:  CCR7, LTB, SELL, LEF1, IL7R, ADTRP, TRAT1, PASK, MYC, NPM1 
#>     SOCS3, TSC22D3, TSHZ2, HSP90AB1, SNHG8, GIMAP7, PIM2, HSPD1, CD3G, TXNIP 
#>     RHOH, GBP1, C12orf57, CA6, PNRC1, CMSS1, CD27, SESN3, NHP2, BIRC3 
#> PC_ 5 
#> Positive:  VMO1, FCGR3A, MS4A4A, CXCL16, MS4A7, PPM1N, HN1, LST1, SMPDL3A, ATP1B3 
#>     CASP5, CDKN1C, CH25H, AIF1, PLAC8, SERPINA1, LRRC25, CD86, HCAR3, GBP5 
#>     TMSB4X, RP11-290F20.3, RGS19, VNN2, ADA, LILRA5, STXBP2, C3AR1, PILRA, FCGR3B 
#> Negative:  CCL2, CCL7, CCL8, PLA2G7, LMNA, S100A9, SDS, TXN, CSTB, ATP6V1F 
#>     CCR1, EMP1, CAPG, CCR5, TPM4, IDO1, MGST1, HPSE, CTSB, LILRB4 
#>     RSAD2, HSPA1A, VIM, CCNA1, CTSL, GCLM, PDE4DIP, SGTB, SLC7A11, FABP5

ifnb <- IntegrateLayers(object = ifnb,
                        method = CCAIntegration,
                        orig.reduction = "pca",
                        new.reduction = "integrated.cca",
                        verbose = FALSE)

ifnb[["RNA"]] <- JoinLayers(ifnb[["RNA"]])
ifnb <- FindNeighbors(ifnb, reduction = "integrated.cca", dims = 1:30)
#> Computing nearest neighbor graph
#> Computing SNN
ifnb <- FindClusters(ifnb, resolution = 1)
#> Modularity Optimizer version 1.3.0 by Ludo Waltman and Nees Jan van Eck
#> 
#> Number of nodes: 13999
#> Number of edges: 590406
#> 
#> Running Louvain algorithm...
#> Maximum modularity in 10 random starts: 0.8448
#> Number of communities: 18
#> Elapsed time: 1 seconds


plots <- VlnPlot(ifnb, features = c("LYZ", "ISG15", "CXCL10"),
                 split.by = "stim", group.by = "seurat_annotations",
                 pt.size = 0.2)
#> The default behaviour of split.by has changed.
#> Separate violin plots are now plotted side-by-side.
#> To restore the old behaviour of a single split violin,
#> set split.plot = TRUE.
#>       
#> This message will be shown once per session.
wrap_plots(plots = plots)
```

![](https://i.imgur.com/OpBfrxw.png)<!-- -->

``` r


VlnPlot(pbmc, features = c("LYZ"),
                 split.by = "sample_id", group.by = "seurat_annotations",
                 pt.size = 0.2)
#> Warning: Groups with fewer than two datapoints have been dropped.
#> ℹ Set `drop = FALSE` to consider such groups for position adjustment purposes.
#> Warning: Groups with fewer than two datapoints have been dropped.
#> ℹ Set `drop = FALSE` to consider such groups for position adjustment purposes.
#> Groups with fewer than two datapoints have been dropped.
#> ℹ Set `drop = FALSE` to consider such groups for position adjustment purposes.
```

![](https://i.imgur.com/9NnxlmZ.png)<!-- -->

<sup>Created on 2025-10-22 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

<details style="margin-bottom:10px;">

<summary>

Session info
</summary>

``` r
sessioninfo::session_info()
#> ─ Session info ───────────────────────────────────────────────────────────────
#>  setting  value
#>  version  R version 4.5.0 (2025-04-11)
#>  os       macOS Sequoia 15.6.1
#>  system   aarch64, darwin20
#>  ui       X11
#>  language (EN)
#>  collate  en_US.UTF-8
#>  ctype    en_US.UTF-8
#>  tz       America/New_York
#>  date     2025-10-22
#>  pandoc   3.4 @ /Applications/RStudio.app/Contents/Resources/app/quarto/bin/tools/aarch64/ (via rmarkdown)
#>  quarto   1.6.42 @ /Applications/RStudio.app/Contents/Resources/app/quarto/bin/quarto
#> 
#> ─ Packages ───────────────────────────────────────────────────────────────────
#>  package                   * version    date (UTC) lib source
#>  abind                       1.4-8      2024-09-12 [1] CRAN (R 4.5.0)
#>  beeswarm                    0.4.0      2021-06-01 [1] CRAN (R 4.5.0)
#>  bmcite.SeuratData         * 0.3.0      2025-06-02 [1] local
#>  cli                         3.6.5      2025-04-23 [1] CRAN (R 4.5.0)
#>  cluster                     2.1.8.1    2025-03-12 [1] CRAN (R 4.5.0)
#>  codetools                   0.2-20     2024-03-31 [1] CRAN (R 4.5.0)
#>  cowplot                     1.2.0      2025-07-07 [1] CRAN (R 4.5.0)
#>  crayon                      1.5.3      2024-06-20 [1] CRAN (R 4.5.0)
#>  curl                        7.0.0      2025-08-19 [1] CRAN (R 4.5.0)
#>  data.table                  1.17.8     2025-07-10 [1] CRAN (R 4.5.0)
#>  deldir                      2.0-4      2024-02-28 [1] CRAN (R 4.5.0)
#>  dichromat                   2.0-0.1    2022-05-02 [1] CRAN (R 4.5.0)
#>  digest                      0.6.37     2024-08-19 [1] CRAN (R 4.5.0)
#>  dotCall64                   1.2        2024-10-04 [1] CRAN (R 4.5.0)
#>  dplyr                       1.1.4      2023-11-17 [1] CRAN (R 4.5.0)
#>  evaluate                    1.0.5      2025-08-27 [1] CRAN (R 4.5.0)
#>  farver                      2.1.2      2024-05-13 [1] CRAN (R 4.5.0)
#>  fastDummies                 1.7.5      2025-01-20 [1] CRAN (R 4.5.0)
#>  fastmap                     1.2.0      2024-05-15 [1] CRAN (R 4.5.0)
#>  fitdistrplus                1.2-4      2025-07-03 [1] CRAN (R 4.5.0)
#>  fs                          1.6.6      2025-04-12 [1] CRAN (R 4.5.0)
#>  future                    * 1.67.0     2025-07-29 [1] CRAN (R 4.5.0)
#>  future.apply                1.20.0     2025-06-06 [1] CRAN (R 4.5.0)
#>  generics                    0.1.4      2025-05-09 [1] CRAN (R 4.5.0)
#>  ggbeeswarm                  0.7.2      2023-04-29 [1] CRAN (R 4.5.0)
#>  ggplot2                     4.0.0      2025-09-11 [1] CRAN (R 4.5.0)
#>  ggrastr                     1.0.2      2023-06-01 [1] CRAN (R 4.5.0)
#>  ggrepel                     0.9.6      2024-09-07 [1] CRAN (R 4.5.0)
#>  ggridges                    0.5.7      2025-08-27 [1] CRAN (R 4.5.0)
#>  globals                     0.18.0     2025-05-08 [1] CRAN (R 4.5.0)
#>  glue                        1.8.0      2024-09-30 [1] CRAN (R 4.5.0)
#>  goftest                     1.2-3      2021-10-07 [1] CRAN (R 4.5.0)
#>  gridExtra                   2.3        2017-09-09 [1] CRAN (R 4.5.0)
#>  gtable                      0.3.6      2024-10-25 [1] CRAN (R 4.5.0)
#>  hcabm40k.SeuratData       * 3.0.0      2025-06-02 [1] local
#>  htmltools                   0.5.8.1    2024-04-04 [1] CRAN (R 4.5.0)
#>  htmlwidgets                 1.6.4      2023-12-06 [1] CRAN (R 4.5.0)
#>  httpuv                      1.6.16     2025-04-16 [1] CRAN (R 4.5.0)
#>  httr                        1.4.7      2023-08-15 [1] CRAN (R 4.5.0)
#>  ica                         1.0-3      2022-07-08 [1] CRAN (R 4.5.0)
#>  ifnb.SeuratData           * 3.1.0      2025-06-02 [1] local
#>  igraph                      2.1.4      2025-01-23 [1] CRAN (R 4.5.0)
#>  irlba                       2.3.5.1    2022-10-03 [1] CRAN (R 4.5.0)
#>  jsonlite                    2.0.0      2025-03-27 [1] CRAN (R 4.5.0)
#>  KernSmooth                  2.23-26    2025-01-01 [1] CRAN (R 4.5.0)
#>  knitr                       1.50       2025-03-16 [1] CRAN (R 4.5.0)
#>  labeling                    0.4.3      2023-08-29 [1] CRAN (R 4.5.0)
#>  later                       1.4.4      2025-08-27 [1] CRAN (R 4.5.0)
#>  lattice                     0.22-7     2025-04-02 [1] CRAN (R 4.5.0)
#>  lazyeval                    0.2.2      2019-03-15 [1] CRAN (R 4.5.0)
#>  lifecycle                   1.0.4      2023-11-07 [1] CRAN (R 4.5.0)
#>  listenv                     0.9.1      2024-01-29 [1] CRAN (R 4.5.0)
#>  lmtest                      0.9-40     2022-03-21 [1] CRAN (R 4.5.0)
#>  magrittr                    2.0.4      2025-09-12 [1] CRAN (R 4.5.0)
#>  MASS                        7.3-65     2025-02-28 [1] CRAN (R 4.5.0)
#>  Matrix                      1.7-4      2025-08-28 [1] CRAN (R 4.5.0)
#>  matrixStats                 1.5.0      2025-01-07 [1] CRAN (R 4.5.0)
#>  mime                        0.13       2025-03-17 [1] CRAN (R 4.5.0)
#>  miniUI                      0.1.2      2025-04-17 [1] CRAN (R 4.5.0)
#>  mousecortexref.SeuratData * 1.0.0      2025-06-02 [1] local
#>  nlme                        3.1-168    2025-03-31 [1] CRAN (R 4.5.0)
#>  parallelly                  1.45.1     2025-07-24 [1] CRAN (R 4.5.0)
#>  patchwork                 * 1.3.2      2025-08-25 [1] CRAN (R 4.5.0)
#>  pbapply                     1.7-4      2025-07-20 [1] CRAN (R 4.5.0)
#>  pbmc3k.SeuratData         * 3.1.4      2025-06-02 [1] local
#>  pbmcMultiome.SeuratData   * 0.1.4      2025-06-02 [1] local
#>  pbmcsca.SeuratData        * 3.0.0      2025-06-02 [1] local
#>  pillar                      1.11.1     2025-09-17 [1] CRAN (R 4.5.0)
#>  pkgconfig                   2.0.3      2019-09-22 [1] CRAN (R 4.5.0)
#>  plotly                      4.11.0     2025-06-19 [1] CRAN (R 4.5.0)
#>  plyr                        1.8.9      2023-10-02 [1] CRAN (R 4.5.0)
#>  png                         0.1-8      2022-11-29 [1] CRAN (R 4.5.0)
#>  polyclip                    1.10-7     2024-07-23 [1] CRAN (R 4.5.0)
#>  progressr                   0.15.1     2024-11-22 [1] CRAN (R 4.5.0)
#>  promises                    1.3.3      2025-05-29 [1] CRAN (R 4.5.0)
#>  purrr                       1.1.0      2025-07-10 [1] CRAN (R 4.5.0)
#>  R6                          2.6.1      2025-02-15 [1] CRAN (R 4.5.0)
#>  RANN                        2.6.2      2024-08-25 [1] CRAN (R 4.5.0)
#>  rappdirs                    0.3.3      2021-01-31 [1] CRAN (R 4.5.0)
#>  RColorBrewer                1.1-3      2022-04-03 [1] CRAN (R 4.5.0)
#>  Rcpp                        1.1.0      2025-07-02 [1] CRAN (R 4.5.0)
#>  RcppAnnoy                   0.0.22     2024-01-23 [1] CRAN (R 4.5.0)
#>  RcppHNSW                    0.6.0      2024-02-04 [1] CRAN (R 4.5.0)
#>  reprex                      2.1.1      2024-07-06 [1] CRAN (R 4.5.0)
#>  reshape2                    1.4.4      2020-04-09 [1] CRAN (R 4.5.0)
#>  reticulate                  1.43.0     2025-07-21 [1] CRAN (R 4.5.0)
#>  rlang                       1.1.6      2025-04-11 [1] CRAN (R 4.5.0)
#>  rmarkdown                   2.30       2025-09-28 [1] CRAN (R 4.5.0)
#>  ROCR                        1.0-11     2020-05-02 [1] CRAN (R 4.5.0)
#>  RSpectra                    0.16-2     2024-07-18 [1] CRAN (R 4.5.0)
#>  rstudioapi                  0.17.1     2024-10-22 [1] CRAN (R 4.5.0)
#>  Rtsne                       0.17       2023-12-07 [1] CRAN (R 4.5.0)
#>  S7                          0.2.0      2024-11-07 [1] CRAN (R 4.5.0)
#>  scales                      1.4.0      2025-04-24 [1] CRAN (R 4.5.0)
#>  scattermore                 1.2        2023-06-12 [1] CRAN (R 4.5.0)
#>  sctransform                 0.4.2      2025-04-30 [1] CRAN (R 4.5.0)
#>  sessioninfo                 1.2.3      2025-02-05 [1] CRAN (R 4.5.0)
#>  Seurat                    * 5.3.1.9999 2025-10-22 [1] Github (samuel-marsh/seurat@1b1d2ca)
#>  SeuratData                * 0.2.2.9002 2025-05-28 [1] Github (satijalab/seurat-data@3e51f44)
#>  SeuratObject              * 5.1.0      2025-04-22 [1] CRAN (R 4.5.0)
#>  shiny                       1.11.1     2025-07-03 [1] CRAN (R 4.5.0)
#>  sp                        * 2.2-0      2025-02-01 [1] CRAN (R 4.5.0)
#>  spam                        2.11-1     2025-01-20 [1] CRAN (R 4.5.0)
#>  spatstat.data               3.1-8      2025-08-18 [1] CRAN (R 4.5.0)
#>  spatstat.explore            3.5-3      2025-09-22 [1] CRAN (R 4.5.0)
#>  spatstat.geom               3.6-0      2025-09-20 [1] CRAN (R 4.5.0)
#>  spatstat.random             3.4-2      2025-09-21 [1] CRAN (R 4.5.0)
#>  spatstat.sparse             3.1-0      2024-06-21 [1] CRAN (R 4.5.0)
#>  spatstat.univar             3.1-4      2025-07-13 [1] CRAN (R 4.5.0)
#>  spatstat.utils              3.2-0      2025-09-20 [1] CRAN (R 4.5.0)
#>  ssHippo.SeuratData        * 3.1.4      2025-08-14 [1] local
#>  stringi                     1.8.7      2025-03-27 [1] CRAN (R 4.5.0)
#>  stringr                     1.5.2      2025-09-08 [1] CRAN (R 4.5.0)
#>  stxBrain.SeuratData       * 0.1.2      2025-06-02 [1] local
#>  stxKidney.SeuratData      * 0.1.0      2025-06-02 [1] local
#>  survival                    3.8-3      2024-12-17 [1] CRAN (R 4.5.0)
#>  tensor                      1.5.1      2025-06-17 [1] CRAN (R 4.5.0)
#>  thp1.eccite.SeuratData    * 3.1.5      2025-10-07 [1] local
#>  tibble                      3.3.0      2025-06-08 [1] CRAN (R 4.5.0)
#>  tidyr                       1.3.1      2024-01-24 [1] CRAN (R 4.5.0)
#>  tidyselect                  1.2.1      2024-03-11 [1] CRAN (R 4.5.0)
#>  uwot                        0.2.3      2025-02-24 [1] CRAN (R 4.5.0)
#>  vctrs                       0.6.5      2023-12-01 [1] CRAN (R 4.5.0)
#>  vipor                       0.4.7      2023-12-18 [1] CRAN (R 4.5.0)
#>  viridisLite                 0.4.2      2023-05-02 [1] CRAN (R 4.5.0)
#>  withr                       3.0.2      2024-10-28 [1] CRAN (R 4.5.0)
#>  xfun                        0.53       2025-08-19 [1] CRAN (R 4.5.0)
#>  xml2                        1.4.0      2025-08-20 [1] CRAN (R 4.5.0)
#>  xtable                      1.8-4      2019-04-21 [1] CRAN (R 4.5.0)
#>  yaml                        2.3.10     2024-07-26 [1] CRAN (R 4.5.0)
#>  zoo                         1.8-14     2025-04-10 [1] CRAN (R 4.5.0)
#> 
#>  [1] /Library/Frameworks/R.framework/Versions/4.5-arm64/Resources/library
#>  * ── Packages attached to the search path.
#> 
#> ──────────────────────────────────────────────────────────────────────────────
```

</details>
