### PR TITLE
Streamline spatial plotting for Visium data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: Seurat
-Version: 5.4.0.9016
+Version: 5.4.0.9017
 Title: Tools for Single Cell Genomics
 Description: A toolkit for quality control, analysis, and exploration of single cell RNA sequencing data. 'Seurat' aims to enable users to identify and interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse types of single cell data. See Satija R, Farrell J, Gennert D, et al (2015) <doi:10.1038/nbt.3192>, Macosko E, Basu A, Satija R, et al (2015) <doi:10.1016/j.cell.2015.05.002>, Stuart T, Butler A, et al (2019) <doi:10.1016/j.cell.2019.05.031>, and Hao, Hao, et al (2020) <doi:10.1101/2020.10.12.335331> for more details.
 Authors@R: c(

--- a/R/convenience.R
+++ b/R/convenience.R
@@ -331,6 +331,7 @@ SpatialDimPlot <- function(
   image.scale = "lowres",
   shape = 21,
   stroke = NA,
+  stroke.alpha = NA,
   label.box = TRUE,
   interactive = FALSE,
   information = NULL,
@@ -357,6 +358,7 @@ SpatialDimPlot <- function(
     image.scale = image.scale,
     shape = shape,
     stroke = stroke,
+    stroke.alpha = stroke.alpha,
     label.box = label.box,
     interactive = interactive,
     information = information,
@@ -386,6 +388,7 @@ SpatialFeaturePlot <- function(
   image.scale = "lowres",
   shape = 21,
   stroke = NA,
+  stroke.alpha = NA,
   interactive = FALSE,
   information = NULL,
   plot_segmentations = FALSE
@@ -407,6 +410,7 @@ SpatialFeaturePlot <- function(
     image.scale = image.scale,
     shape = shape,
     stroke = stroke,
+    stroke.alpha = stroke.alpha,
     interactive = interactive,
     information = information,
     plot_segmentations = plot_segmentations

--- a/R/objects.R
+++ b/R/objects.R
@@ -2259,7 +2259,8 @@ dim.STARmap <- function(x) {
 #' @export
 #'
 dim.VisiumV1 <- function(x) {
-  return(dim(x = GetImage(object = x)$raster))
+  # Use mode='raw' to avoid grob creation
+  return(dim(x = GetImage(object = x, mode = 'raw'))[1:2])
 }
 
 #' @method dim VisiumV2

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -2031,8 +2031,8 @@ as.data.frame.Matrix <- function(
 #'
 #' @return A ggplot2 scale object
 #'
-#' @importFrom RColorBrewer brewer.pal brewer.pal.info scale_fill_brewer scale_color_brewer
-#' @importFrom ggplot2 scale_fill_manual scale_color_manual
+#' @importFrom RColorBrewer brewer.pal brewer.pal.info
+#' @importFrom ggplot2 scale_fill_manual scale_color_manual scale_fill_brewer scale_color_brewer
 #' @keywords internal
 #'
 #' @noRd

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -2022,6 +2022,55 @@ as.data.frame.Matrix <- function(
   return(boundaries)
 }
 
+#' Build a discrete color scale
+#' @param data Data frame containing the variable to color by
+#' @param col.by Column name in \code{data} to color by
+#' @param cols Vector of colors or a single color palette name
+#' @param na.value Color to use for NA values
+#' @param aesthetic "fill" or "color" (aesthetic to apply the scale to)
+#'
+#' @return A ggplot2 scale object
+#'
+#' @importFrom RColorBrewer brewer.pal brewer.pal.info scale_fill_brewer scale_color_brewer
+#' @importFrom ggplot2 scale_fill_manual scale_color_manual
+#' @keywords internal
+#'
+#' @noRd
+#'
+.BuildDiscreteScale <- function(data, cols, col.by, na.value, aesthetic = c("fill", "color")) {
+  aesthetic <- match.arg(arg = aesthetic)
+  manual_scale <- if (aesthetic == "fill") scale_fill_manual else scale_color_manual
+
+  if (length(x = cols) == 1 && (is.numeric(x = cols) || cols %in% rownames(x = brewer.pal.info))) {
+    manual_scale <- if (aesthetic == "fill") scale_fill_brewer else scale_color_brewer
+  } else if (length(x = cols) == 1 && (cols %in% c('alphabet', 'alphabet2', 'glasbey', 'polychrome', 'stepped'))) {
+    palette <- DiscretePalette(length(unique(data[[col.by]])), palette = cols)
+  } else {
+    vals <- sort(unique(data[[col.by]]))
+    # n_groups is number of discrete groups/clusters that need colours
+    n_groups <- length(vals)
+
+    # Check whether 'cols' can be treated as a manual mapping
+    has_valid_names <- !is.null(names(cols)) && !anyNA(names(cols)) && all(names(cols) != "")
+
+    # cols must be a named vector to be treated as an explicit mapping from group->color
+    # otherwise assign to groups in order
+    if (has_valid_names) {
+      palette <- cols[vals]
+      if (anyNA(cols)) {
+        warning("Missing color mappings for ", paste(vals[is.na(cols)], collapse = ", "))
+      }
+    } else {
+      if (length(cols) != n_groups) {
+        warning("Number of colors does not match number of groups; adjusting.")
+      }
+      palette <- rep_len(cols, n_groups)
+      names(palette) <- vals
+    }
+  }
+  return(manual_scale(values = palette, na.value = na.value))
+}
+
 # Generate chunk points
 #
 # @param dsize How big is the data being chunked

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -2043,6 +2043,7 @@ as.data.frame.Matrix <- function(
 
   if (length(x = cols) == 1 && (is.numeric(x = cols) || cols %in% rownames(x = brewer.pal.info))) {
     manual_scale <- if (aesthetic == "fill") scale_fill_brewer else scale_color_brewer
+    return(manual_scale(palette = cols, na.value = na.value))
   } else if (length(x = cols) == 1 && (cols %in% c('alphabet', 'alphabet2', 'glasbey', 'polychrome', 'stepped'))) {
     palette <- DiscretePalette(length(unique(data[[col.by]])), palette = cols)
   } else {

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -2058,12 +2058,16 @@ as.data.frame.Matrix <- function(
     # otherwise assign to groups in order
     if (has_valid_names) {
       palette <- cols[vals]
-      if (anyNA(cols)) {
-        warning("Missing color mappings for ", paste(vals[is.na(cols)], collapse = ", "))
+      if (anyNA(palette)) {
+        warning("Missing color mappings for ", paste(vals[is.na(palette)], collapse = ", "), 
+                call. = FALSE, 
+                immediate. = TRUE)
       }
     } else {
       if (length(cols) != n_groups) {
-        warning("Number of colors does not match number of groups; adjusting.")
+        warning("Number of colors does not match number of groups; adjusting.",
+                call. = FALSE,
+                immediate. = TRUE)
       }
       palette <- rep_len(cols, n_groups)
       names(palette) <- vals

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -7488,7 +7488,7 @@ GeomSpatial <- ggproto(
     point.size <- base.point.size * data$point.size.factor
     coords <- coord$transform(data, panel_scales)
 
-    coords$stroke <- alpha(
+    stroke_color <- alpha(
       "black",
       ifelse(is.na(coords$stroke.alpha), coords$alpha, coords$stroke.alpha)
     )
@@ -7500,7 +7500,8 @@ GeomSpatial <- ggproto(
       size = point.size,
       gp = gpar(
         fill = alpha(colour = coords$fill, alpha = coords$alpha),
-        col = coords$stroke
+        col = stroke_color,
+        lwd = coords$stroke
       )
     )
     canvas_viewport <- viewport()

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -7487,18 +7487,21 @@ GeomSpatial <- ggproto(
     }
     point.size <- base.point.size * data$point.size.factor
     coords <- coord$transform(data, panel_scales)
+
+    coords$stroke <- alpha(
+      "black",
+      ifelse(is.na(coords$stroke.alpha), coords$alpha, coords$stroke.alpha)
+    )
+
     pts <- pointsGrob(
       x = coords$x,
       y = coords$y,
       pch = data$shape,
       size = point.size,
       gp = gpar(
-        col = alpha(
-          colour = coords$colour,
-          alpha = coords$stroke.alpha %||% coords$alpha
-        ),
         fill = alpha(colour = coords$fill, alpha = coords$alpha),
-        lwd = coords$stroke)
+        col = coords$stroke
+      )
     )
     canvas_viewport <- viewport()
     gt <- gTree(vp = canvas_viewport) # empty gTree to add the image and points to
@@ -9696,7 +9699,7 @@ SingleSpatialPlot <- function(
     },
     'poly' = {
       stroke.color <- if (is.na(x = stroke.alpha)) {
-        "black"
+        alpha("black", pt.alpha)
       } else {
         alpha("black", stroke.alpha)
       }

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -4529,22 +4529,20 @@ SpatialPlot <- function(
       )
     }
 
-    coordinates <- GetTissueCoordinates(
-      object = image.use,
-      scale = image.scale
-    )
-
-    if (is_visium_v2) {
-      # if the rownames do not match the cell ids, then dataframe is not created properly
-      rownames(coordinates) <- coordinates$cell
+    # When plotting segmentations, set the default boundary (temporarily) to segmentations
+    if (plot_segmentations == TRUE && inherits(image.use, "VisiumV2") && 
+        "segmentations" %in% names(image.use)) {
+      db <- DefaultBoundary(image.use)
+      on.exit(DefaultBoundary(image.use) <- db, add = TRUE) # Reset on exit
+      DefaultBoundary(image.use) <- "segmentations"
     }
-
+    coordinates <- GetTissueCoordinates(object = image.use, scale = image.scale)
     highlight.use <- if (facet.highlight) {
       cells.highlight[i]
     } else {
       cells.highlight
     }
-    for (j in 1:length(x = features)) {
+    for (j in seq_along(features)) {
       cols.unset <- is.factor(x = data[, features[j]]) && is.null(x = cols)
       if (cols.unset) {
         cols <- hue_pal()(n = length(x = levels(x = data[, features[j]])))
@@ -4556,16 +4554,16 @@ SpatialPlot <- function(
         max.feature.value <- max(data[, features[j]])
       }
 
-      # Check if object is of type Visium and contains segmentations (attached via Load10X_Spatial)
-      has_visium_segm_data <- (inherits(image.use, "VisiumV2") &&
-                      !is.null(image.use@boundaries$segmentations) &&
-                      "sf.data" %in% slotNames(image.use@boundaries$segmentations))
+      # Check if object is of type Visium and contains segmentations
+      has_visium_segm_data <- inherits(image.use, "VisiumV2") &&
+                              !is.null(image.use@boundaries$segmentations) &&
+                              "sf.data" %in% slotNames(image.use@boundaries$segmentations)
+
+      idx <- match(coordinates$cell, rownames(x = data))
+      plot.data <- cbind(coordinates, data[idx, features[j], drop = FALSE])
 
       plot <- SingleSpatialPlot(
-        data = cbind(
-          coordinates,
-          data[rownames(x = coordinates), features[j], drop = FALSE]
-        ),
+        data = plot.data,
         image = image.use,
         image.scale = image.scale,
         image.alpha = image.alpha,
@@ -4583,7 +4581,7 @@ SpatialPlot <- function(
         },
         geom = if (inherits(x = image.use, what = "STARmap")) {
           "poly_starmap"
-        } else if (has_visium_segm_data) {
+        } else if (has_visium_segm_data && plot_segmentations) {
           "poly"
         } else {
           "spatial"
@@ -4593,8 +4591,7 @@ SpatialPlot <- function(
         pt.size.factor = pt.size.factor,
         shape = shape,
         stroke = stroke,
-        crop = crop,
-        plot_segmentations = plot_segmentations
+        crop = crop
       )
       if (is.null(x = group.by)) {
         plot <- plot +

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -7459,9 +7459,10 @@ GeomSpatial <- ggproto(
       data.frame(x = c(0, img.dim[[2]]), y = c(0, img.dim[[1]])),
       panel_scales
     )
+    # Construct viewport for the plot based on img dimensions and plot coords
     wdth <- z$x[2] - z$x[1]
     hgth <- z$y[2] - z$y[1]
-    vp <- viewport(
+    plot_viewport <- viewport(
       x = unit(x = z$x[1], units = "npc"),
       y = unit(x = z$y[1], units = "npc"),
       width = unit(x = wdth, units = "npc"),
@@ -7471,8 +7472,6 @@ GeomSpatial <- ggproto(
 
     spot.size <- Radius(object = image, scale = image.scale)
     coords <- coord$transform(data, panel_scales)
-
-    img <- editGrob(grob = GetImage(image), vp = vp)
     pts <- pointsGrob(
       x = coords$x,
       y = coords$y,
@@ -7483,9 +7482,12 @@ GeomSpatial <- ggproto(
         fill = alpha(colour = coords$fill, alpha = coords$alpha),
         lwd = coords$stroke)
     )
-    vp <- viewport()
-    gt <- gTree(vp = vp)
+    canvas_viewport <- viewport()
+    gt <- gTree(vp = canvas_viewport) # empty gTree to add the image and points to
+    # Only draw the image if it has a non-zero alpha value, otherwise just draw the points
     if (image.alpha > 0) {
+      img_grob <- GetImage(image)
+      img <- editGrob(grob = img_grob, vp = plot_viewport)
       if (image.alpha != 1) {
         img$raster = as.raster(
           x = matrix(

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -4283,8 +4283,8 @@ InteractiveSpatialPlot <- function(
 #' @param shape Control the shape of the spots - same as the ggplot2 parameter.
 #' The default is 21, which plots circles - use 22 to plot squares.
 #' @param stroke Control the width of the border around the spots
-#' @param stroke.alpha Opacity of spot borders. Set to \\code{NA} to use the
-#' same alpha as the spot fill.
+#' @param stroke.alpha Control the opacity of spot borders (when stroke is specified). 
+#' Set to \code{NA} to use the same alpha as the fill.
 #' @param interactive Launch an interactive SpatialDimPlot or SpatialFeaturePlot
 #' session, see \code{\link{ISpatialDimPlot}} or
 #' \code{\link{ISpatialFeaturePlot}} for more details
@@ -9502,8 +9502,8 @@ SingleRasterMap <- function(
 #' to show entire background image.
 #' @param pt.size.factor Sets the size of the points relative to spot.radius
 #' @param stroke Control the width of the border around the spots
-#' @param stroke.alpha Opacity of spot borders. Set to \code{NA} (default) to use the
-#' same alpha as the fill.
+#' @param stroke.alpha Control the opacity of spot borders (when stroke is specified). 
+#' Set to \code{NA} to use the same alpha as the fill.
 #' @param shape Control the shape of the spots - same as the ggplot2 parameter.
 #' The default is 21, which plots cirlces - use 22 to plot squares.
 #' @param col.by Mapping variable for the point color

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -9721,43 +9721,19 @@ SingleSpatialPlot <- function(
     },
     stop("Unknown geom, choose from 'spatial' or 'interactive'", call. = FALSE)
   )
+  scale.aesthetic <- if (geom == "interactive") "color" else "fill"
   if (!is.null(x = cells.highlight)) {
-    plot <- plot + scale_fill_manual(values = cols.highlight)
+    plot <- plot + if (scale.aesthetic == "fill") {
+      scale_fill_manual(values = cols.highlight)
+    } else {
+      scale_color_manual(values = cols.highlight)
+    }
   }
   if (!is.null(x = cols) && is.null(x = cells.highlight)) {
-    if (length(x = cols) == 1 && (is.numeric(x = cols) || cols %in% rownames(x = brewer.pal.info))) {
-      scale <- scale_fill_brewer(palette = cols, na.value = na.value)
-    } else if (length(x = cols) == 1 && (cols %in% c('alphabet', 'alphabet2', 'glasbey', 'polychrome', 'stepped'))) {
-      colors <- DiscretePalette(length(unique(data[[col.by.clean]])), palette = cols)
-      scale <- scale_fill_manual(values = colors, na.value = na.value)
-    } else {
+    if (length(x = col.by.clean) == 1L && nzchar(x = col.by.clean)) {
       data[[col.by.clean]] <- as.character(data[[col.by.clean]])
-      
-      vals <- sort(unique(data[[col.by.clean]]))
-      # n_groups is number of discrete groups/clusters that need colours
-      n_groups <- length(vals)
-      # Check whether 'cols' can be treated as a manual mapping
-      has_valid_names <- !is.null(names(cols)) && !anyNA(names(cols)) && all(names(cols) != "")
-    
-      # cols must be a named vector 
-      # If cols is unnamed, then names(cols) is NULL
-      # Cols is then subsetted down to length 0 
-     if (has_valid_names) {
-        cols <- cols[vals]
-        if (anyNA(cols)) {
-          warning("Missing color mappings for ", paste(vals[is.na(cols)], collapse = ", "))
-        }
-      } else {
-        if (length(cols) != n_groups) {
-          warning("Number of colors does not match number of groups; adjusting.")
-        }
-        cols <- rep_len(cols, n_groups)
-        names(cols) <- vals
-      }
-      scale <- scale_fill_manual(values = cols, na.value = na.value)
-      scale <- scale_fill_manual(values = cols, na.value = na.value)
+      plot <- plot + .BuildDiscreteScale(data = data, cols = cols, col.by = col.by.clean, na.value = na.value, aesthetic = scale.aesthetic)
     }
-    plot <- plot + scale
   }
   plot <- plot + NoAxes() + theme(panel.background = element_blank())
   return(plot)

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -4283,6 +4283,8 @@ InteractiveSpatialPlot <- function(
 #' @param shape Control the shape of the spots - same as the ggplot2 parameter.
 #' The default is 21, which plots circles - use 22 to plot squares.
 #' @param stroke Control the width of the border around the spots
+#' @param stroke.alpha Opacity of spot borders. Set to \\code{NA} to use the
+#' same alpha as the spot fill.
 #' @param interactive Launch an interactive SpatialDimPlot or SpatialFeaturePlot
 #' session, see \code{\link{ISpatialDimPlot}} or
 #' \code{\link{ISpatialFeaturePlot}} for more details
@@ -4339,6 +4341,7 @@ SpatialPlot <- function(
   alpha = c(1, 1),
   shape = 21,
   stroke = NA,
+  stroke.alpha = NA,
   interactive = FALSE,
   do.identify = FALSE,
   identify.ident = NULL,
@@ -4596,6 +4599,7 @@ SpatialPlot <- function(
         pt.size.factor = pt.size.factor,
         shape = shape,
         stroke = stroke,
+        stroke.alpha = stroke.alpha,
         crop = crop
       )
       if (is.null(x = group.by)) {
@@ -7439,7 +7443,8 @@ GeomSpatial <- ggproto(
     point.size.factor = 1.0,
     fill = NA,
     alpha = NA,
-    stroke = NA
+    stroke = NA,
+    stroke.alpha = NA
   ),
   setup_data = function(self, data, params) {
     data <- ggproto_parent(Geom, self)$setup_data(data, params)
@@ -7488,7 +7493,10 @@ GeomSpatial <- ggproto(
       pch = data$shape,
       size = point.size,
       gp = gpar(
-        col = alpha(colour = coords$colour, alpha = coords$alpha),
+        col = alpha(
+          colour = coords$colour,
+          alpha = coords$stroke.alpha %||% coords$alpha
+        ),
         fill = alpha(colour = coords$fill, alpha = coords$alpha),
         lwd = coords$stroke)
     )
@@ -9490,6 +9498,8 @@ SingleRasterMap <- function(
 #' to show entire background image.
 #' @param pt.size.factor Sets the size of the points relative to spot.radius
 #' @param stroke Control the width of the border around the spots
+#' @param stroke.alpha Opacity of spot borders. Set to \code{NA} (default) to use the
+#' same alpha as the fill.
 #' @param shape Control the shape of the spots - same as the ggplot2 parameter.
 #' The default is 21, which plots cirlces - use 22 to plot squares.
 #' @param col.by Mapping variable for the point color
@@ -9527,6 +9537,7 @@ SingleSpatialPlot <- function(
   pt.size.factor = NULL,
   shape = 21,
   stroke = NA,
+  stroke.alpha = NA,
   col.by = NULL,
   alpha.by = NULL,
   cells.highlight = NULL,
@@ -9642,7 +9653,8 @@ SingleSpatialPlot <- function(
           image.scale = image.scale,
           crop = crop,
           shape = shape,
-          stroke = stroke
+          stroke = stroke,
+          stroke.alpha = stroke.alpha
         )
       } else {
         geom_spatial(
@@ -9654,6 +9666,7 @@ SingleSpatialPlot <- function(
           crop = crop,
           shape = shape,
           stroke = stroke,
+          stroke.alpha = stroke.alpha,
           alpha = pt.alpha
         )
       }
@@ -9682,11 +9695,16 @@ SingleSpatialPlot <- function(
         coord_cartesian(expand = FALSE)
     },
     'poly' = {
+      stroke.color <- if (is.na(x = stroke.alpha)) {
+        "black"
+      } else {
+        alpha("black", stroke.alpha)
+      }
       geom_poly_layer <- if (is.null(pt.alpha)) {
         geom_polygon(
           data = data,
           aes(x = .data[[xname]], y = .data[[yname]], fill = !!col.by.plot, alpha = !!alpha.by, group = .data[['cell']]),
-          color = "black",
+          color = stroke.color,
           linewidth = stroke
         )
       } else {
@@ -9694,7 +9712,7 @@ SingleSpatialPlot <- function(
           data = data,
           aes(x = .data[[xname]], y = .data[[yname]], fill = !!col.by.plot, group = .data[['cell']]),
           alpha = pt.alpha,
-          color = "black",
+          color = stroke.color,
           linewidth = stroke
         )
       }

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -7470,13 +7470,20 @@ GeomSpatial <- ggproto(
       just = c("left", "top")
     )
 
-    spot.size <- Radius(object = image, scale = image.scale)
+    # Calculate spot size relative to the image size to be consistent across different images and scales
+    spot.radius <- Radius(object = image, scale = image.scale)
+    base.point.size <- if (length(spot.radius) == 1L) {
+      unit(spot.radius, "npc")
+    } else {
+      unit(rep_len(1, nrow(data)), "mm")
+    }
+    point.size <- base.point.size * data$point.size.factor
     coords <- coord$transform(data, panel_scales)
     pts <- pointsGrob(
       x = coords$x,
       y = coords$y,
       pch = data$shape,
-      size = unit(spot.size, "npc") * data$point.size.factor,
+      size = point.size,
       gp = gpar(
         col = alpha(colour = coords$colour, alpha = coords$alpha),
         fill = alpha(colour = coords$fill, alpha = coords$alpha),

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -9532,6 +9532,64 @@ SingleSpatialPlot <- function(
   na.value = 'grey50'
 ) {
   geom <- match.arg(arg = geom)
+  image_dim <- dim(image)
+  image.height <- image_dim[1]
+  image.width <- image_dim[2]
+  ggplot_version_4 <- packageVersion("ggplot2") >= "4.0.0"
+
+  # Helper to set coord limits based on image dimensions
+  coord_limits <- function() {
+    xlim <- if (!crop) c(0, image.width) else NULL
+    ylim <- NULL
+    if (!crop) {
+      if (!ggplot_version_4) {
+        message("Changing coordinate limits to work with ggplot2 < 4.0.0.")
+        ylim <- c(image.height, 0)
+      } else {
+        ylim <- c(0, image.height)
+      }
+    }
+    list(x = xlim, y = ylim)
+  }
+
+  # Helper to create custom annotation layer for the background image 
+  build_image_annotation <- function() {
+    if (image.alpha == 0) {
+      return(NULL)
+    }
+    image_to_plot <- GetImage(object = image, mode = "raw")
+    if (image.alpha < 1) {
+      rgba_image <- array(data = NA, dim = c(image_dim[1:2], 4))
+      rgba_image[, , 1:3] <- image_to_plot
+      rgba_image[, , 4] <- image.alpha
+      image_to_plot <- rgba_image
+    }
+    image.grob <- rasterGrob(
+      image_to_plot,
+      width = unit(1, "npc"),
+      height = unit(1, "npc"),
+      interpolate = FALSE
+    )
+    if (!ggplot_version_4) {
+      message("Changing image annotation limits to work with ggplot2 < 4.0.0.")
+      return(annotation_custom(
+        grob = image.grob,
+        xmin = 0,
+        xmax = image.width,
+        ymin = -image.height,
+        ymax = 0
+      ))
+    }
+    return(annotation_custom(
+      grob = image.grob,
+      xmin = 0,
+      xmax = image.width,
+      ymin = 0,
+      ymax = image.height
+    ))
+  }
+
+  limits <- coord_limits()
 
   if (!is.null(col.by) && !col.by %in% colnames(data)) {
     warning("Cannot find '", col.by, "' in data, not coloring", call. = FALSE, immediate. = TRUE)
@@ -9552,25 +9610,28 @@ SingleSpatialPlot <- function(
     levels(x = data$ident) <- c(order, setdiff(x = levels(x = data$ident), y = order))
     data <- data[order(data$ident), ]
   }
-  col.by.plot <- col.by %iff% data_sym(col.by) #had to create second variable to safely use tidyeval in plotting but not effect subsetting in gsub call later in function
-  col.by <- col.by %iff% paste0("`", col.by, "`")
 
-  # Store unquoted col.by name for easier access
-  col.by.clean <- gsub("`", "", col.by)
+  col.by.plot <- col.by %iff% data_sym(col.by) # for use in aes() if not NULL
+  col.by <- col.by %iff% paste0("`", col.by, "`") # quote + wrap in backticks for safe direct use within [[ ]]
+  col.by.clean <- gsub("`", "", col.by) # quote
 
   alpha.by <- alpha.by %iff% data_sym(alpha.by)
 
+  xname <- colnames(x = data)[1]
+  yname <- colnames(x = data)[2]
+
   plot <- ggplot(data = data, aes(
-    x = .data[[colnames(x = data)[1]]],
-    y = .data[[colnames(x = data)[2]]],
+    x = .data[[xname]],
+    y = .data[[yname]],
     fill = !!col.by.plot,
     alpha = !!alpha.by
   ))
+
   plot <- switch(
     EXPR = geom,
     'spatial' = {
-      if (is.null(x = pt.alpha)) {
-        plot <- plot + geom_spatial(
+      geom_spatial_layer <- if (is.null(pt.alpha)) {
+        geom_spatial(
           point.size.factor = pt.size.factor,
           data = data,
           image = image,
@@ -9578,10 +9639,10 @@ SingleSpatialPlot <- function(
           image.scale = image.scale,
           crop = crop,
           shape = shape,
-          stroke = stroke,
+          stroke = stroke
         )
       } else {
-        plot <- plot + geom_spatial(
+        geom_spatial(
           point.size.factor = pt.size.factor,
           data = data,
           image = image,
@@ -9593,24 +9654,10 @@ SingleSpatialPlot <- function(
           alpha = pt.alpha
         )
       }
-      
-      xlim <- NULL
-      ylim <- NULL
-
-      if (.hasSlot(object = image, name = "image") && !crop) {
-        image.height <- dim(image@image)[1]
-        image.width <- dim(image@image)[2]
-
-        xlim <- c(0, image.width)
-        if (packageVersion("ggplot2") < "4.0.0") {
-          message("Changing coordinate limits to work with ggplot2 < 4.0.0.")
-          ylim <- c(image.height, 0)
-        } else {
-          ylim <- c(0, image.height)
-        }
-      }
-      
-      plot + coord_fixed(xlim = xlim, ylim = ylim) + scale_y_reverse()
+      plot + geom_spatial_layer +
+        coord_fixed(xlim = limits$x, ylim = limits$y) + 
+        scale_y_reverse() +
+        theme_void()
     },
     'interactive' = {
       plot + geom_spatial_interactive(
@@ -9632,128 +9679,28 @@ SingleSpatialPlot <- function(
         coord_cartesian(expand = FALSE)
     },
     'poly' = {
-      image_to_plot <- image@image
-      image.height <- dim(image_to_plot)[1]
-      image.width <- dim(image_to_plot)[2]
-
-      # Apply image transparency
-      if (image.alpha < 1) {
-          # Convert image to RGBA by adding alpha channel
-          rgba_image <- array(data = NA, dim = c(dim(image_to_plot)[1:2], 4))
-          rgba_image[,,1:3] <- image_to_plot
-          rgba_image[,,4] <- image.alpha
-          image_to_plot <- rgba_image
-      }
-      
-      # Validate image
-      image.grob <- rasterGrob(
-        image_to_plot,
-        width = unit(1, "npc"),
-        height = unit(1, "npc"),
-        interpolate = FALSE
-      )
-
-      # Retrieve scale factor from specified image scale ("lowres"/"hires")
-      scale.factor <- ScaleFactors(image)[[image.scale]]
-      if (is.null(scale.factor)) stop("Scale factor for '", image.scale, "' not found")
-      
-      
-      # Extract and scale segmentation data
-      segm_data <- image@boundaries$segmentations@sf.data
-      segm_data$x <- segm_data$x * scale.factor
-      segm_data$y <- segm_data$y * scale.factor
-
-      # Merge segmentation data with expression data and centroid coordinates
-      plot_data <- merge(segm_data,
-                        data,
-                        by = "cell",
-                        suffixes = c("", ".centroid"),
-                        sort = FALSE)
-      xlim <- if (!crop) c(0, image.width) else NULL
-      ylim <- NULL
-      if (packageVersion("ggplot2") < "4.0.0") {
-        message("Changing image annotation limits to work with ggplot2 < 4.0.0.")
-        image_annotation_layer <- annotation_custom(
-                              grob = image.grob,
-                              xmin = 0,
-                              xmax = image.width,
-                              ymin = -image.height,
-                              ymax = 0)
-        if (!crop) {
-          message("Changing coordinate limits to work with ggplot2 < 4.0.0.")
-          ylim <- c(image.height, 0)
-        }
+      geom_poly_layer <- if (is.null(pt.alpha)) {
+        geom_polygon(
+          data = data,
+          aes(x = .data[[xname]], y = .data[[yname]], fill = !!col.by.plot, alpha = !!alpha.by, group = .data[['cell']]),
+          color = "black",
+          linewidth = stroke
+        )
       } else {
-        image_annotation_layer <- annotation_custom(
-                              grob = image.grob,
-                              xmin = 0,
-                              xmax = image.width,
-                              ymin = 0,
-                              ymax = image.height)
-        ylim <- if (!crop) c(0, image.height) else NULL
+        geom_polygon(
+          data = data,
+          aes(x = .data[[xname]], y = .data[[yname]], fill = !!col.by.plot, group = .data[['cell']]),
+          alpha = pt.alpha,
+          color = "black",
+          linewidth = stroke
+        )
       }
-
-      # Create appropriate geom layer based on plot_segmentations
-      if (!plot_segmentations) {
-        #If plot_segmentations FALSE, then plot just the polygon centroids 
-        if (is.null(pt.alpha)) {
-          #If pt.alpha not provided, then alpha parameter is derived from group/cluster data
-          #Use alpha.by instead of pt.alpha
-          geom_point_layer <- geom_point(
-            data = plot_data,
-            shape = 21, 
-            stroke = stroke,
-            size = pt.size.factor,
-            aes(x = .data[['x.centroid']], y = .data[['y.centroid']], fill = !!col.by.plot, alpha = !!alpha.by)
-          )
-        } else {
-          geom_point_layer <- geom_point(
-            data = plot_data,
-            shape = 21,
-            stroke = stroke,
-            size = pt.size.factor,
-            aes(x = .data[['x.centroid']], y = .data[['y.centroid']], fill = !!col.by.plot),
-            alpha = pt.alpha
-          )
-        }
-        ggplot() +
-            image_annotation_layer +
-            geom_point_layer +
-            scale_y_reverse() + 
-            xlab("x") +
-            ylab("y") +
-            coord_fixed(xlim = xlim, ylim = ylim) +
-            theme_void()
-      } else {
-        
-        if (is.null(pt.alpha)) {
-          # If pt.alpha is not provided, then alpha is derived from group/cluster data
-          # Use alpha.by instead of pt.alpha
-          geom_polygon_layer <- geom_polygon(
-            data = plot_data,
-            aes(x = .data[['x']], y = .data[['y']], fill = !!col.by.plot, alpha = !!alpha.by, group = .data[['cell']]),
-            color = "black",
-            linewidth = stroke
-          )
-        } else {
-          # If pt.alpha is indeed provided, then use that to define alpha
-          geom_polygon_layer <- geom_polygon(
-            data = plot_data,
-            aes(x = .data[['x']], y = .data[['y']], fill = !!col.by.plot, group = .data[['cell']]),
-            alpha = pt.alpha,
-            color = "black",
-            linewidth = stroke
-          )
-        }
-        ggplot() +
-            image_annotation_layer +
-            geom_polygon_layer +
-            scale_y_reverse() + 
-            xlab("x") +
-            ylab("y") +
-            coord_fixed(xlim = xlim, ylim = ylim) +
-            theme_void()
-      }
+      ggplot() +
+        build_image_annotation() +
+        geom_poly_layer +
+        scale_y_reverse() +
+        coord_fixed(xlim = limits$x, ylim = limits$y) +
+        theme_void()
     },
     'poly_starmap' = {
       data$cell <- rownames(x = data)

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -4559,6 +4559,11 @@ SpatialPlot <- function(
                               !is.null(image.use@boundaries$segmentations) &&
                               "sf.data" %in% slotNames(image.use@boundaries$segmentations)
 
+      # GetTissueCoordinates will not always return a "cell" column (e.g., Visium V1)
+      if (!("cell" %in% colnames(x = coordinates))) {
+        coordinates$cell <- rownames(x = coordinates)
+      }
+
       idx <- match(coordinates$cell, rownames(x = data))
       plot.data <- cbind(coordinates, data[idx, features[j], drop = FALSE])
 

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -9501,7 +9501,6 @@ SingleRasterMap <- function(
 #' @param geom Switch between normal spatial geom and geom to enable hover
 #' functionality
 #' @param na.value Color for spots with NA values
-#' @param plot_segmentations Define whether plot should plot centroids or segmentations
 #'
 #' @return A ggplot2 object
 #'
@@ -9530,8 +9529,7 @@ SingleSpatialPlot <- function(
   cells.highlight = NULL,
   cols.highlight = c('#DE2D26', 'grey50'),
   geom = c('spatial', 'interactive', 'poly', 'poly_starmap'),
-  na.value = 'grey50',
-  plot_segmentations = FALSE
+  na.value = 'grey50'
 ) {
   geom <- match.arg(arg = geom)
 

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -4617,8 +4617,6 @@ SpatialPlot <- function(
           ),
           geom = if (inherits(x = image.use, what = "STARmap") || (has_visium_segm_data && plot_segmentations)) {
             'GeomPolygon'
-          } else if (has_visium_segm_data && !plot_segmentations) {
-            'GeomPoint'
           } else {
             'GeomSpatial'
           },

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -9699,24 +9699,28 @@ SingleSpatialPlot <- function(
         coord_cartesian(expand = FALSE)
     },
     'poly' = {
-      stroke.color <- if (is.na(x = stroke.alpha)) {
-        alpha("black", pt.alpha)
-      } else {
-        alpha("black", stroke.alpha)
-      }
+      # define aesthetics for geom_polygon layer based on if pt.alpha (SDP) or alpha.by (SFP) is set
       geom_poly_layer <- if (is.null(pt.alpha)) {
-        geom_polygon(
-          data = data,
-          aes(x = .data[[xname]], y = .data[[yname]], fill = !!col.by.plot, alpha = !!alpha.by, group = .data[['cell']]),
-          color = stroke.color,
-          linewidth = stroke
-        )
+        if (is.na(x = stroke.alpha)) {
+          geom_polygon(
+            data = data,
+            aes(x = .data[[xname]], y = .data[[yname]], fill = !!col.by.plot, alpha = !!alpha.by, group = .data[['cell']], color = after_scale(alpha("black", alpha))),
+            linewidth = stroke
+          )
+        } else {
+          geom_polygon(
+            data = data,
+            aes(x = .data[[xname]], y = .data[[yname]], fill = !!col.by.plot, alpha = !!alpha.by, group = .data[['cell']]),
+            color = alpha("black", stroke.alpha),
+            linewidth = stroke
+          )
+        }
       } else {
         geom_polygon(
           data = data,
           aes(x = .data[[xname]], y = .data[[yname]], fill = !!col.by.plot, group = .data[['cell']]),
           alpha = pt.alpha,
-          color = stroke.color,
+          color = if (is.na(x = stroke.alpha)) alpha("black", pt.alpha) else alpha("black", stroke.alpha),
           linewidth = stroke
         )
       }

--- a/man/SingleSpatialPlot.Rd
+++ b/man/SingleSpatialPlot.Rd
@@ -20,8 +20,7 @@ SingleSpatialPlot(
   cells.highlight = NULL,
   cols.highlight = c("#DE2D26", "grey50"),
   geom = c("spatial", "interactive", "poly", "poly_starmap"),
-  na.value = "grey50",
-  plot_segmentations = FALSE
+  na.value = "grey50"
 )
 }
 \arguments{
@@ -71,8 +70,6 @@ unselected cells.}
 functionality}
 
 \item{na.value}{Color for spots with NA values}
-
-\item{plot_segmentations}{Define whether plot should plot centroids or segmentations}
 }
 \value{
 A ggplot2 object

--- a/man/SingleSpatialPlot.Rd
+++ b/man/SingleSpatialPlot.Rd
@@ -54,8 +54,8 @@ The default is 21, which plots cirlces - use 22 to plot squares.}
 
 \item{stroke}{Control the width of the border around the spots}
 
-\item{stroke.alpha}{Opacity of spot borders. Set to \code{NA} (default) to use the
-same alpha as the fill.}
+\item{stroke.alpha}{Control the opacity of spot borders (when stroke is specified). 
+Set to \code{NA} to use the same alpha as the fill.}
 
 \item{col.by}{Mapping variable for the point color}
 

--- a/man/SingleSpatialPlot.Rd
+++ b/man/SingleSpatialPlot.Rd
@@ -15,6 +15,7 @@ SingleSpatialPlot(
   pt.size.factor = NULL,
   shape = 21,
   stroke = NA,
+  stroke.alpha = NA,
   col.by = NULL,
   alpha.by = NULL,
   cells.highlight = NULL,
@@ -52,6 +53,9 @@ to show entire background image.}
 The default is 21, which plots cirlces - use 22 to plot squares.}
 
 \item{stroke}{Control the width of the border around the spots}
+
+\item{stroke.alpha}{Opacity of spot borders. Set to \code{NA} (default) to use the
+same alpha as the fill.}
 
 \item{col.by}{Mapping variable for the point color}
 

--- a/man/SpatialPlot.Rd
+++ b/man/SpatialPlot.Rd
@@ -177,8 +177,8 @@ The default is 21, which plots circles - use 22 to plot squares.}
 
 \item{stroke}{Control the width of the border around the spots}
 
-\item{stroke.alpha}{Opacity of spot borders. Set to \\code{NA} to use the
-same alpha as the spot fill.}
+\item{stroke.alpha}{Control the opacity of spot borders (when stroke is specified). 
+Set to \code{NA} to use the same alpha as the fill.}
 
 \item{interactive}{Launch an interactive SpatialDimPlot or SpatialFeaturePlot
 session, see \code{\link{ISpatialDimPlot}} or

--- a/man/SpatialPlot.Rd
+++ b/man/SpatialPlot.Rd
@@ -33,6 +33,7 @@ SpatialPlot(
   alpha = c(1, 1),
   shape = 21,
   stroke = NA,
+  stroke.alpha = NA,
   interactive = FALSE,
   do.identify = FALSE,
   identify.ident = NULL,
@@ -62,6 +63,7 @@ SpatialDimPlot(
   image.scale = "lowres",
   shape = 21,
   stroke = NA,
+  stroke.alpha = NA,
   label.box = TRUE,
   interactive = FALSE,
   information = NULL,
@@ -85,6 +87,7 @@ SpatialFeaturePlot(
   image.scale = "lowres",
   shape = 21,
   stroke = NA,
+  stroke.alpha = NA,
   interactive = FALSE,
   information = NULL,
   plot_segmentations = FALSE
@@ -173,6 +176,9 @@ alpha value for each plot.}
 The default is 21, which plots circles - use 22 to plot squares.}
 
 \item{stroke}{Control the width of the border around the spots}
+
+\item{stroke.alpha}{Opacity of spot borders. Set to \\code{NA} to use the
+same alpha as the spot fill.}
 
 \item{interactive}{Launch an interactive SpatialDimPlot or SpatialFeaturePlot
 session, see \code{\link{ISpatialDimPlot}} or


### PR DESCRIPTION
# Summary

Improve plotting performance for Visium data.

- Check Visium image dimensions without loading it as a grob
- Avoid expensive dataframe operations on segmentation data by handling polygons and centroids _separately_ (improves segmentation centroid plotting time drastically)
- Only construct an image grob when `image.alpha > 0`
- Move color palette construction to new (internal) utility function `.BuildDiscreteScale`
- Restructure code for readability
- Introduce `stroke.alpha` parameter to control stroke and fill transparency separately

## Tests & benchmarking

`obj` contains 376,419 8um bins and 84,031 cell segmentations. The data is available for download at https://www.10xgenomics.com/datasets/visium-hd-three-prime-mouse-brain-fresh-frozen.

<details><summary>Expand to see object creation details</summary>

```R
library(Seurat)
obj <- Load10X_Spatial(data.dir = "~/mouse_brain_sr_4", bin.size = c(8, "polygons"))

# create a VisiumV1 image
obj@images$slice1.008um.v1 <- Read10X_Image(image.dir="~/mouse_brain_sr_4/binned_outputs/square_008um/spatial", assay = "Spatial.008um", slice = "slice1.008um.v1", image.type="VisiumV1")

# define groupings (pseudo clusters)
tc_seg <- GetTissueCoordinates(obj@images[["slice1.polygons"]]) # segmentations
obj$x <- tc_seg$x[match(colnames(obj), tc_seg$cell)]
obj$y <- tc_seg$y[match(colnames(obj), tc_seg$cell)]
tc_bin <- GetTissueCoordinates(obj@images[["slice1.008um"]]) # bins
idx <- match(colnames(obj), tc_bin$cell) # preserve the coords already set so do if-else matching
obj$x <- ifelse(is.na(idx), obj$x, tc_bin$x[idx])
obj$y <- ifelse(is.na(idx), obj$y, tc_bin$y[idx])

# set regions
# print ranges to define breaks prior to this step
x_breaks <- c(-Inf, 4000, 10000, 16000, Inf)
y_breaks <- c(-Inf, 10000, Inf)
obj$x_cut <- cut(obj$x, breaks = x_breaks, labels = FALSE)
obj$y_cut <- cut(obj$y, breaks = y_breaks, labels = FALSE)
obj$region <- as.numeric(interaction(obj$x_cut, obj$y_cut))
```

</details>

- - -

Benchmarking was performed with `ggplot2::benchplot(...plotting command...); graphics.off()`. Compared to the release version, we see a substantial speedup for plotting segmentation centroids (particularly for the `draw` step, 28x) with minor speedup for other cases.

<details><summary>benchplot results w/ changes from this branch</summary>

Note there is some variability in times.

```
> ggplot2::benchplot(SpatialDimPlot(obj, images = "slice1.polygons", group.by = "region")); graphics.off()
       step user.self sys.self elapsed
1 construct     0.059    0.002   0.062
2     build     0.038    0.003   0.041
3    render     0.071    0.002   0.077
4      draw     0.177    0.011   0.183
5     TOTAL     0.345    0.018   0.363
> ggplot2::benchplot(SpatialDimPlot(obj, images = "slice1.polygons", plot_segmentations = TRUE, group.by = "region")); graphics.off()
Changing image annotation limits to work with ggplot2 < 4.0.0.
       step user.self sys.self elapsed
1 construct     0.618    0.050   0.675
2     build     0.665    0.175   0.853
3    render     0.130    0.023   0.155
4      draw     0.702    0.084   0.765
5     TOTAL     2.115    0.332   2.448
> ggplot2::benchplot(SpatialDimPlot(obj, images = "slice1.008um", group.by = "region")); graphics.off()
       step user.self sys.self elapsed
1 construct     0.240    0.015   0.256
2     build     0.138    0.028   0.168
3    render     0.111    0.009   0.119
4      draw     0.768    0.058   0.817
5     TOTAL     1.257    0.110   1.360
> ggplot2::benchplot(SpatialDimPlot(obj, images = "slice1.008um.v1", group.by = "region")); graphics.off()
       step user.self sys.self elapsed
1 construct     0.340    0.010   0.352
2     build     0.140    0.024   0.172
3    render     0.110    0.011   0.122
4      draw     0.741    0.057   0.791
5     TOTAL     1.331    0.102   1.437
> ggplot2::benchplot(SpatialDimPlot(obj, images = "slice1.polygons", group.by = "region", image.alpha = 0)); graphics.off()
       step user.self sys.self elapsed
1 construct     0.063    0.004   0.066
2     build     0.038    0.005   0.047
3    render     0.048    0.003   0.053
4      draw     0.182    0.027   0.201
5     TOTAL     0.331    0.039   0.367
> ggplot2::benchplot(SpatialDimPlot(obj, images = "slice1.polygons", plot_segmentations = TRUE, group.by = "region", image.alpha = 0)); graphics.off()
       step user.self sys.self elapsed
1 construct     0.609    0.038   0.652
2     build     0.673    0.179   0.877
3    render     0.123    0.018   0.142
4      draw     0.726    0.113   0.812
5     TOTAL     2.131    0.348   2.483
> ggplot2::benchplot(SpatialDimPlot(obj, images = "slice1.008um", group.by = "region", image.alpha = 0)); graphics.off()
       step user.self sys.self elapsed
1 construct     0.247    0.018   0.267
2     build     0.137    0.014   0.152
3    render     0.084    0.004   0.088
4      draw     0.963    0.070   1.028
5     TOTAL     1.431    0.106   1.535
> ggplot2::benchplot(SpatialDimPlot(obj, images = "slice1.008um.v1", group.by = "region", image.alpha = 0)); graphics.off()
       step user.self sys.self elapsed
1 construct     0.303    0.005   0.308
2     build     0.136    0.019   0.158
3    render     0.084    0.007   0.093
4      draw     0.734    0.061   0.782
5     TOTAL     1.257    0.092   1.341
```
</details>

- - -

```R
path <- "~/seurat-clones/seurat" # should point to this branch
devtools::load_all(path)
# print(git2r::repository_head(repo = path))
# print(packageVersion("Seurat"))

p1 <- SpatialDimPlot(obj, images = "slice1.polygons", group.by = "region") + ggtitle("segmentations | centroids")
p2 <- SpatialDimPlot(obj, images = "slice1.polygons", plot_segmentations = TRUE, group.by = "region") + ggtitle("segmentations | polygons")
p3 <- SpatialDimPlot(obj, images = "slice1.008um", group.by = "region") + ggtitle("8um bins | VisiumV2")
p4 <- SpatialDimPlot(obj, images = "slice1.008um.v1", group.by = "region") + ggtitle("8um bins | VisiumV1")

p1.5 <- SpatialDimPlot(obj, images = "slice1.polygons", group.by = "region", label = T) + ggtitle("segmentations | centroids | label")
p2.5 <- SpatialDimPlot(obj, images = "slice1.polygons", plot_segmentations = TRUE, group.by = "region", label = T) + ggtitle("segmentations | polygons | label")
p3.5 <- SpatialDimPlot(obj, images = "slice1.008um", group.by = "region", label = T) + ggtitle("8um bins | VisiumV2 | label")
p4.5 <- SpatialDimPlot(obj, images = "slice1.008um.v1", group.by = "region", label = T) + ggtitle("8um bins | VisiumV1 | label")

p5 <- SpatialDimPlot(obj, images = "slice1.polygons", group.by = "region", image.alpha = 0) + ggtitle("segmentations | centroids | no image")
p6 <- SpatialDimPlot(obj, images = "slice1.polygons", plot_segmentations = TRUE, group.by = "region", image.alpha = 0) + ggtitle("segmentations | polygons | no image")
p7 <- SpatialDimPlot(obj, images = "slice1.008um", group.by = "region", image.alpha = 0) + ggtitle("8um bins | VisiumV2 | no image")
p8 <- SpatialDimPlot(obj, images = "slice1.008um.v1", group.by = "region", image.alpha = 0) + ggtitle("8um bins | VisiumV1 | no image")

p9 <- p1 + p2 + p3 + p4 + p1.5 + p2.5 + p3.5 + p4.5 + p5 + p6 + p7 + p8 + patchwork::plot_layout(nrow = 3, ncol = 4)

# ggsave(p9, filename="p9.png", width=20, height=10, dpi=300)
```

<img width="800" alt="p9" src="https://github.com/user-attachments/assets/e16da8f1-8424-415b-ad66-fed8b8ff8104" />

<br/>Also tested SlideSeq, `crop=F` argument, various color palettes (RColorBrewer palette (both name and number), other palettes (ex. "glasbey"), vector of colors (both named and unnamed)).