### PR TITLE
Add alternative ggrastr-based rasterization for Dim/Feature Plots

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: Seurat
-Version: 5.4.0.9011
+Version: 5.4.0.9012
 Title: Tools for Single Cell Genomics
 Description: A toolkit for quality control, analysis, and exploration of single cell RNA sequencing data. 'Seurat' aims to enable users to identify and interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse types of single cell data. See Satija R, Farrell J, Gennert D, et al (2015) <doi:10.1038/nbt.3192>, Macosko E, Basu A, Satija R, et al (2015) <doi:10.1016/j.cell.2015.05.002>, Stuart T, Butler A, et al (2019) <doi:10.1016/j.cell.2019.05.031>, and Hao, Hao, et al (2020) <doi:10.1101/2020.10.12.335331> for more details.
 Authors@R: c(

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -8654,6 +8654,16 @@ SingleDimPlot <- function(
   raster = NULL,
   raster.dpi = NULL
 ) {
+  # IF both raster and order are TRUE, points are plotted with ggraster::geom_point_rast to maintain 
+  # correct ordering of points
+  if (isTRUE(raster) && isTRUE(order)){
+    # Check if ggrastr installed correctly
+    if (!is.null(x = raster) && isTRUE(x = raster)){
+      if (isFALSE(x = requireNamespace('ggrastr', quietly = TRUE))) {
+        stop("Please install ggrastr from CRAN to enable rasterization.")
+      }
+    }
+  }
   if ((nrow(x = data) > 1e5) & is.null(x = raster)){
     message("Rasterizing points since number of points exceeds 100,000.",
             "\nTo disable this behavior set `raster=FALSE`")

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -8760,16 +8760,30 @@ SingleDimPlot <- function(
 
   plot <- ggplot(data = data)
   plot <- if (isTRUE(x = raster)) {
-    plot + geom_scattermore(
-      mapping = aes(
-        x = .data[[dims[1]]],
-        y = .data[[dims[2]]],
-        !!!optional
-      ),
-      pointsize = pt.size,
-      alpha = alpha,
-      pixels = raster.dpi
-    )
+    # If order is FALSE, use faster geom_scattermore
+    # If order is TRUE, use slower geom_point_rast, which is needed for correct ordering of points
+    if (!isTRUE(order)){
+      plot + geom_scattermore(
+        mapping = aes(
+          x = .data[[dims[1]]],
+          y = .data[[dims[2]]],
+          !!!optional
+        ),
+        pointsize = pt.size,
+        alpha = alpha,
+        pixels = raster.dpi
+      )
+    }else{
+      plot + geom_point_rast(
+        mapping = aes(
+          x = .data[[dims[1]]],
+          y = .data[[dims[2]]],
+          !!!optional
+        ),
+        size = pt.size,
+        alpha = alpha
+      )  
+    }
   } else {
     plot + geom_point(
       mapping = aes(

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -8656,12 +8656,15 @@ SingleDimPlot <- function(
 ) {
   # IF both raster and order are TRUE, points are plotted with ggraster::geom_point_rast to maintain 
   # correct ordering of points
-  if (isTRUE(raster) && isTRUE(order)){
-    # Check if ggrastr installed correctly
-    if (!is.null(x = raster) && isTRUE(x = raster)){
-      if (isFALSE(x = requireNamespace('ggrastr', quietly = TRUE))) {
-        stop("Please install ggrastr from CRAN to enable rasterization.")
-      }
+  if (isTRUE(raster) && isTRUE(order)) {
+    # installed and loadable
+    if (!requireNamespace("ggrastr", quietly = TRUE)) {
+      stop("Please install ggrastr from CRAN to enable rasterization.")
+    }
+
+    # attached, user has run library(ggrastr)
+    if (!("package:ggrastr" %in% search())) {
+      stop("Please run library(ggrastr) to rasterize points while maintaining point order.")
     }
   }
   if ((nrow(x = data) > 1e5) & is.null(x = raster)){

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -8654,17 +8654,12 @@ SingleDimPlot <- function(
   raster = NULL,
   raster.dpi = NULL
 ) {
-  # IF both raster and order are TRUE, points are plotted with ggraster::geom_point_rast to maintain 
+  # IF both raster and order are TRUE, points are plotted with ggrastr::geom_point_rast to maintain 
   # correct ordering of points
   if (isTRUE(raster) && isTRUE(order)) {
-    # installed and loadable
-    if (!requireNamespace("ggrastr", quietly = TRUE)) {
-      stop("Please install ggrastr from CRAN to enable rasterization.")
-    }
-
-    # attached, user has run library(ggrastr)
-    if (!("package:ggrastr" %in% search())) {
-      stop("Please run library(ggrastr) to rasterize points while maintaining point order.")
+    # Check if ggrastr installed correctly and in namespace
+    if (isFALSE(x = requireNamespace('ggrastr', quietly = TRUE))){
+      stop("Please install ggrastr from CRAN to enable ordered rasterization.")
     }
   }
   if ((nrow(x = data) > 1e5) & is.null(x = raster)){
@@ -8786,8 +8781,8 @@ SingleDimPlot <- function(
         alpha = alpha,
         pixels = raster.dpi
       )
-    }else{
-      plot + geom_point_rast(
+    } else {
+      plot + ggrastr::geom_point_rast(
         mapping = aes(
           x = .data[[dims[1]]],
           y = .data[[dims[2]]],


### PR DESCRIPTION
Fixes: https://github.com/satijalab/seurat/issues/8225 

Previously, when plotting with DimPlot or FeaturePlot, users are able to set the "order" flag to True, which would ensure that points with higher values (eg: cell expression levels) are plotted atop those with lower values. However, with the adoption of geom_scattermore-based rasterization, which does not support cell order within its blending algorithm, users are unable to have both a rasterized plot with correct expression-level ordering. 

This PR addresses this issue by using ggraster::geom_point_rastr; this command rasterizes the point layer into an image when rendering the plot, and importantly maintains point order based on values. Users are able to use the geom_point_rastr render within DimPlot/FeaturePlot calls by specifying both raster = T and order = T. 

Below are plots of single-cell gene expression with these changes. The left plot was generated with ``` FeaturePlot(object, features = "rho", order = T)``` and the right plot was generated with ```FeaturePlot(object, features = "rho")```. Importantly, since the number of points within these plots exceed 100k, rasterization is used by default. With our changes, the left plot uses ggrastr::geom_point_rastr and correctly orders points by expression, while the right plot continues to use geom_scattermore and fails to order points correctly (many cells with high expression are hidden).

<img width="1042" height="484" alt="image" src="https://github.com/user-attachments/assets/2fb5c7e3-c5b4-47a0-b845-433db557747b" />

Reproducible example:

```
library(Seurat)
library(SeuratData)
library(ggrastr)
library(ggplot2)

InstallData("stxBrain")
brain <- LoadData("stxBrain", type = "anterior1")

brain <- SCTransform(brain, assay = "Spatial", verbose = FALSE)
brain <- RunPCA(brain, assay = "SCT", verbose = FALSE)

p1 <- FeaturePlot(brain, features = "Hpca", pt.size = 3, raster = T, order = T)
p2 <- FeaturePlot(brain, features = "Hpca", pt.size = 3, raster = T)
p1 + p2
```