### PR TITLE
Assay argument in FeaturePlot

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: Seurat
-Version: 5.4.0.9019
+Version: 5.4.0.9020
 Title: Tools for Single Cell Genomics
 Description: A toolkit for quality control, analysis, and exploration of single cell RNA sequencing data. 'Seurat' aims to enable users to identify and interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse types of single cell data. See Satija R, Farrell J, Gennert D, et al (2015) <doi:10.1038/nbt.3192>, Macosko E, Basu A, Satija R, et al (2015) <doi:10.1016/j.cell.2015.05.002>, Stuart T, Butler A, et al (2019) <doi:10.1016/j.cell.2019.05.031>, and Hao, Hao, et al (2020) <doi:10.1101/2020.10.12.335331> for more details.
 Authors@R: c(

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -3960,11 +3960,11 @@ InteractiveSpatialPlot <- function(
 ) {
   # Check for required packages, stop with clear message if missing
   required_pkgs <- c("plotly", "magrittr", "base64enc", "shiny")
-
+  
   missing_pkgs <- required_pkgs[
     !vapply(required_pkgs, requireNamespace, quietly = TRUE, FUN.VALUE = logical(1))
   ]
-
+  
   if (length(missing_pkgs) > 0) {
     stop(
       "InteractiveSpatialPlot() functionality requires these packages to be installed: ",
@@ -4527,7 +4527,7 @@ SpatialPlot <- function(
 
     is_visium_v2 <- inherits(image.use, "VisiumV2")
     old_axis_orientation <- (!.hasSlot(image.use, "coords_x_orientation")) || (.hasSlot(image.use, "coords_x_orientation") && (slot(image.use, "coords_x_orientation") != 'horizontal'))
-
+    
     if (is_visium_v2 && old_axis_orientation) {
       stop(
         "Please run `UpdateSeuratObject` on your Seurat object first to ensure that data aligns to the image ", images[[image.idx]], " when plotting.",
@@ -9525,8 +9525,8 @@ SingleRasterMap <- function(
 #' @return A ggplot2 object
 #'
 #' @importFrom tibble tibble
-#' @importFrom ggplot2 ggplot coord_fixed geom_point
-#' xlim ylim coord_cartesian labs theme_void theme
+#' @importFrom ggplot2 ggplot coord_fixed geom_point 
+#' xlim ylim coord_cartesian labs theme_void theme 
 #' scale_fill_brewer scale_y_reverse annotation_custom
 #'
 #' @keywords internal

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -1075,6 +1075,7 @@ DimPlot <- function(
 #'     scales that are not comparable between plots
 #' }
 #' @param slot Which slot to pull expression data from?
+#' @param assay Primary assay to pull feature data from
 #' @param blend Scale and blend expression values to visualize coexpression of two features
 #' @param blend.threshold The color cutoff from weak signal to strong signal; ranges from 0 to 1.
 #' @param ncol Number of columns to combine multiple feature plots to, ignored if \code{split.by} is not \code{NULL}
@@ -1132,6 +1133,7 @@ FeaturePlot <- function(
   keep.scale = "feature",
   shape.by = NULL,
   slot = 'data',
+  assay = NULL,
   blend = FALSE,
   blend.threshold = 0.5,
   label = FALSE,
@@ -1232,7 +1234,8 @@ FeaturePlot <- function(
     object = object,
     vars = c(dims, 'ident', features),
     cells = cells,
-    layer = slot
+    layer = slot,
+    assay = assay
   )
   # Check presence of features/dimensions
   if (ncol(x = data) < 4) {
@@ -3957,11 +3960,11 @@ InteractiveSpatialPlot <- function(
 ) {
   # Check for required packages, stop with clear message if missing
   required_pkgs <- c("plotly", "magrittr", "base64enc", "shiny")
-  
+
   missing_pkgs <- required_pkgs[
     !vapply(required_pkgs, requireNamespace, quietly = TRUE, FUN.VALUE = logical(1))
   ]
-  
+
   if (length(missing_pkgs) > 0) {
     stop(
       "InteractiveSpatialPlot() functionality requires these packages to be installed: ",
@@ -4524,7 +4527,7 @@ SpatialPlot <- function(
 
     is_visium_v2 <- inherits(image.use, "VisiumV2")
     old_axis_orientation <- (!.hasSlot(image.use, "coords_x_orientation")) || (.hasSlot(image.use, "coords_x_orientation") && (slot(image.use, "coords_x_orientation") != 'horizontal'))
-    
+
     if (is_visium_v2 && old_axis_orientation) {
       stop(
         "Please run `UpdateSeuratObject` on your Seurat object first to ensure that data aligns to the image ", images[[image.idx]], " when plotting.",
@@ -9522,8 +9525,8 @@ SingleRasterMap <- function(
 #' @return A ggplot2 object
 #'
 #' @importFrom tibble tibble
-#' @importFrom ggplot2 ggplot coord_fixed geom_point 
-#' xlim ylim coord_cartesian labs theme_void theme 
+#' @importFrom ggplot2 ggplot coord_fixed geom_point
+#' xlim ylim coord_cartesian labs theme_void theme
 #' scale_fill_brewer scale_y_reverse annotation_custom
 #'
 #' @keywords internal

--- a/man/FeaturePlot.Rd
+++ b/man/FeaturePlot.Rd
@@ -27,6 +27,7 @@ FeaturePlot(
   keep.scale = "feature",
   shape.by = NULL,
   slot = "data",
+  assay = NULL,
   blend = FALSE,
   blend.threshold = 0.5,
   label = FALSE,
@@ -105,6 +106,8 @@ cell attribute (that can be pulled with FetchData) allowing for both
 different colors and different shapes on cells.  Only applicable if \code{raster = FALSE}.}
 
 \item{slot}{Which slot to pull expression data from?}
+
+\item{assay}{Primary assay to pull feature data from}
 
 \item{blend}{Scale and blend expression values to visualize coexpression of two features}
 


### PR DESCRIPTION
Addresses #10268 

The change is pretty straightforward, just passing the `assay` argument to `FetchData`

Example usage:

```{r}
library(Seurat)
library(SeuratData)
cbmc <- LoadData("cbmc")

cbmc <- NormalizeData(cbmc)
cbmc <- FindVariableFeatures(cbmc, selection.method = "vst", nfeatures = 2000, verbose = FALSE)

cbmc <- ScaleData(cbmc, features = VariableFeatures(cbmc), verbose = FALSE)
cbmc <- RunPCA(cbmc, features = VariableFeatures(cbmc), npcs = 30, verbose = FALSE)

cbmc <- RunUMAP(cbmc, dims = 1:30, reduction = "pca", verbose = FALSE)

# old behavior:
FeaturePlot(cbmc, "CD3D")
FeaturePlot(cbmc, "CD3") # plots CD3 from ADT assay with a warning

# new behavior:
FeaturePlot(cbmc, "CD3", assay="ADT") # plots CD3 from ADT assay without a warning
FeaturePlot(cbmc, "CD3D", assay="ADT") # plots CD3 from RNA assay with a warning
```