### PR TITLE
Fix link to NEWS file in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,4 @@ Seurat has been successfully installed on Mac OS X, Linux, and Windows, using th
 
 Improvements and new features will be added on a regular basis, please post on the [github page](https://github.com/satijalab/seurat) with any questions or if you would like to contribute
 
-For a version history/changelog, please see the [NEWS file](https://github.com/satijalab/seurat/blob/master/NEWS.md).
+For a version history/changelog, please see the [NEWS file](https://github.com/satijalab/seurat/blob/main/NEWS.md).


### PR DESCRIPTION
The link to NEWS file in README was still ponting to the master branch instead of the main branch

<!--
Thanks for your interest in contributing! 

Please refer the contributor's guide for instructions on submitting a pull request:
https://github.com/satijalab/seurat/wiki#contributors-guide
-->
