### PR TITLE
Fix interactive functionality of spatial plotting functions

### DIFF
--- a/R/visualization.R
+++ b/R/visualization.R
@@ -4392,13 +4392,11 @@ SpatialPlot <- function(
   cells <- unique(CellsByImage(object, images = images, unlist = TRUE))
   if (is.null(x = features)) {
     if (interactive) {
-      return(ISpatialDimPlot(
-        object = object,
-        image = images[1],
-        image.scale = image.scale,
-        group.by = group.by,
-        alpha = alpha
-      ))
+      # default alpha is 1 but interactive plotting requires 
+      # a range for proper cluster selection highlighting
+      if (identical(alpha, c(1, 1))) { 
+        alpha <- c(0.1, 1)
+      }
     }
     group.by <- group.by %||% 'ident'
     object[['ident']] <- Idents(object = object)

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -3637,6 +3637,10 @@ ISpatialDimPlot <- function(
     cells = cells.use
   )
   coords <- GetTissueCoordinates(object = object[[image]], scale = image.scale)
+  sp_x <- colnames(coords)[1]
+  sp_y <- colnames(coords)[2]
+  # coordinates should be in image space, so need to flip y when setting or displaying info for points
+  flip_y <- function(pt) { pt$y <- max(coords[[sp_y]]) - (pt$y - min(coords[[sp_y]])); pt }
   scale.factor <- ScaleFactors(object[[image]])[[image.scale]]
   plot.data <- cbind(coords, group.data)
   plot.data$selected_ <- FALSE
@@ -3653,16 +3657,16 @@ ISpatialDimPlot <- function(
     observeEvent(
       eventExpr = input$click,
       handlerExpr = {
+        click$pt <- flip_y(input$click)
         clicked <- nearPoints(
           df = plot.data,
-          coordinfo = InvertCoordinate(x = input$click),
+          coordinfo = click$pt,
           threshold = 10,
           maxpoints = 1,
-          xvar = "y",
-          yvar = "x"
+          xvar = sp_x,
+          yvar = sp_y
         )
         plot.env$data <- if (nrow(x = clicked) == 1) {
-          cell.clicked <- rownames(x = clicked)
           cell.clicked <- rownames(x = clicked)
           group.clicked <- plot.data[cell.clicked, group.by, drop = TRUE]
           idx.group <- which(x = plot.data[[group.by]] == group.clicked)
@@ -3697,11 +3701,11 @@ ISpatialDimPlot <- function(
       expr = {
         hovered <- nearPoints(
           df = plot.data,
-          coordinfo = InvertCoordinate(x = input$hover),
+          coordinfo = flip_y(input$hover),
           threshold = 10,
           maxpoints = 1,
-          xvar = "y",
-          yvar = "x"
+          xvar = sp_x,
+          yvar = sp_y
         )
         if (nrow(hovered) == 1) {
           cell.hover <- rownames(hovered)

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -3503,6 +3503,12 @@ LinkedFeaturePlot <- function(
   )
   coords <- GetTissueCoordinates(object = object[[image]], scale = image.scale)
   embeddings <- Embeddings(object = object[[reduction]])[cells.use, dims]
+  sp_x <- colnames(coords)[1]
+  sp_y <- colnames(coords)[2]
+  dp_x <- dims[1]
+  dp_y <- dims[2]
+  # coordinates should be in image space, so need to flip y when setting or displaying info for points
+  flip_y <- function(pt) { pt$y <- max(coords[[sp_y]]) - (pt$y - min(coords[[sp_y]])); pt }
   plot.data <- cbind(coords, group.data, embeddings)
   # Setup the server
   server <- function(input, output, session) {
@@ -3556,10 +3562,13 @@ LinkedFeaturePlot <- function(
           coordinfo = if (is.null(x = input[['sphover']])) {
             input$dimhover
           } else {
-            InvertCoordinate(x = input$sphover)
+            flip_y(input$sphover)
           },
           threshold = 10,
-          maxpoints = 1
+          maxpoints = 1,
+          # specify plot-specific axis columns for nearPoints
+          xvar = if (is.null(x = input$sphover)) dp_x else sp_x,
+          yvar = if (is.null(x = input$sphover)) dp_y else sp_y
         ))
         # TODO: Get newlines, extra information, and background color working
         if (length(x = cell.hover) == 1) {

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -4397,6 +4397,29 @@ SpatialPlot <- function(
       if (identical(alpha, c(1, 1))) { 
         alpha <- c(0.1, 1)
       }
+      tryCatch(
+         expr = {
+           return(ISpatialDimPlot(
+             object = object,
+             image = images[1],
+             image.scale = image.scale,
+             group.by = group.by,
+             alpha = alpha
+           ))
+         },
+         error = function(e) {
+          # error can occur when image and assay don't match
+          # or when the default assay set doesn't have data corresponding to the default ident etc.
+          if (grepl("arguments imply differing number of rows", conditionMessage(e))) {
+            stop(
+              "Cells were removed due to missing data; check if the specified image and assay are correct.\n",
+              call. = FALSE
+            )
+          } else {
+            stop(e)
+          }
+         }
+      )
     }
     group.by <- group.by %||% 'ident'
     object[['ident']] <- Idents(object = object)

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -3357,7 +3357,7 @@ LinkedDimPlot <- function(
             plot.data
           }
         } else if (input$brush$outputId == 'dimplot') {
-          brushedPoints(df = plot.data, brush = input$brush, allRows = TRUE)
+          brushedPoints(df = plot.data, brush = input$brush, allRows = TRUE, xvar = dp_x, yvar = dp_y)
         } else if (input$brush$outputId == 'spatialplot') {
           b <- input$brush
           b$ymin <- sp_y_max - (b$ymin - sp_y_min)

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -8859,47 +8859,60 @@ SingleDimPlot <- function(
   optional  <- list(color = col.by, shape = shape.by, alpha = alpha.by)
   is_symbol <- lengths(optional) > 0
   optional  <- c(rlang::data_syms(optional[is_symbol]), optional[!is_symbol])
-
+  # Separate plotting aesthetics based on whether alpha is defined by a scalar or a mapping variable
+  use.alpha.by <- is.null(x = alpha.by) 
+  
   plot <- ggplot(data = data)
   plot <- if (isTRUE(x = raster)) {
     # Use geom_point_rast when generating rasterized plots with specified order
     # (although slower, orders points correctly whereas geom_scattermore does not)
     if (!order_rast) {
-      plot + geom_scattermore(
-        mapping = aes(
-          x = .data[[dims[1]]],
-          y = .data[[dims[2]]],
-          !!!optional
-        ),
-        pointsize = pt.size,
-        alpha = alpha,
-        pixels = raster.dpi
-      )
+      if (use.alpha.by) {
+        plot + geom_scattermore(
+          mapping = aes(x = .data[[dims[1]]], y = .data[[dims[2]]], !!!optional),
+          pointsize = pt.size,
+          alpha = alpha,
+          pixels = raster.dpi
+        )
+      } else {
+        plot + geom_scattermore(
+          mapping = aes(x = .data[[dims[1]]], y = .data[[dims[2]]], !!!optional),
+          pointsize = pt.size,
+          pixels = raster.dpi
+        )
+      }
     } else {
       rlang::warn(message = "Seurat uses ggrastr::rasterise to maintain point order with rasterization.", 
                   .frequency = "once",
                   .frequency_id = "Seurat-ggrastr-rasterise")
-      plot + ggrastr::rasterise(geom_point(
-        mapping = aes(
-          x = .data[[dims[1]]],
-          y = .data[[dims[2]]],
-          !!!optional
-        ),
-        size = pt.size,
-        alpha = alpha
-      ))
+      if (use.alpha.by) {
+        plot + ggrastr::rasterise(geom_point(
+          mapping = aes(x = .data[[dims[1]]], y = .data[[dims[2]]], !!!optional),
+          size = pt.size,
+          alpha = alpha
+        ))
+      } else {
+        plot + ggrastr::rasterise(geom_point(
+          mapping = aes(x = .data[[dims[1]]], y = .data[[dims[2]]], !!!optional),
+          size = pt.size
+        ))
+      }
     }
   } else {
-    plot + geom_point(
-      mapping = aes(
-        x = .data[[dims[1]]],
-        y = .data[[dims[2]]],
-        !!!optional
-      ),
-      size = pt.size,
-      alpha = alpha,
-      stroke = stroke.size
-    )
+    if (use.alpha.by) {
+      plot + geom_point(
+        mapping = aes(x = .data[[dims[1]]], y = .data[[dims[2]]], !!!optional),
+        size = pt.size,
+        alpha = alpha,
+        stroke = stroke.size
+      )
+    } else {
+      plot + geom_point(
+        mapping = aes(x = .data[[dims[1]]], y = .data[[dims[2]]], !!!optional),
+        size = pt.size,
+        stroke = stroke.size
+      )
+    }
   }
   plot <- plot +
     guides(color = guide_legend(override.aes = list(size = 3, alpha = 1))) +

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -3316,6 +3316,8 @@ LinkedDimPlot <- function(
       handlerExpr = {
         click$pt <- NULL
         click$invert <- FALSE
+        plot.env$data <- plot.data
+        plot.env$alpha.by <- NULL
         session$resetBrush(brushId = 'brush')
       }
     )

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -3286,15 +3286,16 @@ LinkedDimPlot <- function(
   plot.data$selected_ <- FALSE
   Idents(object = object) <- group.by
 
-  # Retrieve coordinates for tissue plot and dim plot seperately
+  # Retrieve coordinates for tissue plot and dim plot separately
   sp_x <- colnames(coords)[1]
   sp_y <- colnames(coords)[2]
   dp_x <- dims[1]
   dp_y <- dims[2]
-  sp_y_min <- min(plot.data[[sp_y]]); sp_y_max <- max(plot.data[[sp_y]])
+  sp_y_min <- min(plot.data[[sp_y]])
+  sp_y_max <- max(plot.data[[sp_y]])
 
   # Add tiny helper function to flip interactive coordinate points
-  flip_y <- function(pt) { pt$y <- sp_y_max - (pt$y - sp_y_min); pt }
+  flip_y <- function(pt) { if (!is.null(pt$y)) { pt$y <- sp_y_max - (pt$y - sp_y_min) }; pt }
 
   # Setup the server
   server <- function(input, output, session) {
@@ -3510,7 +3511,7 @@ LinkedFeaturePlot <- function(
   dp_x <- dims[1]
   dp_y <- dims[2]
   # coordinates should be in image space, so need to flip y when setting or displaying info for points
-  flip_y <- function(pt) { pt$y <- max(coords[[sp_y]]) - (pt$y - min(coords[[sp_y]])); pt }
+  flip_y <- function(pt) { if (!is.null(pt)) { pt$y <- max(coords[[sp_y]]) - (pt$y - min(coords[[sp_y]])) }; pt }
   plot.data <- cbind(coords, group.data, embeddings)
   # Setup the server
   server <- function(input, output, session) {
@@ -3642,7 +3643,7 @@ ISpatialDimPlot <- function(
   sp_x <- colnames(coords)[1]
   sp_y <- colnames(coords)[2]
   # coordinates should be in image space, so need to flip y when setting or displaying info for points
-  flip_y <- function(pt) { pt$y <- max(coords[[sp_y]]) - (pt$y - min(coords[[sp_y]])); pt }
+  flip_y <- function(pt) { if (!is.null(pt)) { pt$y <- max(coords[[sp_y]]) - (pt$y - min(coords[[sp_y]])) }; pt }
   scale.factor <- ScaleFactors(object[[image]])[[image.scale]]
   plot.data <- cbind(coords, group.data)
   plot.data$selected_ <- FALSE

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -8863,14 +8863,14 @@ SingleDimPlot <- function(
   is_symbol <- lengths(optional) > 0
   optional  <- c(rlang::data_syms(optional[is_symbol]), optional[!is_symbol])
   # Separate plotting aesthetics based on whether alpha is defined by a scalar or a mapping variable
-  use.alpha.by <- is.null(x = alpha.by) 
+  use.alpha <- is.null(x = alpha.by) 
   
   plot <- ggplot(data = data)
   plot <- if (isTRUE(x = raster)) {
     # Use geom_point_rast when generating rasterized plots with specified order
     # (although slower, orders points correctly whereas geom_scattermore does not)
     if (!order_rast) {
-      if (use.alpha.by) {
+      if (use.alpha) {
         plot + geom_scattermore(
           mapping = aes(x = .data[[dims[1]]], y = .data[[dims[2]]], !!!optional),
           pointsize = pt.size,
@@ -8888,7 +8888,7 @@ SingleDimPlot <- function(
       rlang::warn(message = "Seurat uses ggrastr::rasterise to maintain point order with rasterization.", 
                   .frequency = "once",
                   .frequency_id = "Seurat-ggrastr-rasterise")
-      if (use.alpha.by) {
+      if (use.alpha) {
         plot + ggrastr::rasterise(geom_point(
           mapping = aes(x = .data[[dims[1]]], y = .data[[dims[2]]], !!!optional),
           size = pt.size,
@@ -8902,7 +8902,7 @@ SingleDimPlot <- function(
       }
     }
   } else {
-    if (use.alpha.by) {
+    if (use.alpha) {
       plot + geom_point(
         mapping = aes(x = .data[[dims[1]]], y = .data[[dims[2]]], !!!optional),
         size = pt.size,


### PR DESCRIPTION
# Changes

Main:
- `ISpatialDimPlot`
  - (context: called from `SpatialDimPlot(..., interactive = T)`)
  - Set `xvar` and `yvar` properly in call to `shiny::nearPoints`
  - Flip y coordinate when setting/displaying coordinate info for hover/clicked points (harmonize w/ image space)
- `LinkedDimPlot`
  - Specify `xvar` and `yvar` in call to `shiny::brushedPoints` for the dim plot
- `LinkedFeaturePlot`
  - Separate data for spatial and dim plot similar to setup in `LinkedDimPlot`

Supporting:
- `SpatialPlot`
  - Make sure that alpha is set to a contrasting range (`c(0.1,1)`) in interactive mode (if default, which is `c(1,1)`) so that clusters are properly highlighted upon click
  - Provide more informative messages for errors arising from mismatches between specified arguments and data that actually exists in the object (i.e. when the specified image and default assay don't match, or when the default assay set doesn't have data corresponding to the default ident - the second case can occur when, for example, `Spatial.Polygons` is the default assay but we attempt to plot with `Spatial.008um` which only has `counts` and has not been processed)
- `SingleDimPlot`
  - Handle the `alpha.by` parameter properly
    - (This is not actually available for users to specify in `DimPlot`, but is used in `LinkedDimPlot` to highlight clusters on the dim plot when a cell is clicked)