### PR TITLE
Submit 5.5.0 to CRAN (2)

### DIFF
--- a/R/integration5.R
+++ b/R/integration5.R
@@ -74,7 +74,7 @@ NULL
 #'
 #' @concept integration
 #'
-#' @seealso \code{\link[harmony:HarmonyMatrix]{harmony::HarmonyMatrix}()}
+#' @seealso \code{\link[harmony]{RunHarmony}}
 #'
 HarmonyIntegration <- function(
   object,

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -9,11 +9,6 @@
 
 ## R CMD check results
 
-**possible false positive(s) on R-devel - explained below**
-
-* ERRORs on installation in R-devel are false positives and entirely unrelated to changes in this Seurat version; we have seen these stem from downstream dependencies (such as Rcpp) using header files that do not meet the new requirements posed in R-4.6. 
-* As of 21 April, this seems to no longer be an issue, but adding here as a note.
-
 **Status: OK**
 
 **4 NOTEs**

--- a/man/HarmonyIntegration.Rd
+++ b/man/HarmonyIntegration.Rd
@@ -107,6 +107,6 @@ obj <- IntegrateLayers(object = obj, method = HarmonyIntegration,
 
 }
 \seealso{
-\code{\link[harmony:HarmonyMatrix]{harmony::HarmonyMatrix}()}
+\code{\link[harmony]{RunHarmony}}
 }
 \concept{integration}


### PR DESCRIPTION
- Address WARNING about cross-ref link (`Missing link(s) in Rd file 'HarmonyIntegration.Rd': '[harmony:HarmonyMatrix]{harmony::HarmonyMatrix}'`)
- Remove submission comment about false positive / ERROR on installation as the CRAN check page has now been updated.