### PR TITLE
Fix Interaction between UpdateSeuratObject and VisiumV1 Objects

### DIFF
--- a/R/objects.R
+++ b/R/objects.R
@@ -324,7 +324,8 @@ VisiumV1 <- setClass(
     'image' = 'array',
     'scale.factors' = 'scalefactors',
     'coordinates' = 'data.frame',
-    'spot.radius' = 'numeric'
+    'spot.radius' = 'numeric',
+    "coords_x_orientation" = "character"
   )
 )
 


### PR DESCRIPTION
# Issues

The following issues have been reported at:
- https://github.com/satijalab/seurat/issues/10261

## Issue 1

Currently, attempting to perform Spatial plotting using VisiumV1 objects on Seurat versions 5.4.0+ and SeuratObject versions 5.3.0+ result in the following errors:

```{R}
Error in SpatialPlot(object) : 
  Please run `UpdateSeuratObject` on your Seurat object first to ensure that data aligns to the image slice1 when plotting.

Error updating objects in boundaries in FOV ‘slice1’
Message: ‘coords_x_orientation’ is not a slot in class “VisiumV1”
Class: simpleError, error, condition
Call: checkSlotAssignment(object, name, value)
```

Running UpdateSeuratObject on the V1 object does not resolve this issue. This is because with current UpdateSpatialPlot logic, the coords_x_orientation slot for an object's image will only be updated if that image inherits from the FOV class. While VisiumV2 objects inherit from FOV, VisiumV1 objects do not, merely inheriting from SpatialImage. This means that with existing logic, VisiumV1 objects will never be updated to have the coords_x_orientation slot:

```{R}
# From SeuratObject::UpdateSeuratObject
message("Updating slots in ", x)
        xobj <- object[[x]]
        if (inherits(x = xobj, what = 'FOV')) {
```

To address this, changes in both Seurat and SeuratObject are required. On the Seurat side, the coords_x_orientation slot should be added to the VisiumV1 class definition. Importantly, it seems that coords_x_orientation should be set to "vertical" rather than "horizontal" as it is for VisiumV2 objects:

<img width="265" height="251" alt="image" src="https://github.com/user-attachments/assets/534e44bd-c07b-4c92-a3f6-8fb90f7e1161" />

