### PR TITLE
Warning message for reference SCT model counts correction

### DIFF
--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -4160,6 +4160,9 @@ SCTransform.Assay <- function(
   if (!is.null(reference.SCT.model)){
     do.correct.umi <- FALSE
     do.center <- FALSE
+    message(
+      "NOTE:A reference SCT model was provided, therefore counts are NOT corrected (Regardless of argument passed to do.correct.umi)"
+    )
   }
 
   umi <- GetAssayData(object = object, layer = 'counts')

--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -4160,8 +4160,8 @@ SCTransform.Assay <- function(
   if (!is.null(reference.SCT.model)){
     do.correct.umi <- FALSE
     do.center <- FALSE
-    message(
-      "NOTE:A reference SCT model was provided, therefore counts are NOT corrected (Regardless of argument passed to do.correct.umi)"
+    warning(
+      "A reference SCT model was provided, therefore counts are NOT corrected (Regardless of argument passed to do.correct.umi)"
     )
   }
 


### PR DESCRIPTION
Adding a warning message so that users know if they use a reference SCT model we will hard set do.correct.umi to FALSE. We do this since count correction across models is not statistically sound, but we will send a message so that users know their counts will not be corrected. 

<!--
Thanks for your interest in contributing! 

Please refer the contributor's guide for instructions on submitting a pull request:
https://github.com/satijalab/seurat/wiki#contributors-guide
-->
