### PR TITLE
Follow-up to #10329

### DIFF
--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -4160,8 +4160,10 @@ SCTransform.Assay <- function(
   if (!is.null(reference.SCT.model)){
     do.correct.umi <- FALSE
     do.center <- FALSE
-    warning(
-      "A reference SCT model was provided, therefore counts are NOT corrected (Regardless of argument passed to do.correct.umi)"
+    rlang::warn(
+      "A reference SCT model was provided, therefore counts are not corrected (regardless of do.correct.umi)",
+      .frequency = "once",
+      .frequency_id = "SCTransform-reference-SCTmodel-correct-counts"
     )
   }
 

--- a/tests/testthat/test_integration.R
+++ b/tests/testthat/test_integration.R
@@ -302,9 +302,10 @@ test_that("Mixing SCT and non-SCT assays fails", {
   expect_error(FindTransferAnchors(reference = ref, query = query, reference.assay = "RNA", query.assay = "SCT", k.filter = 50, normalization.method = "SCT"))
 })
 
-test_that("FindTransferAnchors with default SCT works", {
+test_that("FindTransferAnchors with default SCT works (CCA)", {
   skip_on_cran()
-  anchors <- FindTransferAnchors(reference = ref, query = query, normalization.method = "SCT", reduction = "cca", k.filter = 50)
+  ref_correct_counts_warning <- "A reference SCT model was provided, therefore counts are not corrected (regardless of do.correct.umi)"
+  anchors <- expect_warning(FindTransferAnchors(reference = ref, query = query, normalization.method = "SCT", reduction = "cca", k.filter = 50), ref_correct_counts_warning, fixed = TRUE)
   co <- anchors@object.list[[1]]
   expect_equal(dim(co), c(220, 160))
   expect_equal(Reductions(co), c("cca", "cca.l2"))


### PR DESCRIPTION
See #10329 for details.

- Use `rlang::warn` instead of `warning` to limit warning about reference SCT model not correcting counts to once per session.
- Update `FindTransferAnchors` test (**test_integration.R:305**) to expect counts correction warning (https://github.com/satijalab/seurat/pull/10329#issuecomment-4217979128).