### PR TITLE
Fix Bug in IntegrateEmbeddings when Ref is specified

### DIFF
--- a/R/integration.R
+++ b/R/integration.R
@@ -1796,7 +1796,7 @@ IntegrateEmbeddings.IntegrationAnchorSet <- function(
   suppressWarnings(expr = unintegrated[[new.reduction.name]] <- CreateDimReducObject(
     embeddings = as.matrix(x = t(x = integrated.data)),
     assay = intdr.assay,
-    loadings = Loadings(object = reductions),
+    loadings = Loadings(object = reductions)[,dims.to.integrate],
     key = paste0(new.reduction.name.safe, "_")
   ))
   unintegrated <- SetIntegrationData(


### PR DESCRIPTION
Dear developpers,
I noticed that if I want to use IntegrateEmbeddings but I specify `dims.to.integrate` and `reference` I get an error:
```txt
Error in dimnames(x) <- dn : 
  length of 'dimnames' [2] not equal to array extent
```
I could find the origin of the problem. I also so that there was a similar commit: https://github.com/satijalab/seurat/commit/c9f8b5e9fec5c6d6e23ad021e9b9143195b605e9 but unfortunately only the case where reference was not specified was fixed.

You find here the fix for the case where `reference` is specified.