### PR TITLE
Update links to progressr intro vignette in documentation

### DIFF
--- a/man/PrepSCTFindMarkers.Rd
+++ b/man/PrepSCTFindMarkers.Rd
@@ -32,7 +32,7 @@ render status updates and progress bars. To enable progress updates, wrap
 the function call in \code{\link[progressr]{with_progress}} or run
 \code{\link[progressr:handlers]{handlers(global = TRUE)}} before running
 this function. For more details about \pkg{progressr}, please read
-\href{https://progressr.futureverse.org/articles/progressr-intro.html}{\code{vignette("progressr-intro")}}
+\href{https://progressr.futureverse.org/articles/progressr-01-intro.html}{\code{vignette("progressr-intro")}}
 }
 
 \section{Parallelization with \pkg{future}}{

--- a/man/ReadAkoya.Rd
+++ b/man/ReadAkoya.Rd
@@ -77,7 +77,7 @@ render status updates and progress bars. To enable progress updates, wrap
 the function call in \code{\link[progressr]{with_progress}} or run
 \code{\link[progressr:handlers]{handlers(global = TRUE)}} before running
 this function. For more details about \pkg{progressr}, please read
-\href{https://progressr.futureverse.org/articles/progressr-intro.html}{\code{vignette("progressr-intro")}}
+\href{https://progressr.futureverse.org/articles/progressr-01-intro.html}{\code{vignette("progressr-intro")}}
 }
 
 \concept{preprocessing}

--- a/man/ReadNanostring.Rd
+++ b/man/ReadNanostring.Rd
@@ -118,7 +118,7 @@ render status updates and progress bars. To enable progress updates, wrap
 the function call in \code{\link[progressr]{with_progress}} or run
 \code{\link[progressr:handlers]{handlers(global = TRUE)}} before running
 this function. For more details about \pkg{progressr}, please read
-\href{https://progressr.futureverse.org/articles/progressr-intro.html}{\code{vignette("progressr-intro")}}
+\href{https://progressr.futureverse.org/articles/progressr-01-intro.html}{\code{vignette("progressr-intro")}}
 }
 
 \section{Parallelization with \pkg{future}}{

--- a/man/ReadVitessce.Rd
+++ b/man/ReadVitessce.Rd
@@ -80,7 +80,7 @@ render status updates and progress bars. To enable progress updates, wrap
 the function call in \code{\link[progressr]{with_progress}} or run
 \code{\link[progressr:handlers]{handlers(global = TRUE)}} before running
 this function. For more details about \pkg{progressr}, please read
-\href{https://progressr.futureverse.org/articles/progressr-intro.html}{\code{vignette("progressr-intro")}}
+\href{https://progressr.futureverse.org/articles/progressr-01-intro.html}{\code{vignette("progressr-intro")}}
 }
 
 \examples{

--- a/man/ReadVizgen.Rd
+++ b/man/ReadVizgen.Rd
@@ -115,7 +115,7 @@ render status updates and progress bars. To enable progress updates, wrap
 the function call in \code{\link[progressr]{with_progress}} or run
 \code{\link[progressr:handlers]{handlers(global = TRUE)}} before running
 this function. For more details about \pkg{progressr}, please read
-\href{https://progressr.futureverse.org/articles/progressr-intro.html}{\code{vignette("progressr-intro")}}
+\href{https://progressr.futureverse.org/articles/progressr-01-intro.html}{\code{vignette("progressr-intro")}}
 }
 
 \section{Parallelization with \pkg{future}}{

--- a/man/roxygen/templates/section-progressr.R
+++ b/man/roxygen/templates/section-progressr.R
@@ -5,4 +5,4 @@
 #' the function call in \code{\link[progressr]{with_progress}} or run
 #' \code{\link[progressr:handlers]{handlers(global = TRUE)}} before running
 #' this function. For more details about \pkg{progressr}, please read
-#' \href{https://progressr.futureverse.org/articles/progressr-intro.html}{\code{vignette("progressr-intro")}}
+#' \href{https://progressr.futureverse.org/articles/progressr-01-intro.html}{\code{vignette("progressr-intro")}}


### PR DESCRIPTION
Fix invalid link to [progressr introduction vignette](https://progressr.futureverse.org/articles/progressr-01-intro.html) in the documentation for the following functions:

- `PrepSCTFindMarkers`
- `ReadAkoya`
- `ReadNanostring`
- `ReadVitessce`
- `ReadVizgen`