### PR TITLE
Fixed feature subsetting in PrepDR5

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: Seurat
-Version: 5.5.0.9003
+Version: 5.5.0.9004
 Title: Tools for Single Cell Genomics
 Description: A toolkit for quality control, analysis, and exploration of single cell RNA sequencing data. 'Seurat' aims to enable users to identify and interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse types of single cell data. See Satija R, Farrell J, Gennert D, et al (2015) <doi:10.1038/nbt.3192>, Macosko E, Basu A, Satija R, et al (2015) <doi:10.1016/j.cell.2015.05.002>, Stuart T, Butler A, et al (2019) <doi:10.1016/j.cell.2019.05.031>, and Hao, Hao, et al (2020) <doi:10.1101/2020.10.12.335331> for more details.
 Authors@R: c(

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 
 - Fixed issue with `FindClusters` not setting metadata properly when a vector of resolutions is passed to `resolution` and a custom cluster name is specified ([#10385](https://github.com/satijalab/seurat/pull/10385))
 - Updated logic in `Parenting` to extract function names from the call stack efficiently, avoiding slowdowns when functions are run with `do.call` ([#10161](https://github.com/satijalab/seurat/pull/10161))
+- Fixed bug in `PrepDR5` affecting `RunPCA` on v5 objects, where supplied features could be incorrectly dropped when non-supplied features had zero variance ([#10398](https://github.com/satijalab/seurat/pull/10398))
 
 # Seurat 5.5.0
 

--- a/R/dimensional_reduction.R
+++ b/R/dimensional_reduction.R
@@ -2544,9 +2544,9 @@ PrepDR5 <- function(object, features = NULL, layer = 'scale.data', verbose = TRU
     stop("No variable features, run FindVariableFeatures() or provide a vector of features", call. = FALSE)
   }
   if (is(data.use, "IterableMatrix")) {
-    features.var <- BPCells::matrix_stats(matrix=data.use, row_stats="variance")$row_stats["variance",]
+    features.var <- BPCells::matrix_stats(matrix=data.use[features,], row_stats="variance")$row_stats["variance",]
   } else {
-    features.var <- apply(X = data.use, MARGIN = 1L, FUN = var)
+    features.var <- apply(X = data.use[features,], MARGIN = 1L, FUN = var)
   }
   features.keep <- features[features.var > 0]
   if (!length(x = features.keep)) {

--- a/tests/testthat/test_dimensional_reduction.R
+++ b/tests/testthat/test_dimensional_reduction.R
@@ -124,6 +124,45 @@ test_that("`RunPCA` returns total variance", {
   )
 })
 
+test_that("`RunPCA` does not drop features when there are zero-variance features outside the supplied set", {
+  set.seed(123)
+  
+  mat <- get_random_counts()
+  # Set some features outside the supplied set to have zero variance
+  mat[1:50, ] <- 0
+
+  test_case <- get_test_data(counts = mat, assay_version = "v5")
+  supplied_features <- rownames(mat)[51:80]
+
+  result <- suppressWarnings(RunPCA(test_case, features = supplied_features, npcs = 10, verbose = FALSE))
+
+  loadings_features <- rownames(Loadings(result[["pca"]]))
+  expect_equal(length(loadings_features), length(supplied_features))
+  expect_equal(loadings_features, supplied_features)
+})
+
+test_that("`RunPCA` drops zero-variance features only within the supplied feature set", {
+  set.seed(123)
+
+  mat <- get_random_counts()
+  # Set some features outside the supplied set to have zero variance
+  mat[1:50, ] <- 0
+  # Set some features within the supplied set to have zero variance
+  mat[51:60, ] <- 0
+
+  test_case <- get_test_data(counts = mat, assay_version = "v5")
+
+  supplied_features <- rownames(mat)[51:100]
+
+  result <- suppressWarnings(RunPCA(test_case, features = supplied_features, npcs = 10, verbose = FALSE))
+
+  loadings_features <- rownames(Loadings(result[["pca"]]))
+  expected_features <- setdiff(supplied_features, rownames(mat)[51:60])
+
+  expect_equal(loadings_features, expected_features)
+  expect_false(any(rownames(mat)[51:60] %in% loadings_features))
+})
+
 context("RunICA")
 
 test_that("`RunPCA` works as expected", {


### PR DESCRIPTION
To fix GitHub issue #8627 -- previously, `RunPCA` incorrectly discards features if any zero-variance features are present, due to improper subsetting. This is now fixed through a simple modification to `PrepDR5`.