### PR TITLE
Use `fill` when passed through `...` in `LabelClusters` for label box background color

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: Seurat
-Version: 5.5.0.9004
+Version: 5.5.0.9005
 Title: Tools for Single Cell Genomics
 Description: A toolkit for quality control, analysis, and exploration of single cell RNA sequencing data. 'Seurat' aims to enable users to identify and interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse types of single cell data. See Satija R, Farrell J, Gennert D, et al (2015) <doi:10.1038/nbt.3192>, Macosko E, Basu A, Satija R, et al (2015) <doi:10.1016/j.cell.2015.05.002>, Stuart T, Butler A, et al (2019) <doi:10.1016/j.cell.2019.05.031>, and Hao, Hao, et al (2020) <doi:10.1101/2020.10.12.335331> for more details.
 Authors@R: c(

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 - Fixed issue with `FindClusters` not setting metadata properly when a vector of resolutions is passed to `resolution` and a custom cluster name is specified ([#10385](https://github.com/satijalab/seurat/pull/10385))
 - Updated logic in `Parenting` to extract function names from the call stack efficiently, avoiding slowdowns when functions are run with `do.call` ([#10161](https://github.com/satijalab/seurat/pull/10161))
 - Fixed bug in `PrepDR5` affecting `RunPCA` on v5 objects, where supplied features could be incorrectly dropped when non-supplied features had zero variance ([#10398](https://github.com/satijalab/seurat/pull/10398))
+- Updated `LabelClusters` to use `fill` argument for label background color in `geom_label*` when specified, instead of the default per-cluster color ([#10404](https://github.com/satijalab/seurat/pull/10404))
 
 # Seurat 5.5.0
 

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -6310,16 +6310,24 @@ LabelClusters <- function(
   for (group in groups) {
     labels.loc[labels.loc[, id] == group, id] <- labels[group]
   }
-
   if (box) {
+    # Use fill for box color and default to cluster color if not provided
+    dots <- list(...)
+    if ("fill" %in% names(x = dots)) {
+      box.color <- dots$fill
+      dots$fill <- NULL # Make sure fill isn't passed to the geom twice
+    } else {
+      box.color <- labels.loc$color
+    }
     geom.use <- ifelse(test = repel, yes = geom_label_repel, no = geom_label)
-    plot <- plot + geom.use(
+    plot <- plot + exec(
+      .fn = geom.use,
       data = labels.loc,
       mapping = aes(x = .data[[xynames['x']]], y = .data[[xynames['y']]], label = .data[[id]]),
-      fill = labels.loc$color,
+      fill = box.color,
       show.legend = FALSE,
       inherit.aes = FALSE,
-      ...
+      !!!dots
     )
   } else {
     geom.use <- ifelse(test = repel, yes = geom_text_repel, no = geom_text)


### PR DESCRIPTION
Fix ability to specify `fill` for label box background color in `LabelClusters`; this resolves #10403.

[Previously: label box fill remained the default (cluster color) even when a value was passed, and produced warning `"Warning message: Duplicated aesthetics after name standardisation: fill"`.]

## Tests & examples

```r
# First make sure you’re on this branch 
devtools::load_all("~/seurat") # pak::pkg_install("satijalab/seurat@fix/labelclusters-box-fill")
plot <- DimPlot(pbmc_small)

# Default behavior - boxes are filled with the color assigned to the cluster
p1 <- LabelClusters(plot = plot, id = "ident", box = T)

# Specify white background for label box
p2 <- LabelClusters(plot = plot, id = "ident", box = T, fill = "white")

# Specify white background (with repel=F)
p3 <- LabelClusters(plot = plot, id = "ident", box = T, fill = "white", repel=F)

# Passing other arguments works as before
p4 <- LabelClusters(plot = plot, id = "ident", box = T, fill = "black", color = "lightgreen", size = 2)

p1 | p2 | p3 | p4
```
<img width="1000" height="200" alt="image" src="https://github.com/user-attachments/assets/31c5c836-c59b-40cb-b50e-1a4797e3e4e9" />