### PR TITLE
Fix SCTransform umi.assay incorrect source assay labels

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: Seurat
-Version: 5.4.0.9021
+Version: 5.4.0.9022
 Title: Tools for Single Cell Genomics
 Description: A toolkit for quality control, analysis, and exploration of single cell RNA sequencing data. 'Seurat' aims to enable users to identify and interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse types of single cell data. See Satija R, Farrell J, Gennert D, et al (2015) <doi:10.1038/nbt.3192>, Macosko E, Basu A, Satija R, et al (2015) <doi:10.1016/j.cell.2015.05.002>, Stuart T, Butler A, et al (2019) <doi:10.1016/j.cell.2019.05.031>, and Hao, Hao, et al (2020) <doi:10.1101/2020.10.12.335331> for more details.
 Authors@R: c(

--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -4298,10 +4298,10 @@ SCTransform.Seurat <- function(
   sct_models <- slot(object = assay.data, name = "SCTModel.list")
   
   # Update umi.assay field for every SCT model 
-  for (i in seq_along(sct_models)) {
-    slot(object = sct_models[[i]], name = "umi.assay") <- assay
-  }
-  slot(object = assay.data, name = "SCTModel.list") <- sct_models
+  slot(object = assay.data, name = "SCTModel.list") <- lapply(sct_models, function(model) {
+    slot(model, name = "umi.assay") <- assay
+    model
+  })
 
   object[[new.assay.name]] <- assay.data
 

--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -4294,7 +4294,10 @@ SCTransform.Seurat <- function(
                             ...)
   assay.data <- SCTAssay(assay.data, assay.orig = assay)
   
+  # Extract all SCT models stored in assay
   sct_models <- slot(object = assay.data, name = "SCTModel.list")
+  
+  # Update umi.assay field for every SCT model 
   for (i in seq_along(sct_models)) {
     slot(object = sct_models[[i]], name = "umi.assay") <- assay
   }

--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -4293,7 +4293,13 @@ SCTransform.Seurat <- function(
                             verbose = verbose,
                             ...)
   assay.data <- SCTAssay(assay.data, assay.orig = assay)
-  slot(object = slot(object = assay.data, name = "SCTModel.list")[[1]], name = "umi.assay") <- assay
+  
+  sct_models <- slot(object = assay.data, name = "SCTModel.list")
+  for (i in seq_along(sct_models)) {
+    slot(object = sct_models[[i]], name = "umi.assay") <- assay
+  }
+  slot(object = assay.data, name = "SCTModel.list") <- sct_models
+
   object[[new.assay.name]] <- assay.data
 
   if (verbose) {


### PR DESCRIPTION
Fixes: https://github.com/satijalab/seurat/issues/10323

Previously, SCTransform.Seurat() was hard-coded to only updated the umi.assay field for the first entry in SCTModel.list:

```{R}
slot(object = slot(object = assay.data, name = "SCTModel.list")[[1]], name = "umi.assay") <- assay
```

For objects with multiple SCT models, such as those created from multiple samples or layers, the remaining models did not have their source assay updated correctly, which would remain at the default "RNA" source assay. This would cause issues with downstream functions such as PrepSCTFindMarkers.

This simple change updates umi.assay for every model in SCTModel.list, so all SCT models consistently record the assay used to run SCTransform(). With these changes, individual SCT models should now correctly have their source assay assigned following SCTransform(). 

Reproducible example: 
```{R}
data("pbmc_small")

# Create fake Seurat object with two samples
rna_counts <- LayerData(pbmc_small, assay = "RNA", layer = "counts")
obj <- CreateSeuratObject(counts = rna_counts)
obj$sample <- rep(c("sample1", "sample2"), length.out = ncol(obj))

# Create new "decontX" assay
obj[["decontX"]] <- CreateAssayObject(counts = rna_counts)
obj[["decontX"]] <- split(obj[["decontX"]], f = obj$sample)

# Run SCTransform
obj <- SCTransform(
  object = obj,
  assay = "decontX",
  ncells = ncol(obj),
  variable.features.n = 20,
  return.only.var.genes = FALSE,
  conserve.memory = FALSE
)

# Inspect resulting SCT assay
# With these changes, there should be two SCT models model1 and model1.1, both with the
# decontX source assay (rather than an incorrect RNA source assay)
SCTResults(obj, slot = "umi.assay")
```