### PR TITLE
Fix genes being set to zero counts in PrepSCTFindMarkers for multi-SCT model objects

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: Seurat
-Version: 5.5.0.9005
+Version: 5.5.0.9006
 Title: Tools for Single Cell Genomics
 Description: A toolkit for quality control, analysis, and exploration of single cell RNA sequencing data. 'Seurat' aims to enable users to identify and interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse types of single cell data. See Satija R, Farrell J, Gennert D, et al (2015) <doi:10.1038/nbt.3192>, Macosko E, Basu A, Satija R, et al (2015) <doi:10.1016/j.cell.2015.05.002>, Stuart T, Butler A, et al (2019) <doi:10.1016/j.cell.2019.05.031>, and Hao, Hao, et al (2020) <doi:10.1101/2020.10.12.335331> for more details.
 Authors@R: c(

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 
 ### Fixes
 
+- Fixed bug in `PrepSCTFindMarkers` in the multi-model case that produced zero counts for some valid genes due to an incorrect filter for theta ([#10410](https://github.com/satijalab/seurat/pull/10410))
 - Fixed issue with `FindClusters` not setting metadata properly when a vector of resolutions is passed to `resolution` and a custom cluster name is specified ([#10385](https://github.com/satijalab/seurat/pull/10385))
 - Updated logic in `Parenting` to extract function names from the call stack efficiently, avoiding slowdowns when functions are run with `do.call` ([#10161](https://github.com/satijalab/seurat/pull/10161))
 - Fixed bug in `PrepDR5` affecting `RunPCA` on v5 objects, where supplied features could be incorrectly dropped when non-supplied features had zero variance ([#10398](https://github.com/satijalab/seurat/pull/10398))

--- a/R/differential_expression.R
+++ b/R/differential_expression.R
@@ -2263,7 +2263,7 @@ PrepSCTFindMarkers <- function(object, assay = "SCT", verbose = TRUE) {
     # This is because in split-layer SCT workflows, some sparse genes may have NaN values for
     # fitted parameters due to low expression levels in some layers
     valid_genes <- rownames(pars)[
-      is.finite(pars[, "theta"]) &
+      !is.na(pars[, "theta"]) &
       is.finite(pars[, "(Intercept)"]) &
       is.finite(pars[, "log_umi"])
     ]

--- a/tests/testthat/test_differential_expression.R
+++ b/tests/testthat/test_differential_expression.R
@@ -307,6 +307,133 @@ if (is_not_cran_submission) {
     expect_equal(nrow(x = markers.bp), 228)
     expect_equal(rownames(markers.bp)[1], "HLA-DPB1")
   })
+
+  # set up a multi-model SCT object for PrepSCTFindMarkers tests
+  sct1 <- suppressWarnings(SCTransform(pbmc_small[, 1:40], variable.features.n = 20, vst.flavor = "v1", verbose = FALSE, seed.use = 123))
+  sct2 <- suppressWarnings(SCTransform(pbmc_small[, 41:80], variable.features.n = 20, vst.flavor = "v1", verbose = FALSE, seed.use = 123))
+  sct_merged <- merge(x = sct1, y = sct2)
+
+  test_that("PrepSCTFindMarkers matches correct_counts for unchanged SCT models", {
+    model_name <- "model1.1"
+    sct <- sct_merged[["SCT"]]
+    model <- slot(sct, name = "SCTModel.list")[[model_name]]
+    cell_attributes <- slot(model, name = "cell.attributes")
+    model_cells <- rownames(cell_attributes)
+    feature_attributes <- slot(model, name = "feature.attributes")
+
+    valid_genes <- rownames(feature_attributes)[!is.na(feature_attributes[, "theta"]) &
+                                                is.finite(feature_attributes[, "(Intercept)"]) &
+                                                is.finite(feature_attributes[, "log_umi"])]
+
+    raw_counts <- GetAssayData(sct_merged, assay = SCTResults(sct, slot = "umi.assay")[[model_name]], layer = "counts")
+
+    expected_counts <- sctransform::correct_counts(
+      list(model_str = SCTResults(sct, slot = "model")[[model_name]],
+        arguments = SCTResults(sct, slot = "arguments")[[model_name]],
+        model_pars_fit = as.matrix(feature_attributes[valid_genes, c("theta", "(Intercept)", "log_umi"), drop = FALSE]),
+        cell_attr = cell_attributes),
+      umi = raw_counts[valid_genes, model_cells, drop = FALSE],
+      verbosity = 0,
+      scale_factor = min(unlist(lapply(SCTResults(sct, slot = "cell.attributes"), function(x) median(x[, "umi"]))))
+    )
+
+    result <- PrepSCTFindMarkers(sct_merged, verbose = FALSE)
+
+    # PrepSCTFindMarkers recorrection should match sctransform::correct_counts at the same shared median UMI depth
+    result_counts <- GetAssayData(result, assay = "SCT", layer = "counts")[rownames(expected_counts), model_cells, drop = FALSE]
+    result_data <- GetAssayData(result, assay = "SCT", layer = "data")[rownames(expected_counts), model_cells, drop = FALSE]
+
+    expect_equal(as.matrix(result_counts), as.matrix(expected_counts))
+    expect_equal(as.matrix(result_data), as.matrix(log1p(expected_counts)))
+  })
+
+  test_that("PrepSCTFindMarkers keeps infinite theta genes with valid corrected counts", {
+    sct_test <- sct_merged
+    model_name <- "model1.1"
+    model <- slot(sct_test[["SCT"]], name = "SCTModel.list")[[model_name]]
+    cell_attributes <- slot(model, name = "cell.attributes")
+    model_cells <- rownames(cell_attributes)
+    feature_attributes <- slot(model, name = "feature.attributes")
+    counts <- GetAssayData(sct_test, assay = "SCT", layer = "counts")
+    before_counts <- counts[rownames(feature_attributes), model_cells, drop = FALSE]
+    nonzero_genes <- names(sort(Matrix::rowSums(before_counts > 0), decreasing = TRUE))
+
+    # set a single gene with finite intercept and log_umi to have infinite theta (valid)
+    infinite_theta_gene <- nonzero_genes[is.finite(feature_attributes[nonzero_genes, "(Intercept)"]) &
+                                        is.finite(feature_attributes[nonzero_genes, "log_umi"])][[1]]
+    feature_attributes[infinite_theta_gene, "theta"] <- Inf
+    slot(slot(sct_test[["SCT"]], name = "SCTModel.list")[[model_name]], name = "feature.attributes") <- feature_attributes
+
+    result <- PrepSCTFindMarkers(sct_test, verbose = FALSE)
+    result_counts <- GetAssayData(result, assay = "SCT", layer = "counts")
+    result_counts <- result_counts[infinite_theta_gene, model_cells, drop = FALSE]
+
+    # check that infinite theta is retained, and corrected counts are valid (not all zero or non-finite)
+    expect_false(is.finite(feature_attributes[infinite_theta_gene, "theta"]))
+    expect_gt(Matrix::rowSums(before_counts[infinite_theta_gene, , drop = FALSE] > 0), expected = 0)
+    expect_gt(Matrix::rowSums(result_counts > 0), expected = 0)
+  })
+
+  test_that("PrepSCTFindMarkers excludes missing theta genes", {
+    sct_test <- sct_merged
+    model_name <- "model1.1"
+    model <- slot(sct_test[["SCT"]], name = "SCTModel.list")[[model_name]]
+    cell_attributes <- slot(model, name = "cell.attributes")
+    model_cells <- rownames(cell_attributes)
+    feature_attributes <- slot(model, name = "feature.attributes")
+    counts <- GetAssayData(sct_test, assay = "SCT", layer = "counts")
+
+    before_counts <- counts[rownames(feature_attributes), model_cells, drop = FALSE]
+
+    nonzero_genes <- names(sort(Matrix::rowSums(before_counts > 0), decreasing = TRUE))
+
+    # set a single gene with finite intercept and log_umi to have missing/NA theta (invalid)
+    # this gene should be filtered out in PrepSCTFindMarkers, then added back in the original order w/ all zero corrected counts
+    missing_theta_gene <- nonzero_genes[is.finite(feature_attributes[nonzero_genes, "(Intercept)"]) &
+                                        is.finite(feature_attributes[nonzero_genes, "log_umi"])][[1]]
+
+    feature_attributes[missing_theta_gene, "theta"] <- NA
+    slot(slot(sct_test[["SCT"]], name = "SCTModel.list")[[model_name]], name = "feature.attributes") <- feature_attributes
+
+    result <- PrepSCTFindMarkers(sct_test, verbose = FALSE)
+    result_counts <- GetAssayData(result, assay = "SCT", layer = "counts")
+    result_counts <- result_counts[missing_theta_gene, model_cells, drop = FALSE]
+
+    # check that missing theta is excluded, and corrected counts are all zero for this gene
+    expect_equal(unlist(unname(Matrix::rowSums(result_counts > 0))), expected = 0)
+
+    # check that it is in the same order as the original assay and has finite counts (not NaN or Inf)
+    expect_identical(rownames(result_counts), missing_theta_gene)
+    expect_true(all(is.finite(result_counts@x)))
+  })
+
+  test_that("PrepSCTFindMarkers drops rows with NaN corrected counts", {
+    sct_test <- sct_merged
+    model_name <- "model1.1"
+    model <- slot(sct_test[["SCT"]], name = "SCTModel.list")[[model_name]]
+    cell_attributes <- slot(model, name = "cell.attributes")
+    model_cells <- rownames(cell_attributes)
+    feature_attributes <- slot(model, name = "feature.attributes")
+    counts <- GetAssayData(sct_test, assay = "SCT", layer = "counts")
+    before_counts <- counts[rownames(feature_attributes), model_cells, drop = FALSE]
+    nonzero_genes <- names(sort(Matrix::rowSums(before_counts > 0), decreasing = TRUE))
+
+    # set a single gene with finite intercept and log_umi to have theta = 0, which causes sctransform::correct_counts to produce NaN values for this gene
+    nan_counts_gene <- nonzero_genes[is.finite(feature_attributes[nonzero_genes, "(Intercept)"]) &
+                                    is.finite(feature_attributes[nonzero_genes, "log_umi"])][[3]]
+    feature_attributes[nan_counts_gene, "theta"] <- 0
+
+    slot(slot(sct_test[["SCT"]], name = "SCTModel.list")[[model_name]], name = "feature.attributes") <- feature_attributes
+
+    result <- PrepSCTFindMarkers(sct_test, verbose = FALSE)
+    result_counts <- GetAssayData(result, assay = "SCT", layer = "counts")
+
+    result_counts <- result_counts[nan_counts_gene, model_cells, drop = FALSE]
+
+    # check that the gene with NaN corrected counts is dropped, and thus has zero non-zero counts in the result
+    expect_equal(unlist(unname(Matrix::rowSums(result_counts > 0))), expected = 0)
+    expect_true(all(is.finite(result_counts@x)))
+  })
 }
 
 results <- suppressWarnings(
@@ -558,4 +685,3 @@ if (requireNamespace('metap', quietly = TRUE)) {
     expect_equal(rownames(markers.missing)[1], "HLA-DPB1")
   })
 }
-


### PR DESCRIPTION
Fixes #10409

In a fix for a previous bug (#10361) where genes with NaN SCT parameters were being incorrectly left out of downstream FindMarkers and visualization steps, valid genes would sometimes incorrectly have their counts set to zero. 

Previously, PrepSCTFindMarkers() filtered genes prior to recorrection by requiring theta, (Intercept), and log_umi parameters to all be finite. This unintentionally removed genes with theta = Inf even when (Intercept) and log_umi were valid. 

For instance, in the below SCTModel.list, genes HMGN2 and AK2 in a multi-SCT model object would have their corrected counts set to 0 for model1:

```
[1] "model1"
           gene     theta intercept  log_umi  keep before after
HMGN2     HMGN2       Inf -10.94026 2.302585 FALSE     98     0
AK2         AK2       Inf -11.22116 2.302585 FALSE     73     0
CDK11B   CDK11B 0.1568015 -11.77633 2.302585  TRUE     39    39
PLEKHM2 PLEKHM2 0.3541736 -11.06855 2.302585  TRUE     84    84
[1] "model1.1"
           gene     theta intercept  log_umi  keep before after
HMGN2     HMGN2 0.2618025 -11.46332 2.302585  TRUE     61    61
AK2         AK2 0.2448065 -11.52153 2.302585  TRUE     54    54
CDK11B   CDK11B       Inf -12.13767 2.302585 FALSE     32     0
PLEKHM2 PLEKHM2       Inf -11.19668 2.302585 FALSE     81     0
```

This PR keeps genes with theta = Inf when mean model parameters are valid, while still excluding genes that produce NaN correct_counts().

Reproducible example: 
```
library(Seurat)
library(SeuratData)
library(Matrix)

#Load small ifnb subset
data("ifnb")
ifnb <- UpdateSeuratObject(ifnb)
ifnb <- subset(ifnb, subset = seurat_annotations == "CD14 Mono")

#Create a multi layer RNA assay
x <- ifnb
x[["RNA"]] <- split(x[["RNA"]], f = x$stim)
x <- SCTransform(
  x,
  min_cells = 0,
  return.only.var.genes = FALSE,
  verbose = FALSE
)

#These genes are erroneously set to zero counts
genes <- c("HMGN2", "AK2", "CDK11B", "PLEKHM2")

#Compare SCT counts before and after PrepSCTFindMarkers
before <- x
after <- PrepSCTFindMarkers(x)

models <- slot(before[["SCT"]], "SCTModel.list")

for (m in names(models)) {
  cells <- rownames(slot(models[[m]], "cell.attributes"))
  fa <- slot(models[[m]], "feature.attributes")
  
  before_counts <- GetAssayData(
    before,
    assay = "SCT",
    layer = "counts"
  )[, cells]
  
  after_counts <- GetAssayData(
    after,
    assay = "SCT",
    layer = "counts"
  )[, cells]
  
  genes_present <- intersect(genes, rownames(fa))
  
  #When looking at SCTModel parameters for genes of interest, "before" and "after" should be identical (ie: no genes erroneously filtered out)
  cat("\nSCT model:", m, "\n")
  print(data.frame(
    gene = genes_present,
    theta = fa[genes_present, "theta"],
    intercept = fa[genes_present, "(Intercept)"],
    log_umi = fa[genes_present, "log_umi"],
    passes_current_filter =
      is.finite(fa[genes_present, "theta"]) &
      is.finite(fa[genes_present, "(Intercept)"]) &
      is.finite(fa[genes_present, "log_umi"]),
    nonzero_before_prep = Matrix::rowSums(
      before_counts[genes_present, , drop = FALSE] > 0
    ),
    nonzero_after_prep = Matrix::rowSums(
      after_counts[genes_present, , drop = FALSE] > 0
    )
  ))
}
```