### PR TITLE
Add warning when `FindMarkers` / `FindAllMarkers` sees an `IterableMatrix` (BPCells) w/ column-major order

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: Seurat
-Version: 5.4.0.9017
+Version: 5.4.0.9018
 Title: Tools for Single Cell Genomics
 Description: A toolkit for quality control, analysis, and exploration of single cell RNA sequencing data. 'Seurat' aims to enable users to identify and interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse types of single cell data. See Satija R, Farrell J, Gennert D, et al (2015) <doi:10.1038/nbt.3192>, Macosko E, Basu A, Satija R, et al (2015) <doi:10.1016/j.cell.2015.05.002>, Stuart T, Butler A, et al (2019) <doi:10.1016/j.cell.2019.05.031>, and Hao, Hao, et al (2020) <doi:10.1101/2020.10.12.335331> for more details.
 Authors@R: c(

--- a/R/differential_expression.R
+++ b/R/differential_expression.R
@@ -118,54 +118,66 @@ FindAllMarkers <- function(
   }
   genes.de <- list()
   messages <- list()
-  for (i in 1:length(x = idents.all)) {
-    if (verbose) {
-      message("Calculating cluster ", idents.all[i])
-    }
-    genes.de[[i]] <- tryCatch(
-      expr = {
-        FindMarkers(
-          object = object,
-          assay = assay,
-          ident.1 = if (is.null(x = node)) {
-            idents.all[i]
-          } else {
-            tree
-          },
-          ident.2 = if (is.null(x = node)) {
-            NULL
-          } else {
-            idents.all[i]
-          },
-          features = features,
-          logfc.threshold = logfc.threshold,
-          test.use = test.use,
-          slot = slot,
-          min.pct = min.pct,
-          min.diff.pct = min.diff.pct,
-          verbose = verbose,
-          only.pos = only.pos,
-          max.cells.per.ident = max.cells.per.ident,
-          random.seed = random.seed,
-          latent.vars = latent.vars,
-          min.cells.feature = min.cells.feature,
-          min.cells.group = min.cells.group,
-          mean.fxn = mean.fxn,
-          fc.name = fc.name,
-          base = base,
-          densify = densify,
-          ...
-        )
-      },
-      error = function(cond) {
-        return(cond$message)
+  bpcells_warning_shown <- FALSE
+  withCallingHandlers({
+    for (i in 1:length(x = idents.all)) {
+      if (verbose) {
+        message("Calculating cluster ", idents.all[i])
       }
-    )
-    if (is.character(x = genes.de[[i]])) {
-      messages[[i]] <- genes.de[[i]]
-      genes.de[[i]] <- NULL
+      genes.de[[i]] <- tryCatch(
+        expr = {
+          FindMarkers(
+            object = object,
+            assay = assay,
+            ident.1 = if (is.null(x = node)) {
+              idents.all[i]
+            } else {
+              tree
+            },
+            ident.2 = if (is.null(x = node)) {
+              NULL
+            } else {
+              idents.all[i]
+            },
+            features = features,
+            logfc.threshold = logfc.threshold,
+            test.use = test.use,
+            slot = slot,
+            min.pct = min.pct,
+            min.diff.pct = min.diff.pct,
+            verbose = verbose,
+            only.pos = only.pos,
+            max.cells.per.ident = max.cells.per.ident,
+            random.seed = random.seed,
+            latent.vars = latent.vars,
+            min.cells.feature = min.cells.feature,
+            min.cells.group = min.cells.group,
+            mean.fxn = mean.fxn,
+            fc.name = fc.name,
+            base = base,
+            densify = densify,
+            ...
+          )
+        },
+        error = function(cond) {
+          return(cond$message)
+        }
+      )
+      if (is.character(x = genes.de[[i]])) {
+        messages[[i]] <- genes.de[[i]]
+        genes.de[[i]] <- NULL
+      }
     }
-  }
+  }, warning = function(w) {
+    if (grepl("Column-major order detected", conditionMessage(w))) {
+      if (!bpcells_warning_shown) {
+        bpcells_warning_shown <<- TRUE
+        warning(paste(conditionMessage(w), "to avoid repeated transpositions.", sep = " "), 
+                immediate. = TRUE, call. = FALSE)
+      }
+      invokeRestart("muffleWarning")
+    }
+  })
   gde.all <- data.frame()
   for (i in 1:length(x = idents.all)) {
     if (is.null(x = unlist(x = genes.de[i]))) {

--- a/R/differential_expression.R
+++ b/R/differential_expression.R
@@ -594,6 +594,11 @@ FindMarkers.default <- function(
       stop("Differential expression with BPCells currently only supports the 'wilcox' method.",
            " Please rerun with test.use = 'wilcox'")
     }
+    if (BPCells::storage_order(object) == "col") {
+      warning(paste("Column-major order detected; FindMarkers requires row-major order.", 
+              "Consider first running BPCells::transpose_storage_order()", sep = "\n"),
+              immediate. = TRUE, call. = FALSE)
+    }
     data.use <- object[features, c(cells.1, cells.2), drop = FALSE]
     groups <- c(rep("foreground", length(cells.1)), rep("background", length(cells.2)))
     de.results <- suppressMessages(

--- a/R/differential_expression.R
+++ b/R/differential_expression.R
@@ -118,7 +118,8 @@ FindAllMarkers <- function(
   }
   genes.de <- list()
   messages <- list()
-  bpcells_warning_shown <- FALSE
+  old_opt <- options(Seurat.warn.findmarkers.bpcells.colmajor = TRUE)
+  on.exit(options(old_opt), add = TRUE)
   withCallingHandlers({
     for (i in 1:length(x = idents.all)) {
       if (verbose) {
@@ -170,11 +171,9 @@ FindAllMarkers <- function(
     }
   }, warning = function(w) {
     if (grepl("Column-major order detected", conditionMessage(w))) {
-      if (!bpcells_warning_shown) {
-        bpcells_warning_shown <<- TRUE
-        warning(paste(conditionMessage(w), "to avoid repeated transpositions.", sep = " "), 
-                immediate. = TRUE, call. = FALSE)
-      }
+      msg <- conditionMessage(w)
+      msg <- sub("\\.\\nThis message will be shown once per session\\.$", " to avoid repeated transpositions.", msg)
+      warning(msg, immediate. = TRUE, call. = FALSE)
       invokeRestart("muffleWarning")
     }
   })
@@ -606,10 +605,12 @@ FindMarkers.default <- function(
       stop("Differential expression with BPCells currently only supports the 'wilcox' method.",
            " Please rerun with test.use = 'wilcox'")
     }
-    if (BPCells::storage_order(object) == "col") {
+    if (BPCells::storage_order(object) == "col" && isTRUE(getOption('Seurat.warn.findmarkers.bpcells.colmajor'))) {
       warning(paste("Column-major order detected; FindMarkers requires row-major order.", 
-              "Consider first running BPCells::transpose_storage_order()", sep = "\n"),
+              "Consider first running BPCells::transpose_storage_order().",
+              "This message will be shown once per session.", sep = "\n"),
               immediate. = TRUE, call. = FALSE)
+      options(Seurat.warn.findmarkers.bpcells.colmajor = FALSE)
     }
     data.use <- object[features, c(cells.1, cells.2), drop = FALSE]
     groups <- c(rep("foreground", length(cells.1)), rep("background", length(cells.2)))

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -44,6 +44,8 @@ NULL
 #'   Moran's I function available via the Rfast2 package}}
 #'   \item{\code{Seurat.warn.vlnplot.split}}{Show message about changes to
 #'   default behavior of split/multi violin plots}
+#'   \item{\code{Seurat.warn.findmarkers.bpcells.colmajor}}{Show message about improving
+#'   memory usage when running FindMarkers with a column-major ordered BPCells IterableMatrix.}
 #' }
 #'
 #' @docType package
@@ -62,6 +64,7 @@ seurat_default_options <- list(
   Seurat.checkdots = "warn",
   Seurat.presto.wilcox.msg = TRUE, #CHANGE
   Seurat.Rfast2.msg = TRUE,
+  Seurat.warn.findmarkers.bpcells.colmajor = TRUE,
   Seurat.warn.vlnplot.split = TRUE,
   Seurat.object.assay.version = "v5"
 )

--- a/man/Seurat-package.Rd
+++ b/man/Seurat-package.Rd
@@ -30,6 +30,8 @@ Seurat uses the following [options()] to configure behaviour:
   Moran's I function available via the Rfast2 package}}
   \item{\code{Seurat.warn.vlnplot.split}}{Show message about changes to
   default behavior of split/multi violin plots}
+  \item{\code{Seurat.warn.findmarkers.bpcells.colmajor}}{Show message about improving
+  memory usage when running FindMarkers with a column-major ordered BPCells IterableMatrix.}
 }
 }
 

--- a/tests/testthat/test_differential_expression.R
+++ b/tests/testthat/test_differential_expression.R
@@ -482,7 +482,42 @@ test_that("BPCells FindAllMarkers gives same results", {
   expect_equal(rownames(results.bp)[1], "HLA-DPB1")
 })
 
+test_that("BPCells FindAllMarkers warns for column-major storage", {
+  skip_on_cran()
+  skip_if_not_installed("BPCells")
+  library(BPCells)
+  library(Matrix)
 
+  mat_bpcells_row <- t(as(t(pbmc_small[['RNA']]$counts), "IterableMatrix"))
+  mat_bpcells_col <- BPCells::transpose_storage_order(mat_bpcells_row)
+
+  expect_equal(BPCells::storage_order(mat_bpcells_col), "col")
+
+  pbmc_small[['RNAbpRowMajor']] <- CreateAssay5Object(counts = mat_bpcells_row)
+  pbmc_small[['RNAbpColMajor']] <- CreateAssay5Object(counts = mat_bpcells_col)
+  pbmc_small <- NormalizeData(pbmc_small, assay = "RNAbpRowMajor")
+  pbmc_small <- NormalizeData(pbmc_small, assay = "RNAbpColMajor")
+
+  fam.results.row <- suppressMessages(
+    suppressWarnings(
+      FindAllMarkers(object = pbmc_small, assay = "RNAbpRowMajor", pseudocount.use = 1)
+    )
+  )
+  fam.results.col <- suppressMessages(
+    expect_warning(
+      FindAllMarkers(object = pbmc_small, assay = "RNAbpColMajor", pseudocount.use = 1),
+      regexp = "Column-major order detected"
+    )
+  )
+  fm.results.col.2 <- suppressMessages(
+    expect_warning(
+        FindMarkers(object = pbmc_small, assay = "RNAbpColMajor", ident.1 = 0, ident.2 = 1),
+        regexp = "Column-major order detected"
+    )
+  )
+  expect_equal(fam.results.col$gene, fam.results.row$gene)
+  expect_equal(fam.results.col$cluster, fam.results.row$cluster)
+})
 
 # Tests for FindConservedMarkers
 # -------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #10334 (we choose to warn the user instead of forcibly transposing the storage order at once at the beginning of `FindAllMarkers`).

- Add warning in `FindMarkers`. This is only shown _once per session_.
- The warning bubbles up to `FindAllMarkers`. This is shown _every time_ `FindAllMarkers` is called (per run, not per `FindMarkers` iteration, to avoid clogging output).
- Add relevant test to `test_differential_expression.R`, skipped on CRAN.

Below is an example that demonstrates behavior with these changes.

```R
> mat_bpcells_row <- t(as(t(pbmc_small[['RNA']]$counts), "IterableMatrix"))
> mat_bpcells_col <- BPCells::transpose_storage_order(mat_bpcells_row)
> pbmc_small[['RNAbpRowMajor']] <- CreateAssay5Object(counts = mat_bpcells_row)
> pbmc_small[['RNAbpColMajor']] <- CreateAssay5Object(counts = mat_bpcells_col)
> pbmc_small <- NormalizeData(pbmc_small, assay = "RNAbpRowMajor")
# Normalizing layer: counts
> pbmc_small <- NormalizeData(pbmc_small, assay = "RNAbpColMajor")
# Normalizing layer: counts
> a <- FindMarkers(object = pbmc_small, assay = "RNAbpColMajor", ident.1 = 0, ident.2 = 1)
# Warning: Column-major order detected; FindMarkers requires row-major order.
# Consider first running BPCells::transpose_storage_order().
# This message will be shown once per session.
> b <- FindAllMarkers(object = pbmc_small, assay = "RNAbpColMajor", pseudocount.use = 1)
# Calculating cluster 0
# Warning: Column-major order detected; FindMarkers requires row-major order.
# Consider first running BPCells::transpose_storage_order() to avoid repeated transpositions.
# Calculating cluster 1
# Calculating cluster 2
```