### PR TITLE
aes_string fix Spatial Plotting

### DIFF
--- a/R/visualization.R
+++ b/R/visualization.R
@@ -9636,7 +9636,7 @@ SingleSpatialPlot <- function(
             shape = 21,
             stroke = stroke,
             size = pt.size.factor,
-            aes(fill = .data[[col.by]], alpha = .data[[alpha.by]])
+            aes(fill = .data[[col.by.clean]], alpha = .data[[alpha.by]])
           )
         } else {
           #If pt.alpha is indeed provided, then use that to define alpha
@@ -9644,7 +9644,7 @@ SingleSpatialPlot <- function(
             shape = 21,
             stroke = stroke,
             size = pt.size.factor,
-            aes(fill = .data[[col.by]]),
+            aes(fill = .data[[col.by.clean]]),
             alpha = if (is.null(pt.alpha)) 1 else pt.alpha
           )
         }
@@ -9670,7 +9670,7 @@ SingleSpatialPlot <- function(
           #Use alpha.by instead of pt.alpha
           geom_sf_layer <- geom_sf(
             data = sf.cleaned,
-            aes(fill = .data[[col.by]], alpha = .data[[alpha.by]]),
+            aes(fill = .data[[col.by.clean]], alpha = .data[[alpha.by]]),
             color = "black",
             linewidth = stroke
           )
@@ -9678,7 +9678,7 @@ SingleSpatialPlot <- function(
           #If pt.alpha is indeed provided, then use that to define alpha
           geom_sf_layer <- geom_sf(
             data = sf.cleaned,
-            aes(fill = .data[[col.by]]),
+            aes(fill = .data[[col.by.clean]]),
             alpha = if (is.null(pt.alpha)) 1 else pt.alpha,
             color = "black",
             linewidth = stroke


### PR DESCRIPTION
Hi Seurat Team,

This is related to #10183  and the presence of 2 instances of `aes_string` in the "main" branch that seem to have been introduced post-CRAN 5.3.1 release.  While I cannot replicate the warnings from that issue I have fixed those two instances and testing using my PR branch and reprex below has no issues.

Best,
Sam

``` r
library(Seurat)
#> Loading required package: SeuratObject
#> Loading required package: sp
#> 'SeuratObject' was built with package 'Matrix' 1.7.3 but the current
#> version is 1.7.4; it is recomended that you reinstall 'SeuratObject' as
#> the ABI for 'Matrix' may have changed
#> 
#> Attaching package: 'SeuratObject'
#> The following objects are masked from 'package:base':
#> 
#>     intersect, t
library(SeuratData)
#> ── Installed datasets ──────────────────────────────── SeuratData v0.2.2.9002 ──
#> ✔ bmcite         0.3.0                  ✔ pbmcsca        3.0.0
#> ✔ hcabm40k       3.0.0                  ✔ ssHippo        3.1.4
#> ✔ ifnb           3.1.0                  ✔ stxBrain       0.1.2
#> ✔ mousecortexref 1.0.0                  ✔ stxKidney      0.1.0
#> ✔ pbmc3k         3.1.4                  ✔ thp1.eccite    3.1.5
#> ✔ pbmcMultiome   0.1.4
#> ────────────────────────────────────── Key ─────────────────────────────────────
#> ✔ Dataset loaded successfully
#> ❯ Dataset built with a newer version of Seurat than installed
#> ❓ Unknown version of Seurat installed

slide.seq <- LoadData("ssHippo")
#> Validating object structure
#> Updating object slots
#> Ensuring keys are in the proper structure
#> Warning: Assay Spatial changing from Assay to Assay
#> Ensuring keys are in the proper structure
#> Ensuring feature names don't have underscores or pipes
#> Updating slots in Spatial
#> Updating slots in image
#> Validating object structure for Assay 'Spatial'
#> Validating object structure for SlideSeq 'image'
#> Object representation is consistent with the most current Seurat version
slide.seq <- SCTransform(slide.seq, assay = "Spatial", ncells = 3000, verbose = FALSE)
slide.seq <- RunPCA(slide.seq)
#> PC_ 1 
#> Positive:  PLP1, MAL, CNP, MBP, PTGDS, MOBP, CLDN11, APOD, SEPT4, MAG 
#>     TRF, QDPR, MOG, ERMN, CAR2, ENPP2, CRYAB, SCD2, FTH1, GATM 
#>     OPALIN, TMEM88B, QK, TSPAN2, NDRG1, APLP1, UGT8A, TTR, NEAT1, CNTN2 
#> Negative:  HPCA, PPP3CA, NRGN, MEG3, CHGB, ATP2B1, SNAP25, ATP1B1, CHN1, OLFM1 
#>     SYT1, CALM2, NCDN, CAMK2B, RBFOX1, KCNIP4, GRIA2, GRIA1, RTN1, SNHG11 
#>     PPP3R1, PTK2B, WIPF3, MAP1B, ATP1A3, DLGAP1, CELF2, THY1, ATP6V1G2, NRXN3 
#> PC_ 2 
#> Positive:  TTR, ENPP2, 1500015O10RIK, IGF2, PTGDS, RBP1, COL9A3, FOLR1, IGFBP2, TRPM3 
#>     IFI27, PPP1R1B, CD63, CCDC153, CLU, DBI, RSPH1, PLTP, RARRES2, TAC2 
#>     APOE, MGP, NNAT, FXYD1, PCP4L1, ARL6IP1, EZR, HTR2C, IGFBP7, BSG 
#> Negative:  PLP1, MAL, MBP, HPCA, CNP, MOBP, PPP3CA, CLDN11, SEPT4, MAG 
#>     NRGN, APLP1, KCNIP4, ATP2B1, PCDH9, MOG, QDPR, RBFOX1, ERMN, PTPRD 
#>     CHGB, CHN1, KIF5A, TRF, OLFM1, SYT1, NRXN3, DLG2, GRIA2, SNAP25 
#> PC_ 3 
#> Positive:  MT-RNR1, CST3, APOE, MT-RNR2, MT-ND2, MT-ND4, MT-CYTB, SLC1A2, ATP1A2, MT-ND1 
#>     CAMK2A, MT-CO1, ALDOC, DDN, MT-ND5, NDRG2, CLU, SPARCL1, GLUL, SLC1A3 
#>     FAM107A, TTYH1, CPE, SPARC, PLA2G7, GSTM1, MT1, KIF5A, PPP1R9B, PRDX6 
#> Negative:  TTR, PLP1, ENPP2, MEG3, HPCA, PPP3CA, KCNIP4, MAL, NRGN, SNHG11 
#>     ATP2B1, CHGB, DLG2, NRG3, ATP1B1, GRIA2, CSMD1, MALAT1, PTPRD, SYT1 
#>     RBFOX1, CLDN11, NRXN3, GRIN2A, CNP, PCDH9, OPCML, RTN1, LRRTM4, SNAP25 
#> PC_ 4 
#> Positive:  PCP4, PRKCD, RORA, MEG3, ZIC1, PCP4L1, PLCB4, TCF7L2, TNNT1, NEFH 
#>     NTNG1, CCDC136, CPLX1, ADARB1, SLC17A6, SPARC, SNHG11, AMOTL1, NDRG4, KCNIP4 
#>     CALB2, PDP1, RAMP3, UCHL1, NEFM, SHOX2, NECAB2, RAB3C, GAP43, SYNPO2 
#> Negative:  HPCA, DDN, CAMK2A, PPP3CA, NRGN, TTR, WIPF3, PSD, TMSB4X, CPLX2 
#>     MT-RNR1, OLFM1, PTK2B, ZBTB20, 2010300C02RIK, MT-RNR2, ARF3, TCF4, FBXL16, GRIA2 
#>     CHN1, JPH4, GRIA1, HPCAL4, SLC1A2, CAMK2B, CABP7, ITPKA, FAM131A, CRYM 
#> PC_ 5 
#> Positive:  SST, PLP1, HPCA, KIF5A, NPY, SNAP25, MBP, CHGB, VSNL1, CPLX1 
#>     ATP6V1G2, ATP1B1, CALM2, RAB6B, STMN2, SULT4A1, FTH1, TTR, CAMK2N1, MAP1A 
#>     ATP1A3, STMN3, NEFL, YWHAG, MDH1, CALM1, GAD1, ALDOA, MOBP, RAB6A 
#> Negative:  MALAT1, LSAMP, KCNIP4, NRG3, PTGDS, DLG2, MEG3, CSMD1, GPC5, LRRTM4 
#>     FGF14, TRPM3, PCDH9, GM3764, ZBTB20, NRXN1, MDGA2, LRP1B, NPAS3, PTPRD 
#>     KCNMA1, APOE, FRMD4A, SNHG11, ADGRB3, NLGN1, ATP1A2, AUTS2, MAGI2, CADM2
slide.seq <- RunUMAP(slide.seq, dims = 1:30)
#> Warning: The default method for RunUMAP has changed from calling Python UMAP via reticulate to the R-native UWOT using the cosine metric
#> To use Python UMAP via reticulate, set umap.method to 'umap-learn' and metric to 'correlation'
#> This message will be shown once per session
#> 11:43:46 UMAP embedding parameters a = 0.9922 b = 1.112
#> 11:43:46 Read 53173 rows and found 30 numeric columns
#> 11:43:46 Using Annoy for neighbor search, n_neighbors = 30
#> 11:43:46 Building Annoy index with metric = cosine, n_trees = 50
#> 0%   10   20   30   40   50   60   70   80   90   100%
#> [----|----|----|----|----|----|----|----|----|----|
#> **************************************************|
#> 11:43:49 Writing NN index file to temp file /var/folders/pw/3dpdng3965q77npt97qm5dbm0000gn/T//RtmpIpV5Tn/file71bf2d3abcc7
#> 11:43:49 Searching Annoy index using 1 thread, search_k = 3000
#> 11:43:58 Annoy recall = 100%
#> 11:43:59 Commencing smooth kNN distance calibration using 1 thread with target n_neighbors = 30
#> 11:43:59 Initializing from normalized Laplacian + noise (using RSpectra)
#> 11:44:00 Commencing optimization for 200 epochs, with 2520214 positive edges
#> 11:44:00 Using rng type: pcg
#> 11:44:11 Optimization finished
slide.seq <- FindNeighbors(slide.seq, dims = 1:30)
#> Computing nearest neighbor graph
#> Computing SNN
slide.seq <- FindClusters(slide.seq, resolution = 0.3, verbose = FALSE)
DimPlot(slide.seq, reduction = "umap", label = TRUE)
```

![](https://i.imgur.com/Xa58qdp.png)<!-- -->

``` r
SpatialPlot(slide.seq, stroke = 0)
```

![](https://i.imgur.com/MqJtyHZ.png)<!-- -->

``` r
SpatialPlot(slide.seq, features = "ACTB")
```

![](https://i.imgur.com/EgLT52C.png)<!-- -->

<sup>Created on 2025-11-03 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

<details style="margin-bottom:10px;">

<summary>

Session info
</summary>

``` r
sessioninfo::session_info()
#> ─ Session info ───────────────────────────────────────────────────────────────
#>  setting  value
#>  version  R version 4.5.0 (2025-04-11)
#>  os       macOS Sequoia 15.6.1
#>  system   aarch64, darwin20
#>  ui       X11
#>  language (EN)
#>  collate  en_US.UTF-8
#>  ctype    en_US.UTF-8
#>  tz       America/New_York
#>  date     2025-11-03
#>  pandoc   3.6.3 @ /Applications/RStudio.app/Contents/Resources/app/quarto/bin/tools/aarch64/ (via rmarkdown)
#>  quarto   1.7.32 @ /Applications/RStudio.app/Contents/Resources/app/quarto/bin/quarto
#> 
#> ─ Packages ───────────────────────────────────────────────────────────────────
#>  package                   * version    date (UTC) lib source
#>  abind                       1.4-8      2024-09-12 [1] CRAN (R 4.5.0)
#>  beachmat                    2.24.0     2025-04-15 [1] Bioconductor 3.21 (R 4.5.0)
#>  Biobase                     2.68.0     2025-04-15 [1] Bioconductor 3.21 (R 4.5.0)
#>  BiocGenerics                0.54.0     2025-04-15 [1] Bioconductor 3.21 (R 4.5.0)
#>  bmcite.SeuratData         * 0.3.0      2025-06-02 [1] local
#>  cli                         3.6.5      2025-04-23 [1] CRAN (R 4.5.0)
#>  cluster                     2.1.8.1    2025-03-12 [1] CRAN (R 4.5.0)
#>  codetools                   0.2-20     2024-03-31 [1] CRAN (R 4.5.0)
#>  cowplot                     1.2.0      2025-07-07 [1] CRAN (R 4.5.0)
#>  crayon                      1.5.3      2024-06-20 [1] CRAN (R 4.5.0)
#>  curl                        7.0.0      2025-08-19 [1] CRAN (R 4.5.0)
#>  data.table                  1.17.8     2025-07-10 [1] CRAN (R 4.5.0)
#>  DelayedArray                0.34.1     2025-04-17 [1] Bioconductor 3.21 (R 4.5.0)
#>  DelayedMatrixStats          1.30.0     2025-04-15 [1] Bioconductor 3.21 (R 4.5.0)
#>  deldir                      2.0-4      2024-02-28 [1] CRAN (R 4.5.0)
#>  dichromat                   2.0-0.1    2022-05-02 [1] CRAN (R 4.5.0)
#>  digest                      0.6.37     2024-08-19 [1] CRAN (R 4.5.0)
#>  dotCall64                   1.2        2024-10-04 [1] CRAN (R 4.5.0)
#>  dplyr                       1.1.4      2023-11-17 [1] CRAN (R 4.5.0)
#>  evaluate                    1.0.5      2025-08-27 [1] CRAN (R 4.5.0)
#>  farver                      2.1.2      2024-05-13 [1] CRAN (R 4.5.0)
#>  fastDummies                 1.7.5      2025-01-20 [1] CRAN (R 4.5.0)
#>  fastmap                     1.2.0      2024-05-15 [1] CRAN (R 4.5.0)
#>  fitdistrplus                1.2-4      2025-07-03 [1] CRAN (R 4.5.0)
#>  fs                          1.6.6      2025-04-12 [1] CRAN (R 4.5.0)
#>  future                    * 1.67.0     2025-07-29 [1] CRAN (R 4.5.0)
#>  future.apply                1.20.0     2025-06-06 [1] CRAN (R 4.5.0)
#>  generics                    0.1.4      2025-05-09 [1] CRAN (R 4.5.0)
#>  GenomeInfoDb                1.44.0     2025-04-15 [1] Bioconductor 3.21 (R 4.5.0)
#>  GenomeInfoDbData            1.2.14     2025-05-28 [1] Bioconductor
#>  GenomicRanges               1.60.0     2025-04-15 [1] Bioconductor 3.21 (R 4.5.0)
#>  ggplot2                     4.0.0      2025-09-11 [1] CRAN (R 4.5.0)
#>  ggrepel                     0.9.6      2024-09-07 [1] CRAN (R 4.5.0)
#>  ggridges                    0.5.7      2025-08-27 [1] CRAN (R 4.5.0)
#>  glmGamPoi                   1.20.0     2025-04-15 [1] Bioconductor 3.21 (R 4.5.0)
#>  globals                     0.18.0     2025-05-08 [1] CRAN (R 4.5.0)
#>  glue                        1.8.0      2024-09-30 [1] CRAN (R 4.5.0)
#>  goftest                     1.2-3      2021-10-07 [1] CRAN (R 4.5.0)
#>  gridExtra                   2.3        2017-09-09 [1] CRAN (R 4.5.0)
#>  gtable                      0.3.6      2024-10-25 [1] CRAN (R 4.5.0)
#>  hcabm40k.SeuratData       * 3.0.0      2025-06-02 [1] local
#>  htmltools                   0.5.8.1    2024-04-04 [1] CRAN (R 4.5.0)
#>  htmlwidgets                 1.6.4      2023-12-06 [1] CRAN (R 4.5.0)
#>  httpuv                      1.6.16     2025-04-16 [1] CRAN (R 4.5.0)
#>  httr                        1.4.7      2023-08-15 [1] CRAN (R 4.5.0)
#>  ica                         1.0-3      2022-07-08 [1] CRAN (R 4.5.0)
#>  ifnb.SeuratData           * 3.1.0      2025-06-02 [1] local
#>  igraph                      2.2.1      2025-10-27 [1] CRAN (R 4.5.0)
#>  IRanges                     2.42.0     2025-04-15 [1] Bioconductor 3.21 (R 4.5.0)
#>  irlba                       2.3.5.1    2022-10-03 [1] CRAN (R 4.5.0)
#>  jsonlite                    2.0.0      2025-03-27 [1] CRAN (R 4.5.0)
#>  KernSmooth                  2.23-26    2025-01-01 [1] CRAN (R 4.5.0)
#>  knitr                       1.50       2025-03-16 [1] CRAN (R 4.5.0)
#>  labeling                    0.4.3      2023-08-29 [1] CRAN (R 4.5.0)
#>  later                       1.4.4      2025-08-27 [1] CRAN (R 4.5.0)
#>  lattice                     0.22-7     2025-04-02 [1] CRAN (R 4.5.0)
#>  lazyeval                    0.2.2      2019-03-15 [1] CRAN (R 4.5.0)
#>  lifecycle                   1.0.4      2023-11-07 [1] CRAN (R 4.5.0)
#>  listenv                     0.9.1      2024-01-29 [1] CRAN (R 4.5.0)
#>  lmtest                      0.9-40     2022-03-21 [1] CRAN (R 4.5.0)
#>  magrittr                    2.0.4      2025-09-12 [1] CRAN (R 4.5.0)
#>  MASS                        7.3-65     2025-02-28 [1] CRAN (R 4.5.0)
#>  Matrix                      1.7-4      2025-08-28 [1] CRAN (R 4.5.0)
#>  MatrixGenerics              1.20.0     2025-04-15 [1] Bioconductor 3.21 (R 4.5.0)
#>  matrixStats                 1.5.0      2025-01-07 [1] CRAN (R 4.5.0)
#>  mime                        0.13       2025-03-17 [1] CRAN (R 4.5.0)
#>  miniUI                      0.1.2      2025-04-17 [1] CRAN (R 4.5.0)
#>  mousecortexref.SeuratData * 1.0.0      2025-06-02 [1] local
#>  nlme                        3.1-168    2025-03-31 [1] CRAN (R 4.5.0)
#>  otel                        0.2.0      2025-08-29 [1] CRAN (R 4.5.0)
#>  parallelly                  1.45.1     2025-07-24 [1] CRAN (R 4.5.0)
#>  patchwork                   1.3.2      2025-08-25 [1] CRAN (R 4.5.0)
#>  pbapply                     1.7-4      2025-07-20 [1] CRAN (R 4.5.0)
#>  pbmc3k.SeuratData         * 3.1.4      2025-06-02 [1] local
#>  pbmcMultiome.SeuratData   * 0.1.4      2025-06-02 [1] local
#>  pbmcsca.SeuratData        * 3.0.0      2025-06-02 [1] local
#>  pillar                      1.11.1     2025-09-17 [1] CRAN (R 4.5.0)
#>  pkgconfig                   2.0.3      2019-09-22 [1] CRAN (R 4.5.0)
#>  plotly                      4.11.0     2025-06-19 [1] CRAN (R 4.5.0)
#>  plyr                        1.8.9      2023-10-02 [1] CRAN (R 4.5.0)
#>  png                         0.1-8      2022-11-29 [1] CRAN (R 4.5.0)
#>  polyclip                    1.10-7     2024-07-23 [1] CRAN (R 4.5.0)
#>  progressr                   0.17.0     2025-10-15 [1] CRAN (R 4.5.0)
#>  promises                    1.4.0      2025-10-22 [1] CRAN (R 4.5.0)
#>  purrr                       1.1.0      2025-07-10 [1] CRAN (R 4.5.0)
#>  R6                          2.6.1      2025-02-15 [1] CRAN (R 4.5.0)
#>  RANN                        2.6.2      2024-08-25 [1] CRAN (R 4.5.0)
#>  rappdirs                    0.3.3      2021-01-31 [1] CRAN (R 4.5.0)
#>  RColorBrewer                1.1-3      2022-04-03 [1] CRAN (R 4.5.0)
#>  Rcpp                        1.1.0      2025-07-02 [1] CRAN (R 4.5.0)
#>  RcppAnnoy                   0.0.22     2024-01-23 [1] CRAN (R 4.5.0)
#>  RcppHNSW                    0.6.0      2024-02-04 [1] CRAN (R 4.5.0)
#>  reprex                      2.1.1      2024-07-06 [1] CRAN (R 4.5.0)
#>  reshape2                    1.4.4      2020-04-09 [1] CRAN (R 4.5.0)
#>  reticulate                  1.44.0     2025-10-25 [1] CRAN (R 4.5.0)
#>  rlang                       1.1.6      2025-04-11 [1] CRAN (R 4.5.0)
#>  rmarkdown                   2.30       2025-09-28 [1] CRAN (R 4.5.0)
#>  ROCR                        1.0-11     2020-05-02 [1] CRAN (R 4.5.0)
#>  RSpectra                    0.16-2     2024-07-18 [1] CRAN (R 4.5.0)
#>  rstudioapi                  0.17.1     2024-10-22 [1] CRAN (R 4.5.0)
#>  Rtsne                       0.17       2023-12-07 [1] CRAN (R 4.5.0)
#>  S4Arrays                    1.8.0      2025-04-15 [1] Bioconductor 3.21 (R 4.5.0)
#>  S4Vectors                   0.46.0     2025-04-15 [1] Bioconductor 3.21 (R 4.5.0)
#>  S7                          0.2.0      2024-11-07 [1] CRAN (R 4.5.0)
#>  scales                      1.4.0      2025-04-24 [1] CRAN (R 4.5.0)
#>  scattermore                 1.2        2023-06-12 [1] CRAN (R 4.5.0)
#>  sctransform                 0.4.2      2025-04-30 [1] CRAN (R 4.5.0)
#>  sessioninfo                 1.2.3      2025-02-05 [1] CRAN (R 4.5.0)
#>  Seurat                    * 5.3.1.9999 2025-11-03 [1] Github (samuel-marsh/seurat@423ef48)
#>  SeuratData                * 0.2.2.9002 2025-05-28 [1] Github (satijalab/seurat-data@3e51f44)
#>  SeuratObject              * 5.1.0      2025-04-22 [1] CRAN (R 4.5.0)
#>  shiny                       1.11.1     2025-07-03 [1] CRAN (R 4.5.0)
#>  sp                        * 2.2-0      2025-02-01 [1] CRAN (R 4.5.0)
#>  spam                        2.11-1     2025-01-20 [1] CRAN (R 4.5.0)
#>  SparseArray                 1.8.0      2025-04-15 [1] Bioconductor 3.21 (R 4.5.0)
#>  sparseMatrixStats           1.20.0     2025-04-15 [1] Bioconductor 3.21 (R 4.5.0)
#>  spatstat.data               3.1-9      2025-10-18 [1] CRAN (R 4.5.0)
#>  spatstat.explore            3.5-3      2025-09-22 [1] CRAN (R 4.5.0)
#>  spatstat.geom               3.6-0      2025-09-20 [1] CRAN (R 4.5.0)
#>  spatstat.random             3.4-2      2025-09-21 [1] CRAN (R 4.5.0)
#>  spatstat.sparse             3.1-0      2024-06-21 [1] CRAN (R 4.5.0)
#>  spatstat.univar             3.1-4      2025-07-13 [1] CRAN (R 4.5.0)
#>  spatstat.utils              3.2-0      2025-09-20 [1] CRAN (R 4.5.0)
#>  ssHippo.SeuratData        * 3.1.4      2025-08-14 [1] local
#>  stringi                     1.8.7      2025-03-27 [1] CRAN (R 4.5.0)
#>  stringr                     1.5.2      2025-09-08 [1] CRAN (R 4.5.0)
#>  stxBrain.SeuratData       * 0.1.2      2025-11-03 [1] local
#>  stxKidney.SeuratData      * 0.1.0      2025-06-02 [1] local
#>  SummarizedExperiment        1.38.1     2025-04-28 [1] Bioconductor 3.21 (R 4.5.0)
#>  survival                    3.8-3      2024-12-17 [1] CRAN (R 4.5.0)
#>  tensor                      1.5.1      2025-06-17 [1] CRAN (R 4.5.0)
#>  thp1.eccite.SeuratData    * 3.1.5      2025-10-07 [1] local
#>  tibble                      3.3.0      2025-06-08 [1] CRAN (R 4.5.0)
#>  tidyr                       1.3.1      2024-01-24 [1] CRAN (R 4.5.0)
#>  tidyselect                  1.2.1      2024-03-11 [1] CRAN (R 4.5.0)
#>  UCSC.utils                  1.4.0      2025-04-17 [1] Bioconductor 3.21 (R 4.5.0)
#>  uwot                        0.2.3      2025-02-24 [1] CRAN (R 4.5.0)
#>  vctrs                       0.6.5      2023-12-01 [1] CRAN (R 4.5.0)
#>  viridisLite                 0.4.2      2023-05-02 [1] CRAN (R 4.5.0)
#>  withr                       3.0.2      2024-10-28 [1] CRAN (R 4.5.0)
#>  xfun                        0.53       2025-08-19 [1] CRAN (R 4.5.0)
#>  xml2                        1.4.1      2025-10-27 [1] CRAN (R 4.5.0)
#>  xtable                      1.8-4      2019-04-21 [1] CRAN (R 4.5.0)
#>  XVector                     0.48.0     2025-04-15 [1] Bioconductor 3.21 (R 4.5.0)
#>  yaml                        2.3.10     2024-07-26 [1] CRAN (R 4.5.0)
#>  zoo                         1.8-14     2025-04-10 [1] CRAN (R 4.5.0)
#> 
#>  [1] /Library/Frameworks/R.framework/Versions/4.5-arm64/Resources/library
#>  * ── Packages attached to the search path.
#> 
#> ──────────────────────────────────────────────────────────────────────────────
```

</details>