### PR TITLE
Add `uwot.init` parameter to `RunUMAP` to customize initialization

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: Seurat
-Version: 5.5.0.9001
+Version: 5.5.0.9002
 Title: Tools for Single Cell Genomics
 Description: A toolkit for quality control, analysis, and exploration of single cell RNA sequencing data. 'Seurat' aims to enable users to identify and interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse types of single cell data. See Satija R, Farrell J, Gennert D, et al (2015) <doi:10.1038/nbt.3192>, Macosko E, Basu A, Satija R, et al (2015) <doi:10.1016/j.cell.2015.05.002>, Stuart T, Butler A, et al (2019) <doi:10.1016/j.cell.2019.05.031>, and Hao, Hao, et al (2020) <doi:10.1101/2020.10.12.335331> for more details.
 Authors@R: c(

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ### Additions
 
+- Added `uwot.init` parameter to `RunUMAP` to optionally customize method of UMAP initialization ([#10386](https://github.com/satijalab/seurat/pull/10386))
+
 ### Fixes
 
 - Fixed issue with `FindClusters` not setting metadata properly when a vector of resolutions is passed to `resolution` and a custom cluster name is specified ([#10385](https://github.com/satijalab/seurat/pull/10385))

--- a/R/dimensional_reduction.R
+++ b/R/dimensional_reduction.R
@@ -1656,6 +1656,8 @@ RunUMAP.Graph <- function(
   a = NULL,
   b = NULL,
   uwot.sgd = FALSE,
+  uwot.approx_pow = FALSE,
+  uwot.init = "spectral",
   seed.use = 42L,
   metric.kwds = NULL,
   densmap = FALSE,
@@ -1707,7 +1709,8 @@ RunUMAP.Graph <- function(
     negative_sample_rate = negative.sample.rate,
     n_epochs = as.integer(x = n.epochs),
     random_state = random.state,
-    init = "spectral",
+    approx_pow = uwot.approx_pow,
+    init = uwot.init,
     metric = metric,
     metric_kwds = metric.kwds,
     verbose = verbose
@@ -1818,7 +1821,8 @@ RunUMAP.Neighbor <- function(
 #' @param uwot.approx_pow Set \code{uwot::umap(approx_pow = TRUE)}. Default is \code{FALSE}. See
 #' \code{\link[uwot]{umap}} for more details.
 #' @param uwot.init Set the initialization method to use for \code{\link[uwot]{umap}} or 
-#' \code{\link[uwot]{umap2}} (see these functions for available options). Default is \code{"spectral"}.
+#' \code{\link[uwot]{umap2}}, which is passed to the \code{init} parameter of these functions.
+#' See these functions for available options. Default is \code{"spectral"}.
 #' @param metric.kwds A dictionary of arguments to pass on to the metric, such as the p value for
 #' Minkowski distance. If NULL then no arguments are passed on.
 #' @param angular.rp.forest Whether to use an angular random projection forest to initialize the
@@ -1885,6 +1889,7 @@ RunUMAP.Seurat <- function(
   b = NULL,
   uwot.sgd = FALSE,
   uwot.approx_pow = FALSE,
+  uwot.init = "spectral",
   seed.use = 42L,
   metric.kwds = NULL,
   angular.rp.forest = FALSE,
@@ -1978,6 +1983,7 @@ RunUMAP.Seurat <- function(
     b = b,
     uwot.sgd = uwot.sgd,
     uwot.approx_pow = uwot.approx_pow,
+    uwot.init = uwot.init,
     seed.use = seed.use,
     metric.kwds = metric.kwds,
     angular.rp.forest = angular.rp.forest,

--- a/R/dimensional_reduction.R
+++ b/R/dimensional_reduction.R
@@ -1354,6 +1354,7 @@ RunUMAP.default <- function(
   b = NULL,
   uwot.sgd = FALSE,
   uwot.approx_pow = FALSE,
+  uwot.init = "spectral",
   seed.use = 42,
   metric.kwds = NULL,
   angular.rp.forest = FALSE,
@@ -1480,6 +1481,7 @@ RunUMAP.default <- function(
           negative_sample_rate = negative.sample.rate,
           a = a,
           b = b,
+          init = uwot.init,
           fast_sgd = uwot.sgd,
           approx_pow = uwot.approx_pow,
           verbose = verbose,
@@ -1502,6 +1504,7 @@ RunUMAP.default <- function(
           negative_sample_rate = negative.sample.rate,
           a = a,
           b = b,
+          init = uwot.init,
           fast_sgd = uwot.sgd,
           approx_pow = uwot.approx_pow,
           verbose = verbose,
@@ -1527,6 +1530,7 @@ RunUMAP.default <- function(
           negative_sample_rate = negative.sample.rate,
           a = a,
           b = b,
+          init = uwot.init,
           fast_sgd = uwot.sgd,
           verbose = verbose,
           ret_model = return.model
@@ -1548,6 +1552,7 @@ RunUMAP.default <- function(
           negative_sample_rate = negative.sample.rate,
           a = a,
           b = b,
+          init = uwot.init,
           fast_sgd = uwot.sgd,
           verbose = verbose,
           ret_model = return.model
@@ -1812,6 +1817,8 @@ RunUMAP.Neighbor <- function(
 #' @param uwot.sgd Set \code{uwot::umap(fast_sgd = TRUE)}; see \code{\link[uwot]{umap}} for more details
 #' @param uwot.approx_pow Set \code{uwot::umap(approx_pow = TRUE)}. Default is \code{FALSE}. See
 #' \code{\link[uwot]{umap}} for more details.
+#' @param uwot.init Set the initialization method to use for \code{\link[uwot]{umap}} or 
+#' \code{\link[uwot]{umap2}} (see these functions for available options). Default is \code{"spectral"}.
 #' @param metric.kwds A dictionary of arguments to pass on to the metric, such as the p value for
 #' Minkowski distance. If NULL then no arguments are passed on.
 #' @param angular.rp.forest Whether to use an angular random projection forest to initialize the

--- a/man/RunUMAP.Rd
+++ b/man/RunUMAP.Rd
@@ -59,6 +59,8 @@ RunUMAP(object, ...)
   a = NULL,
   b = NULL,
   uwot.sgd = FALSE,
+  uwot.approx_pow = FALSE,
+  uwot.init = "spectral",
   seed.use = 42L,
   metric.kwds = NULL,
   densmap = FALSE,
@@ -97,6 +99,7 @@ RunUMAP(object, ...)
   b = NULL,
   uwot.sgd = FALSE,
   uwot.approx_pow = FALSE,
+  uwot.init = "spectral",
   seed.use = 42L,
   metric.kwds = NULL,
   angular.rp.forest = FALSE,
@@ -189,7 +192,8 @@ right adjoint functor.}
 \code{\link[uwot]{umap}} for more details.}
 
 \item{uwot.init}{Set the initialization method to use for \code{\link[uwot]{umap}} or 
-\code{\link[uwot]{umap2}} (see these functions for available options). Default is \code{"spectral"}.}
+\code{\link[uwot]{umap2}}, which is passed to the \code{init} parameter of these functions.
+See these functions for available options. Default is \code{"spectral"}.}
 
 \item{seed.use}{Set a random seed. By default, sets the seed to 42. Setting
 NULL will not set a seed}

--- a/man/RunUMAP.Rd
+++ b/man/RunUMAP.Rd
@@ -32,6 +32,7 @@ RunUMAP(object, ...)
   b = NULL,
   uwot.sgd = FALSE,
   uwot.approx_pow = FALSE,
+  uwot.init = "spectral",
   seed.use = 42,
   metric.kwds = NULL,
   angular.rp.forest = FALSE,
@@ -186,6 +187,9 @@ right adjoint functor.}
 
 \item{uwot.approx_pow}{Set \code{uwot::umap(approx_pow = TRUE)}. Default is \code{FALSE}. See
 \code{\link[uwot]{umap}} for more details.}
+
+\item{uwot.init}{Set the initialization method to use for \code{\link[uwot]{umap}} or 
+\code{\link[uwot]{umap2}} (see these functions for available options). Default is \code{"spectral"}.}
 
 \item{seed.use}{Set a random seed. By default, sets the seed to 42. Setting
 NULL will not set a seed}


### PR DESCRIPTION
# Summary

Introduces parameter `uwot.init` for customizing initialization of UMAP, passed to `uwot::umap` or `uwot::umap2` (depending on `umap.method`). From the `uwot` docs:

> Options are:
> "spectral" Spectral embedding using the normalized Laplacian of the fuzzy 1-skeleton, with Gaussian noise added.
> "normlaplacian". Spectral embedding using the normalized Laplacian of the fuzzy 1-skeleton, without noise.
> "random". Coordinates assigned using a uniform random distribution between -10 and 10.
> "lvrandom". Coordinates assigned using a Gaussian distribution with standard deviation 1e-4, as used in LargeVis (Tang et al., 2016) and t-SNE.
> "laplacian". Spectral embedding using the Laplacian Eigenmap (Belkin and Niyogi, 2002).
> "pca". The first two principal components from PCA of X if X is a data frame, and from a 2-dimensional classical MDS if X is of class "dist".
> "spca". Like "pca", but each dimension is then scaled so the standard deviation is 1e-4, to give a distribution similar to that used in t-SNE. This is an alias for init = "pca", init_sdev = 1e-4.
> "agspectral" An "approximate global" modification of "spectral" which all edges in the graph to a value of 1, and then sets a random number of edges (negative_sample_rate edges per vertex) to 0.1, to approximate the effect of non-local affinities.
> A matrix of initial coordinates.

In previous discussions `https://github.com/jlmelville/uwot/issues/16#issuecomment-465459350`, `https://github.com/satijalab/seurat/issues/9352`, it's been pointed out that using the `"agspectral"` initialization option can produce better results for data of certain structure, e.g. when the default initialization produces a graph with disconnected components, causing issues with convergence (long runtimes and possible segfaults).

## Type of change
Bug fix (non-breaking change fixing an issue)

## Tests & examples
```r
# ensure you are working off of this branch
devtools::load_all(".")
library(SeuratData)
data("pbmc3k")
pbmc3k.final <- UpdateSeuratObject(pbmc3k.final)
p <- RunUMAP(pbmc3k.final, dims=1:10, uwot.init = "agspectral")
```

## Related issues
`https://github.com/satijalab/seurat/issues/9352`, `https://github.com/satijalab/seurat/issues/10384`
(should confirm whether using this option / passing "agspectral" is able to solve the reported issues)

## Checklist
<!-- Ensure all items are complete before submitting -->

- [x] Branch is named appropriately (`feat/*`, `fix/*`, `docs/*`)
- [x] Code follows Seurat [style guidelines](https://github.com/satijalab/seurat/wiki/Contributor%27s-Guide)
- [x] Documentation and comments have been updated
- [x] `devtools::document()` has been run
- [x] `devtools::check()` passes with no errors or warnings