### PR TITLE
Quick patch of InteractiveSpatialPlot CRAN check NOTES

### DIFF
--- a/R/visualization.R
+++ b/R/visualization.R
@@ -4109,8 +4109,8 @@ InteractiveSpatialPlot <- function(
     gadgetTitleBar("Select a subset of cells"),
     miniContentPanel(
       plotly::plotlyOutput("plot", height = "100%"),
-      tags$div(
-        uiOutput("selection_count"),
+      shiny::tags$div(
+        shiny::uiOutput("selection_count"),
         style = "position:absolute; bottom:8px; right:10px; padding:4px 6px; background:rgba(255,255,255,0.8); font-size:12px; border-radius:3px; pointer-events:none;"
       )
     )
@@ -4119,7 +4119,7 @@ InteractiveSpatialPlot <- function(
   # Shiny gadget server logic for interactive plot and lasso selection
   server <- function(input, output, session) {
 
-    current_selection <- reactiveVal(coords$cell)
+    current_selection <- shiny::reactiveVal(coords$cell)
 
     # Render the interactive plotly scattergl plot
     output$plot <- plotly::renderPlotly({
@@ -4189,8 +4189,8 @@ InteractiveSpatialPlot <- function(
       }
     }, ignoreInit = TRUE)
 
-    output$selection_count <- renderUI({
-      tags$span(paste0("Selected cells: ", NROW(current_selection())))
+    output$selection_count <- shiny::renderUI({
+      shiny::tags$span(paste0("Selected cells: ", NROW(current_selection())))
     })
 
     # When user clicks "Done", retrieve lasso selection and close gadget


### PR DESCRIPTION
Small patch to fix CRAN check NOTES: ```InteractiveSpatialPlot: no visible global function definition``` for uiOutput, renderUI, reactiveVal, and tags global variables. These function names are now loaded in via @importFrom from the miniUI and shiny packages in InteractiveSpatialPlot roxygen comments. 