### PR TITLE
Add sanity check for two layers needed for IntegrateLayers

### DIFF
--- a/R/integration5.R
+++ b/R/integration5.R
@@ -621,6 +621,20 @@ IntegrateLayers <- function(
   } else {
     abort(message = "'assay' must be a v5 or SCT assay")
   }
+  n.groups <- if (inherits(x = object[[assay]], what = 'SCTAssay')) {
+    length(levels(x = object[[assay]]))
+  } else {
+    length(layers)
+  }
+  if (n.groups < 2L) {
+    abort(message = paste0(
+      "IntegrateLayers requires at least two groups/layers in assay '",
+      assay,
+      "', but found ",
+      n.groups,
+      ". Split the assay by sample/batch (e.g. object[[assay]] <- split(object[[assay]], f = object$batch)) and check that subsetting retained cells from multiple batches."
+    ))
+  }
   if (!is.null(scale.layer)) {
     features <- intersect(
       x = features,

--- a/tests/testthat/test_integration5.R
+++ b/tests/testthat/test_integration5.R
@@ -327,6 +327,20 @@ test_that("IntegrateLayers fails when expected", {
       new.reduction = "integrated"
     )
   )
+
+  # an error should be raised if the assay has only one layer after split
+  test.data.one <- test.data.std
+  test.data.one[["RNA"]] <- JoinLayers(test.data.one[["RNA"]])
+  test.data.one[["RNA"]] <- split(test.data.one[["RNA"]], f = rep("single", ncol(test.data.one)))
+  expect_error(
+    IntegrateLayers(
+      test.data.one,
+      method = CCAIntegration,
+      orig.reduction = "pca",
+      new.reduction = "integrated"
+    ),
+    regexp = "at least two groups/layers"
+  )
 })
 
 


### PR DESCRIPTION
Taking the suggestion from issue #9381 on including a sanity check for at least 2-layers in the input for IntegrateLayers() function.