### PR TITLE
Fix `FindClusters` behavior when passed a vector of resolutions and custom names

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: Seurat
-Version: 5.5.0.9000
+Version: 5.5.0.9001
 Title: Tools for Single Cell Genomics
 Description: A toolkit for quality control, analysis, and exploration of single cell RNA sequencing data. 'Seurat' aims to enable users to identify and interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse types of single cell data. See Satija R, Farrell J, Gennert D, et al (2015) <doi:10.1038/nbt.3192>, Macosko E, Basu A, Satija R, et al (2015) <doi:10.1016/j.cell.2015.05.002>, Stuart T, Butler A, et al (2019) <doi:10.1016/j.cell.2019.05.031>, and Hao, Hao, et al (2020) <doi:10.1101/2020.10.12.335331> for more details.
 Authors@R: c(

--- a/R/clustering.R
+++ b/R/clustering.R
@@ -534,14 +534,7 @@ FindClusters.Seurat <- function(
     }
   )
   Idents(object = object) <- factor(x = Idents(object = object), levels = sort(x = levels))
-
-  # If no cluster name is specified, use default cluster name(s) and write active identities to seurat_clusters
-  # Otherwise, use cluster name provided by user / refresh the active identity column
-  if (isTRUE(x = all(cluster.name %in% default.cluster.name))) {
-    object[['seurat_clusters']] <- Idents(object = object)
-  } else {
-    object[[idents.use]] <- Idents(object = object)
-  }
+  object[['seurat_clusters']] <- Idents(object = object)
 
   cmd <- LogSeuratCommand(object = object, return.command = TRUE)
   slot(object = cmd, name = 'assay.used') <- DefaultAssay(object = object[[graph.name]])

--- a/R/clustering.R
+++ b/R/clustering.R
@@ -535,12 +535,12 @@ FindClusters.Seurat <- function(
   )
   Idents(object = object) <- factor(x = Idents(object = object), levels = sort(x = levels))
 
-  # If cluster name is NULL, default cluster name is used (seurat_clusters) when assigning factor levels
-  # Otherwise, use cluster name provided by user
+  # If no cluster name is specified, use default cluster name(s) and write active identities to seurat_clusters
+  # Otherwise, use cluster name provided by user / refresh the active identity column
   if (isTRUE(x = all(cluster.name %in% default.cluster.name))) {
     object[['seurat_clusters']] <- Idents(object = object)
   } else {
-    object[[cluster.name]] <- Idents(object = object)
+    object[[idents.use]] <- Idents(object = object)
   }
 
   cmd <- LogSeuratCommand(object = object, return.command = TRUE)

--- a/tests/testthat/test_find_clusters.R
+++ b/tests/testthat/test_find_clusters.R
@@ -99,3 +99,31 @@ test_that("`FindClusters` works if passed a vector of resolutions", {
     )
   }
 })
+
+test_that("`FindClusters` sorts numeric factor levels correctly", {
+  # Helper to verify numeric levels are sorted numerically, not lexicographically
+  # We want (1, 2, ..., 9, 10) instead of (1, 10, 2, ... 9)
+  check_numeric_levels <- function(factor_col) {
+    levels_str <- as.character(levels(factor_col))
+    numeric_levels <- levels_str[grepl("^[0-9]+$", levels_str)]
+    if (length(numeric_levels) > 0) {
+      numeric_values <- as.integer(numeric_levels)
+      expect_equal(numeric_levels, as.character(sort(numeric_values)))
+    }
+  }
+
+  # Test factor levels for default cluster name
+  test_case <- get_test_data()
+  clustered_default <- FindClusters(test_case, verbose = FALSE)
+  check_numeric_levels(clustered_default[["seurat_clusters", drop = TRUE]])
+
+  # and also for the default RNA_snn_res column
+  default_res_col <- grep("RNA_snn_res", colnames(clustered_default[[]]), value = TRUE)[1]
+  expect_true(!is.na(default_res_col))
+  check_numeric_levels(clustered_default[[default_res_col, drop = TRUE]])
+
+  # Test factor levels for custom cluster name
+  test_case2 <- get_test_data()
+  clustered_custom <- FindClusters(test_case2, cluster.name = "custom_clusters", verbose = FALSE)
+  check_numeric_levels(clustered_custom[["custom_clusters", drop = TRUE]])
+})

--- a/tests/testthat/test_find_clusters.R
+++ b/tests/testthat/test_find_clusters.R
@@ -61,3 +61,41 @@ test_that("Smoke test for `FindClusters`", {
   expect_warning(FindClusters(test_case, algorithm = 4, leiden_method = "leidenbase"))
   expect_no_warning(FindClusters(test_case, algorithm = 4, leiden_method = "leidenbase", random.seed = 1))
 })
+
+test_that("`FindClusters` works if passed a vector of resolutions", {
+  test_case <- get_test_data()
+  resolutions <- seq(0.4, 0.8, by = 0.1)
+  cluster_names <- paste0("resolution_", resolutions)
+
+  # Run FindClusters with multiple resolutions in one call
+  clustered <- FindClusters(
+    test_case,
+    resolution = resolutions,
+    cluster.name = cluster_names,
+    verbose = FALSE
+  )
+
+  # Check that the active identity is set to the last computed clustering
+  expect_identical(
+    as.character(clustered[[tail(cluster_names, n = 1), drop = TRUE]]),
+    as.character(Idents(clustered))
+  )
+
+  clustered_loop <- get_test_data()
+  for (i in seq_along(resolutions)) {
+    clustered_loop <- FindClusters(
+      clustered_loop,
+      resolution = resolutions[i],
+      cluster.name = cluster_names[i],
+      verbose = FALSE
+    )
+  }
+
+  # Check that passing multiple resolutions at once produces identical results to running in a loop
+  for (cluster_name in cluster_names) {
+    expect_identical(
+      as.character(clustered[[cluster_name, drop = TRUE]]),
+      as.character(clustered_loop[[cluster_name, drop = TRUE]])
+    )
+  }
+})


### PR DESCRIPTION
# Summary
`FindClusters` was no longer assigning cluster-associated metadata properly when passed a vector of resolutions and custom cluster names - the active identity was being assigned using `cluster.name` (containing all custom cluster names) instead of `idents.use`. Here, `idents.use` is the name of the last clustering column that was created in clustering.results, ensuring the active identity is properly updated for the most recent clustering run. In this fix, we switch to using this for active identity assignment for custom cluster names. (Note that the individual resolution columns were already correctly stored earlier via `object[[]] <- clustering.results`.)

In addition to fixing this bug, this PR also proposes two tests in `tests/testthat/test_find_clusters.R`, checking that:
1. `FindClusters` works if passed a vector of resolutions
2. `FindClusters` sorts numeric factor levels correctly (the bug in question was initially introduced in the process of fixing the level ordering issue)

## Type of change
Bug fix (non-breaking change fixing an issue)

## Tests & examples

`test_find_clusters.R` includes a test for this fix, below is a reproducible example adapted from #10382.

```r
# first check out this branch
devtools::load_all(".")
library(SeuratData)
library(dplyr)
pbmc <- LoadData("pbmc3k")

pbmc <- NormalizeData(pbmc) %>% FindVariableFeatures() %>% ScaleData() %>% RunPCA(features = VariableFeatures(pbmc)) %>% FindNeighbors(dims = 1:10)
res_sequence <- seq(0.4,0.8, by = 0.1)

pbmc <- FindClusters(pbmc, resolution = res_sequence, cluster.name = paste0("resolution_",res_sequence))

for (i in res_sequence) {
  col_name <- grep(i, colnames(pbmc@meta.data), value = TRUE)
  print(unique(pbmc@meta.data[[col_name]]))
}
```

## Related issues
Fixes #10382

## Checklist

- [x] Branch is named appropriately (`feat/*`, `fix/*`, `docs/*`)
- [x] Code follows Seurat [style guidelines](https://github.com/satijalab/seurat/wiki/Contributor%27s-Guide)
- [x] Documentation and comments have been updated
- [x] `devtools::document()` has been run
- [x] `devtools::check()` passes with no errors or warnings
- [x] Test case demonstrating new functionality is included