### PR TITLE
Quick Updates to as.SingleCellExperiment (Re: 9266)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: Seurat
-Version: 5.5.1.9001
+Version: 5.5.1.9002
 Title: Tools for Single Cell Genomics
 Description: A toolkit for quality control, analysis, and exploration of single cell RNA sequencing data. 'Seurat' aims to enable users to identify and interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse types of single cell data. See Satija R, Farrell J, Gennert D, et al (2015) <doi:10.1038/nbt.3192>, Macosko E, Basu A, Satija R, et al (2015) <doi:10.1016/j.cell.2015.05.002>, Stuart T, Butler A, et al (2019) <doi:10.1016/j.cell.2019.05.031>, and Hao, Hao, et al (2020) <doi:10.1101/2020.10.12.335331> for more details.
 Authors@R: c(

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Fixed bug in `PercentageFeatureSet` where layer data was incorrectly retrieved prior to finding features with requested pattern
+- Updated `as.SingleCellExperiment` to address conversion case where an object has both original and sketched assay / reductions (differing numbers of cells)
 
 # Seurat 5.5.1
 

--- a/R/objects.R
+++ b/R/objects.R
@@ -1335,16 +1335,25 @@ as.SingleCellExperiment.Seurat <- function(x, assay = NULL, ...) {
     stop("One or more of assays do not have them same number of cells. Ensure all assays have same number of cells before converting.")
   }
 
+  # filter dim reducs to keep only those in assays being converted
+  all_reducs <- .FilterObjects(object = marsh_myeloid, classes.keep = "DimReduc")
+
+  reduc_assays <- sapply(X = all_reducs, FUN = function(i) {
+    DefaultAssay(object = marsh_myeloid[[i]])
+  })
+  names(x = reduc_assays) <- all_reducs
+
+  good_reducs <- names(reduc_assays[reduc_assays %in% assay])
+
   # Equal Number of Cells check reductions
-  reduc_names <- Reductions(object = x)
-  dim_cell_nums <- sapply(X = reduc_names, function(z) {
+  dim_cell_nums <- sapply(X = good_reducs, function(z) {
     nrow(x = Embeddings(object = x, reduction = z))
   })
   if (!all(dim_cell_nums == dim_cell_nums[1])) {
     stop("One or more of reductions do not have them same number of cells. Ensure all reductions have same number of cells before converting.")
   }
 
-
+  # convert assay data
   if (DefaultAssay(object = x) %in% assay) {
     assay <- union(DefaultAssay(object = x), assay)
   }
@@ -1397,16 +1406,6 @@ as.SingleCellExperiment.Seurat <- function(x, assay = NULL, ...) {
       )
     }
   }
-
-  # filter dim reducs to keep only those in assays being converted
-  all_reducs <- .FilterObjects(object = marsh_myeloid, classes.keep = "DimReduc")
-
-  reduc_assays <- sapply(X = all_reducs, FUN = function(i) {
-    DefaultAssay(object = marsh_myeloid[[i]])
-  })
-  names(x = reduc_assays) <- all_reducs
-
-  good_reducs <- names(reduc_assays[reduc_assays %in% assay])
 
   # convert reductions
   for (dr in good_reducs) {

--- a/R/objects.R
+++ b/R/objects.R
@@ -1345,7 +1345,7 @@ as.SingleCellExperiment.Seurat <- function(x, assay = NULL, ...) {
 
   # Equal Number of Cells check reductions
   dim_cell_nums <- sapply(X = good_reducs, function(z) {
-    length(x = Cells(x = x[["full.umap"]]))
+    length(x = Cells(x = x[[z]]))
   })
   if (!all(dim_cell_nums == dim_cell_nums[1])) {
     stop("One or more of reductions do not have them same number of cells. Ensure all reductions have same number of cells before converting.")

--- a/R/objects.R
+++ b/R/objects.R
@@ -1327,6 +1327,14 @@ as.SingleCellExperiment.Seurat <- function(x, assay = NULL, ...) {
     stop("One or more of the assays you are trying to convert is not in the Seurat object")
   }
 
+  # filter dim reducs to keep only those in assays being converted
+  all_reducs <- .FilterObjects(object = marsh_myeloid, classes.keep = "DimReduc")
+  reduc_assays <- sapply(X = all_reducs, FUN = function(i) {
+    DefaultAssay(object = marsh_myeloid[[i]])
+  })
+  names(x = reduc_assays) <- all_reducs
+  good_reducs <- names(reduc_assays[reduc_assays %in% assay])
+
   # Equal Number of Cells check assays
   cell_nums <- sapply(X = assay, FUN = function(y) {
     length(x = Cells(x = marsh_myeloid, assay = y))
@@ -1334,16 +1342,6 @@ as.SingleCellExperiment.Seurat <- function(x, assay = NULL, ...) {
   if (!all(cell_nums == cell_nums[1])) {
     stop("One or more of assays do not have them same number of cells. Ensure all assays have same number of cells before converting.")
   }
-
-  # filter dim reducs to keep only those in assays being converted
-  all_reducs <- .FilterObjects(object = marsh_myeloid, classes.keep = "DimReduc")
-
-  reduc_assays <- sapply(X = all_reducs, FUN = function(i) {
-    DefaultAssay(object = marsh_myeloid[[i]])
-  })
-  names(x = reduc_assays) <- all_reducs
-
-  good_reducs <- names(reduc_assays[reduc_assays %in% assay])
 
   # Equal Number of Cells check reductions
   dim_cell_nums <- sapply(X = good_reducs, function(z) {

--- a/R/objects.R
+++ b/R/objects.R
@@ -1397,7 +1397,19 @@ as.SingleCellExperiment.Seurat <- function(x, assay = NULL, ...) {
       )
     }
   }
-  for (dr in .FilterObjects(object = x, classes.keep = "DimReduc")) {
+
+  # filter dim reducs to keep only those in assays being converted
+  all_reducs <- .FilterObjects(object = marsh_myeloid, classes.keep = "DimReduc")
+
+  reduc_assays <- sapply(X = all_reducs, FUN = function(i) {
+    DefaultAssay(object = marsh_myeloid[[i]])
+  })
+  names(x = reduc_assays) <- all_reducs
+
+  good_reducs <- names(reduc_assays[reduc_assays %in% assay])
+
+  # convert reductions
+  for (dr in good_reducs) {
     assay.used <- DefaultAssay(object = x[[dr]])
     swap.exp <- assay.used %in% SingleCellExperiment::altExpNames(x = sce) & assay.used != orig.exp.name
     if (swap.exp) {

--- a/R/objects.R
+++ b/R/objects.R
@@ -1328,16 +1328,16 @@ as.SingleCellExperiment.Seurat <- function(x, assay = NULL, ...) {
   }
 
   # filter dim reducs to keep only those in assays being converted
-  all_reducs <- .FilterObjects(object = marsh_myeloid, classes.keep = "DimReduc")
+  all_reducs <- .FilterObjects(object = x, classes.keep = "DimReduc")
   reduc_assays <- sapply(X = all_reducs, FUN = function(i) {
-    DefaultAssay(object = marsh_myeloid[[i]])
+    DefaultAssay(object = x[[i]])
   })
   names(x = reduc_assays) <- all_reducs
   good_reducs <- names(reduc_assays[reduc_assays %in% assay])
 
   # Equal Number of Cells check assays
   cell_nums <- sapply(X = assay, FUN = function(y) {
-    length(x = Cells(x = marsh_myeloid, assay = y))
+    length(x = Cells(x = x, assay = y))
   })
   if (!all(cell_nums == cell_nums[1])) {
     stop("One or more of assays do not have them same number of cells. Ensure all assays have same number of cells before converting.")
@@ -1345,7 +1345,7 @@ as.SingleCellExperiment.Seurat <- function(x, assay = NULL, ...) {
 
   # Equal Number of Cells check reductions
   dim_cell_nums <- sapply(X = good_reducs, function(z) {
-    nrow(x = Embeddings(object = x, reduction = z))
+    length(x = Cells(x = x[["full.umap"]]))
   })
   if (!all(dim_cell_nums == dim_cell_nums[1])) {
     stop("One or more of reductions do not have them same number of cells. Ensure all reductions have same number of cells before converting.")

--- a/R/objects.R
+++ b/R/objects.R
@@ -1326,6 +1326,25 @@ as.SingleCellExperiment.Seurat <- function(x, assay = NULL, ...) {
   if (!all(assay %in% Assays(object = x))) {
     stop("One or more of the assays you are trying to convert is not in the Seurat object")
   }
+
+  # Equal Number of Cells check assays
+  cell_nums <- sapply(X = assay, FUN = function(y) {
+    length(x = Cells(x = marsh_myeloid, assay = y))
+  })
+  if (!all(cell_nums == cell_nums[1])) {
+    stop("One or more of assays do not have them same number of cells. Ensure all assays have same number of cells before converting.")
+  }
+
+  # Equal Number of Cells check reductions
+  reduc_names <- Reductions(object = x)
+  dim_cell_nums <- sapply(X = reduc_names, function(z) {
+    nrow(x = Embeddings(object = x, reduction = z))
+  })
+  if (!all(dim_cell_nums == dim_cell_nums[1])) {
+    stop("One or more of reductions do not have them same number of cells. Ensure all reductions have same number of cells before converting.")
+  }
+
+
   if (DefaultAssay(object = x) %in% assay) {
     assay <- union(DefaultAssay(object = x), assay)
   }
@@ -1740,7 +1759,7 @@ GetTissueCoordinates.VisiumV2 <- function(
   # do some cleanup of the resulting data.frame to make it play nice
   # with `SpatialPlot` - namely set rownames and re-order the columns so
   # that the actual position values appear first
-  
+
   # avoid extra processing for Segmentation objects,
   # otherwise "duplicate 'row.names' are not allowed" error occurs
   if (!(inherits(object[[which]], "Segmentation"))) {
@@ -2147,10 +2166,10 @@ VariableFeatures.SCTAssay <- function(
 #' @concept spatial
 #'
 ScaleFactors.SlideSeq <- function(object, ...) {
-  # The concept of image scale factors comes from the 10x Visium platform. 
+  # The concept of image scale factors comes from the 10x Visium platform.
   # Although SlideSeq has no equivalent, we still want to provide the generic
   # so that the all of our concrete `SpatialImage` classes implement the same
-  # interface, so we'll return an S3 `scalefactors` object with all values set 
+  # interface, so we'll return an S3 `scalefactors` object with all values set
   # to 1.
   return(scalefactors())
 }
@@ -2161,10 +2180,10 @@ ScaleFactors.SlideSeq <- function(object, ...) {
 #' @concept spatial
 #'
 ScaleFactors.STARmap <- function(object, ...) {
-  # The concept of image scale factors comes from the 10x Visium platform. 
+  # The concept of image scale factors comes from the 10x Visium platform.
   # Although STARmap has no equivalent, we still want to provide the generic
   # so that the all of our concrete `SpatialImage` classes implement the same
-  # interface, so we'll return an S3 `scalefactors` object with all values set 
+  # interface, so we'll return an S3 `scalefactors` object with all values set
   # to 1.
   return(scalefactors())
 }

--- a/R/objects.R
+++ b/R/objects.R
@@ -1327,27 +1327,25 @@ as.SingleCellExperiment.Seurat <- function(x, assay = NULL, ...) {
     stop("One or more of the assays you are trying to convert is not in the Seurat object")
   }
 
+  # filter dim reducs to keep only those in assays being converted
+  all_reducs <- .FilterObjects(object = x, classes.keep = "DimReduc")
+  reduc_assays <- sapply(X = all_reducs, FUN = function(i) {
+    DefaultAssay(object = x[[i]])
+  })
+  names(x = reduc_assays) <- all_reducs
+  good_reducs <- names(reduc_assays[reduc_assays %in% assay])
+
   # Equal Number of Cells check assays
   cell_nums <- sapply(X = assay, FUN = function(y) {
-    length(x = Cells(x = marsh_myeloid, assay = y))
+    length(x = Cells(x = x, assay = y))
   })
   if (!all(cell_nums == cell_nums[1])) {
     stop("One or more of assays do not have them same number of cells. Ensure all assays have same number of cells before converting.")
   }
 
-  # filter dim reducs to keep only those in assays being converted
-  all_reducs <- .FilterObjects(object = marsh_myeloid, classes.keep = "DimReduc")
-
-  reduc_assays <- sapply(X = all_reducs, FUN = function(i) {
-    DefaultAssay(object = marsh_myeloid[[i]])
-  })
-  names(x = reduc_assays) <- all_reducs
-
-  good_reducs <- names(reduc_assays[reduc_assays %in% assay])
-
   # Equal Number of Cells check reductions
   dim_cell_nums <- sapply(X = good_reducs, function(z) {
-    nrow(x = Embeddings(object = x, reduction = z))
+    length(x = Cells(x = x[[z]]))
   })
   if (!all(dim_cell_nums == dim_cell_nums[1])) {
     stop("One or more of reductions do not have them same number of cells. Ensure all reductions have same number of cells before converting.")

--- a/R/objects.R
+++ b/R/objects.R
@@ -1339,16 +1339,16 @@ as.SingleCellExperiment.Seurat <- function(x, assay = NULL, ...) {
   cell_nums <- sapply(X = assay, FUN = function(y) {
     length(x = Cells(x = x, assay = y))
   })
-  if (!all(cell_nums == cell_nums[1])) {
-    stop("One or more of assays do not have them same number of cells. Ensure all assays have same number of cells before converting.")
+  if (length(unique(cell_nums)) > 1) {
+    stop("Cannot convert assays with differing numbers of cells.\nEnsure all assays contain the same number of cells before converting.")
   }
 
   # Equal Number of Cells check reductions
   dim_cell_nums <- sapply(X = good_reducs, function(z) {
     length(x = Cells(x = x[[z]]))
   })
-  if (!all(dim_cell_nums == dim_cell_nums[1])) {
-    stop("One or more of reductions do not have them same number of cells. Ensure all reductions have same number of cells before converting.")
+  if (length(unique(dim_cell_nums)) > 1) {
+    stop("Cannot convert reductions with differing numbers of cells.\nEnsure all reductions contain the same number of cells before converting.")
   }
 
   # convert assay data


### PR DESCRIPTION
Hi Seurat Team,

As always thanks for everything that you do!  This is quick PR that adds two quick updates to `as.SingleCellExperiment` to simplify user experience.  Both fixes are related to issue #9266 which occurs when a sketch assay is present and therefore assays and reductions don't have the same cells.

1. First, is quick filtering step to only attempt to convert reductions associated with assays that are being converted.  This simplifies scenario where Seurat object contains sketch assay but user specifies only to convert "RNA "assay.  Normally user would get the cryptic error found in #9266 when the function got to converting the sketch reductions.  This fix stops that issue as those reductions are not associated with assay being converted.
```
  # filter dim reducs to keep only those in assays being converted
  all_reducs <- .FilterObjects(object = marsh_myeloid, classes.keep = "DimReduc")
  reduc_assays <- sapply(X = all_reducs, FUN = function(i) {
    DefaultAssay(object = marsh_myeloid[[i]])
  })
  names(x = reduc_assays) <- all_reducs
  good_reducs <- names(reduc_assays[reduc_assays %in% assay])
```
Also changes the for loop since names of reductions already checked
```
for (dr in good_reducs) {
```

1. Second, is the cryptic warning itself which is not an easily informative error message.  This PR adds two checks to `as.SingleCellExperiment`.  First, it checks that the number of cells in all of the assays is equivalent and then checks the number of cells in the `good_reducs` (see above) are equivalent.  If it detects number of cells that aren't equivalent it throws informative error message so user can adjust code or filter object.
```
  # Equal Number of Cells check assays
  cell_nums <- sapply(X = assay, FUN = function(y) {
    length(x = Cells(x = x, assay = y))
  })
  if (!all(cell_nums == cell_nums[1])) {
    stop("One or more of assays do not have them same number of cells. Ensure all assays have same number of cells before converting.")
  }

  # Equal Number of Cells check reductions
  dim_cell_nums <- sapply(X = good_reducs, function(z) {
    length(x = Cells(x = x[[z]]))
  })
  if (!all(dim_cell_nums == dim_cell_nums[1])) {
    stop("One or more of reductions do not have them same number of cells. Ensure all reductions have same number of cells before converting.")
  }
```

Below are 2 reprexes:
- Current Seurat version: Showing error that occurs due to reductions when only RNA assay selected or when trying to include all assays.
- PR version running same code.

If there are any edits or additional changes you would like to PR just let me know!
Thanks again!
Sam



## Release Seurat 5.5.1
``` r
library(tidyverse)
library(Seurat)
#> Warning: package 'Seurat' was built under R version 4.6.1
#> Loading required package: SeuratObject
#> Loading required package: sp
#> 
#> Attaching package: 'SeuratObject'
#> The following objects are masked from 'package:base':
#> 
#>     intersect, t

pbmc <- SeuratData::LoadData("pbmc3k")
#> Validating object structure
#> Updating object slots
#> Ensuring keys are in the proper structure
#> Warning: Assay RNA changing from Assay to Assay
#> Ensuring keys are in the proper structure
#> Ensuring feature names don't have underscores or pipes
#> Updating slots in RNA
#> Validating object structure for Assay 'RNA'
#> Object representation is consistent with the most current Seurat version
#> Warning: Assay RNA changing from Assay to Assay5

pbmc <- NormalizeData(object = pbmc, verbose = F) %>% 
  FindVariableFeatures(verbose = F) %>% 
  ScaleData(verbose = F) %>% 
  RunPCA(verbose = F) %>% 
  FindNeighbors(dims = 1:10, verbose = F) %>% 
  FindClusters(verbose = F) %>% 
  RunUMAP(dims = 1:10, verbose = F)
#> Warning: The default method for RunUMAP has changed from calling Python UMAP via reticulate to the R-native UWOT using the cosine metric
#> To use Python UMAP via reticulate, set umap.method to 'umap-learn' and metric to 'correlation'
#> This message will be shown once per session


pbmc <- SketchData(pbmc, ncells = 100)
#> Calcuating Leverage Score
#> Running LeverageScore for layer data
#> No variable features were found in data. Falling back to variable features from counts
#> Attempting to cast layer counts to dgCMatrix
#> Attempting to cast layer data to dgCMatrix

pbmc <- NormalizeData(object = pbmc, verbose = F) %>% 
  FindVariableFeatures(verbose = F) %>% 
  ScaleData(verbose = F) %>% 
  RunPCA(verbose = F) %>% 
  FindNeighbors(dims = 1:10, verbose = F) %>% 
  FindClusters(verbose = F) %>% 
  RunUMAP(dims = 1:10, verbose = F)
#> Warning in simpleLoess(y, x, w, span, degree = degree, parametric = parametric,
#> : pseudoinverse used at -2.0189
#> Warning in simpleLoess(y, x, w, span, degree = degree, parametric = parametric,
#> : neighborhood radius 0.31998
#> Warning in simpleLoess(y, x, w, span, degree = degree, parametric = parametric,
#> : reciprocal condition number 4.0517e-30
#> Warning in simpleLoess(y, x, w, span, degree = degree, parametric = parametric,
#> : There are other near singularities as well. 0.031008
#> Warning in svd.function(A = t(x = object), nv = npcs, ...): You're computing
#> too large a percentage of total singular values, use a standard svd instead.
#> Warning: Number of cells changing from 2700 to 100
#> Warning: Number of cells changing from 2700 to 100

# fails due to trying to convert all reductions instead of just reductions associated with RNA
marsh_sce <- as.SingleCellExperiment(pbmc, assay = "RNA")
#> Warning in .check_reddim_names(x, value, withDimnames): non-NULL 'rownames(value)' should be the same as 'colnames(x)' for
#> 'reducedDim<-'. This will be an error in the next release of
#> Bioconductor.
#> Error in `.set_internal_character()`:
#> ! invalid 'value' in 'reducedDim(<SingleCellExperiment>, type="character") <- value':
#>   'value' should have number of rows equal to 'ncol(x)'

# throws error because uneven cell numbers
marsh_sce <- as.SingleCellExperiment(pbmc)
#> Warning in .check_altexp_columns(x, value[[v]], withDimnames = withDimnames, : 'colnames(value[[2]])' are not the same as 'colnames(x)' for
#> 'altExps<-'. This will be an error in the next release of Bioconductor.
#> Error in `.set_internal_all()`:
#> ! invalid 'value' in 'altExps(<SingleCellExperiment>) <- value'
#> each element of 'value' should have number of columns equal to 'ncol(x)'
```

<sup>Created on 2026-06-29 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

<details style="margin-bottom:10px;">

<summary>

Session info
</summary>

``` r
sessioninfo::session_info()
#> ─ Session info ───────────────────────────────────────────────────────────────
#>  setting  value
#>  version  R version 4.6.0 (2026-04-24)
#>  os       macOS Sequoia 15.7.5
#>  system   aarch64, darwin23
#>  ui       X11
#>  language (EN)
#>  collate  en_US.UTF-8
#>  ctype    en_US.UTF-8
#>  tz       America/New_York
#>  date     2026-06-29
#>  pandoc   3.8.3 @ /Applications/RStudio.app/Contents/Resources/app/quarto/bin/tools/aarch64/ (via rmarkdown)
#>  quarto   1.9.37 @ /Applications/RStudio.app/Contents/Resources/app/quarto/bin/quarto
#> 
#> ─ Packages ───────────────────────────────────────────────────────────────────
#>  package                   * version    date (UTC) lib source
#>  abind                       1.4-8      2024-09-12 [1] CRAN (R 4.6.0)
#>  Biobase                     2.72.0     2026-04-28 [1] Bioconductor 3.23 (R 4.6.0)
#>  BiocGenerics                0.58.0     2026-04-28 [1] Bioconductor 3.23 (R 4.6.0)
#>  bmcite.SeuratData           0.3.0      2026-05-13 [1] local
#>  cli                         3.6.6      2026-04-09 [1] CRAN (R 4.6.0)
#>  cluster                     2.1.8.2    2026-02-05 [1] CRAN (R 4.6.0)
#>  codetools                   0.2-20     2024-03-31 [1] CRAN (R 4.6.0)
#>  cowplot                     1.2.0      2025-07-07 [1] CRAN (R 4.6.0)
#>  crayon                      1.5.3      2024-06-20 [1] CRAN (R 4.6.0)
#>  data.table                  1.18.4     2026-05-06 [1] CRAN (R 4.6.0)
#>  DelayedArray                0.38.1     2026-04-30 [1] Bioconductor 3.23 (R 4.6.0)
#>  deldir                      2.0-4      2024-02-28 [1] CRAN (R 4.6.0)
#>  dichromat                   2.0-0.1    2022-05-02 [1] CRAN (R 4.6.0)
#>  digest                      0.6.39     2025-11-19 [1] CRAN (R 4.6.0)
#>  dotCall64                   1.2        2024-10-04 [1] CRAN (R 4.6.0)
#>  dplyr                     * 1.2.1      2026-04-03 [1] CRAN (R 4.6.0)
#>  evaluate                    1.0.5      2025-08-27 [1] CRAN (R 4.6.0)
#>  farver                      2.1.2      2024-05-13 [1] CRAN (R 4.6.0)
#>  fastDummies                 1.7.6      2026-04-22 [1] CRAN (R 4.6.0)
#>  fastmap                     1.2.0      2024-05-15 [1] CRAN (R 4.6.0)
#>  fitdistrplus                1.2-6      2026-01-24 [1] CRAN (R 4.6.0)
#>  forcats                   * 1.0.1      2025-09-25 [1] CRAN (R 4.6.0)
#>  fs                          2.1.0      2026-04-18 [1] CRAN (R 4.6.0)
#>  future                    * 1.70.0     2026-03-14 [1] CRAN (R 4.6.0)
#>  future.apply                1.20.2     2026-02-20 [1] CRAN (R 4.6.0)
#>  generics                    0.1.4      2025-05-09 [1] CRAN (R 4.6.0)
#>  GenomicRanges               1.64.0     2026-04-28 [1] Bioconductor 3.23 (R 4.6.0)
#>  ggplot2                   * 4.0.3      2026-04-22 [1] CRAN (R 4.6.0)
#>  ggrepel                     0.9.8      2026-03-17 [1] CRAN (R 4.6.0)
#>  ggridges                    0.5.7      2025-08-27 [1] CRAN (R 4.6.0)
#>  globals                     0.19.1     2026-03-13 [1] CRAN (R 4.6.0)
#>  glue                        1.8.1      2026-04-17 [1] CRAN (R 4.6.0)
#>  goftest                     1.2-3      2021-10-07 [1] CRAN (R 4.6.0)
#>  gridExtra                   2.3        2017-09-09 [1] CRAN (R 4.6.0)
#>  gtable                      0.3.6      2024-10-25 [1] CRAN (R 4.6.0)
#>  hcabm40k.SeuratData         3.0.0      2026-05-13 [1] local
#>  hms                         1.1.4      2025-10-17 [1] CRAN (R 4.6.0)
#>  htmltools                   0.5.9      2025-12-04 [1] CRAN (R 4.6.0)
#>  htmlwidgets                 1.6.4      2023-12-06 [1] CRAN (R 4.6.0)
#>  httpuv                      1.6.17     2026-03-18 [1] CRAN (R 4.6.0)
#>  httr                        1.4.8      2026-02-13 [1] CRAN (R 4.6.0)
#>  ica                         1.0-3      2022-07-08 [1] CRAN (R 4.6.0)
#>  ifnb.SeuratData             3.1.0      2026-05-13 [1] local
#>  igraph                      2.3.1      2026-05-04 [1] CRAN (R 4.6.0)
#>  IRanges                     2.46.0     2026-04-28 [1] Bioconductor 3.23 (R 4.6.0)
#>  irlba                       2.3.7      2026-01-30 [1] CRAN (R 4.6.0)
#>  jsonlite                    2.0.0      2025-03-27 [1] CRAN (R 4.6.0)
#>  KernSmooth                  2.23-26    2025-01-01 [1] CRAN (R 4.6.0)
#>  knitr                       1.51       2025-12-20 [1] CRAN (R 4.6.0)
#>  later                       1.4.8      2026-03-05 [1] CRAN (R 4.6.0)
#>  lattice                     0.22-9     2026-02-09 [1] CRAN (R 4.6.0)
#>  lazyeval                    0.2.3      2026-04-04 [1] CRAN (R 4.6.0)
#>  lifecycle                   1.0.5      2026-01-08 [1] CRAN (R 4.6.0)
#>  listenv                     0.10.1     2026-03-10 [1] CRAN (R 4.6.0)
#>  lmtest                      0.9-40     2022-03-21 [1] CRAN (R 4.6.0)
#>  lubridate                 * 1.9.5      2026-02-04 [1] CRAN (R 4.6.0)
#>  magrittr                    2.0.5      2026-04-04 [1] CRAN (R 4.6.0)
#>  MASS                        7.3-65     2025-02-28 [1] CRAN (R 4.6.0)
#>  Matrix                      1.7-5      2026-03-21 [1] CRAN (R 4.6.0)
#>  MatrixGenerics              1.24.0     2026-04-28 [1] Bioconductor 3.23 (R 4.6.0)
#>  matrixStats                 1.5.0      2025-01-07 [1] CRAN (R 4.6.0)
#>  mime                        0.13       2025-03-17 [1] CRAN (R 4.6.0)
#>  miniUI                      0.1.2      2025-04-17 [1] CRAN (R 4.6.0)
#>  mousecortexref.SeuratData   1.0.0      2026-05-13 [1] local
#>  nlme                        3.1-169    2026-03-27 [1] CRAN (R 4.6.0)
#>  otel                        0.2.0      2025-08-29 [1] CRAN (R 4.6.0)
#>  parallelly                  1.47.0     2026-04-17 [1] CRAN (R 4.6.0)
#>  patchwork                   1.3.2      2025-08-25 [1] CRAN (R 4.6.0)
#>  pbapply                     1.7-4      2025-07-20 [1] CRAN (R 4.6.0)
#>  pbmc3k.SeuratData           3.1.4      2026-05-13 [1] local
#>  pbmcMultiome.SeuratData     0.1.4      2026-05-13 [1] local
#>  pbmcref.SeuratData          1.0.0      2026-05-13 [1] local
#>  pbmcsca.SeuratData          3.0.0      2026-05-13 [1] local
#>  pillar                      1.11.1     2025-09-17 [1] CRAN (R 4.6.0)
#>  pkgconfig                   2.0.3      2019-09-22 [1] CRAN (R 4.6.0)
#>  plotly                      4.12.0     2026-01-24 [1] CRAN (R 4.6.0)
#>  plyr                        1.8.9      2023-10-02 [1] CRAN (R 4.6.0)
#>  png                         0.1-9      2026-03-15 [1] CRAN (R 4.6.0)
#>  polyclip                    1.10-7     2024-07-23 [1] CRAN (R 4.6.0)
#>  progressr                   0.19.0     2026-03-31 [1] CRAN (R 4.6.0)
#>  promises                    1.5.0      2025-11-01 [1] CRAN (R 4.6.0)
#>  purrr                     * 1.2.2      2026-04-10 [1] CRAN (R 4.6.0)
#>  R6                          2.6.1      2025-02-15 [1] CRAN (R 4.6.0)
#>  RANN                        2.6.2      2024-08-25 [1] CRAN (R 4.6.0)
#>  rappdirs                    0.3.4      2026-01-17 [1] CRAN (R 4.6.0)
#>  RColorBrewer                1.1-3      2022-04-03 [1] CRAN (R 4.6.0)
#>  Rcpp                        1.1.1-1.1  2026-04-24 [1] CRAN (R 4.6.0)
#>  RcppAnnoy                   0.0.23     2026-01-12 [1] CRAN (R 4.6.0)
#>  RcppHNSW                    0.6.0      2024-02-04 [1] CRAN (R 4.6.0)
#>  readr                     * 2.2.0      2026-02-19 [1] CRAN (R 4.6.0)
#>  reprex                      2.1.1      2024-07-06 [1] CRAN (R 4.6.0)
#>  reshape2                    1.4.5      2025-11-12 [1] CRAN (R 4.6.0)
#>  reticulate                  1.46.0     2026-04-09 [1] CRAN (R 4.6.0)
#>  rlang                       1.2.0      2026-04-06 [1] CRAN (R 4.6.0)
#>  rmarkdown                   2.31       2026-03-26 [1] CRAN (R 4.6.0)
#>  ROCR                        1.0-12     2026-01-23 [1] CRAN (R 4.6.0)
#>  RSpectra                    0.16-2     2024-07-18 [1] CRAN (R 4.6.0)
#>  rstudioapi                  0.18.0     2026-01-16 [1] CRAN (R 4.6.0)
#>  Rtsne                       0.17       2023-12-07 [1] CRAN (R 4.6.0)
#>  S4Arrays                    1.12.0     2026-04-28 [1] Bioconductor 3.23 (R 4.6.0)
#>  S4Vectors                   0.50.0     2026-04-28 [1] Bioconductor 3.23 (R 4.6.0)
#>  S7                          0.2.2      2026-04-22 [1] CRAN (R 4.6.0)
#>  scales                      1.4.0      2025-04-24 [1] CRAN (R 4.6.0)
#>  scattermore                 1.2        2023-06-12 [1] CRAN (R 4.6.0)
#>  sctransform                 0.4.3      2026-01-10 [1] CRAN (R 4.6.0)
#>  Seqinfo                     1.2.0      2026-04-28 [1] Bioconductor 3.23 (R 4.6.0)
#>  sessioninfo                 1.2.3      2025-02-05 [1] CRAN (R 4.6.0)
#>  Seurat                    * 5.5.1      2026-06-26 [1] CRAN (R 4.6.1)
#>  SeuratData                  0.2.2.9002 2026-05-13 [1] Github (satijalab/seurat-data@3e51f44)
#>  SeuratObject              * 5.4.0      2026-04-11 [1] CRAN (R 4.6.0)
#>  shiny                       1.13.0     2026-02-20 [1] CRAN (R 4.6.0)
#>  SingleCellExperiment        1.34.0     2026-04-28 [1] Bioconductor 3.23 (R 4.6.0)
#>  sp                        * 2.2-1      2026-02-13 [1] CRAN (R 4.6.0)
#>  spam                        2.11-3     2026-01-08 [1] CRAN (R 4.6.0)
#>  SparseArray                 1.12.2     2026-05-01 [1] Bioconductor 3.23 (R 4.6.0)
#>  spatstat.data               3.1-9      2025-10-18 [1] CRAN (R 4.6.0)
#>  spatstat.explore            3.8-0      2026-03-22 [1] CRAN (R 4.6.0)
#>  spatstat.geom               3.7-3      2026-03-23 [1] CRAN (R 4.6.0)
#>  spatstat.random             3.4-5      2026-03-22 [1] CRAN (R 4.6.0)
#>  spatstat.sparse             3.1-0      2024-06-21 [1] CRAN (R 4.6.0)
#>  spatstat.univar             3.1-7      2026-03-18 [1] CRAN (R 4.6.0)
#>  spatstat.utils              3.2-3      2026-05-10 [1] CRAN (R 4.6.0)
#>  ssHippo.SeuratData          3.1.4      2026-05-13 [1] local
#>  stringi                     1.8.7      2025-03-27 [1] CRAN (R 4.6.0)
#>  stringr                   * 1.6.0      2025-11-04 [1] CRAN (R 4.6.0)
#>  stxBrain.SeuratData         0.1.2      2026-05-13 [1] local
#>  stxKidney.SeuratData        0.1.0      2026-05-13 [1] local
#>  SummarizedExperiment        1.42.0     2026-04-28 [1] Bioconductor 3.23 (R 4.6.0)
#>  survival                    3.8-6      2026-01-16 [1] CRAN (R 4.6.0)
#>  tensor                      1.5.1      2025-06-17 [1] CRAN (R 4.6.0)
#>  tibble                    * 3.3.1      2026-01-11 [1] CRAN (R 4.6.0)
#>  tidyr                     * 1.3.2      2025-12-19 [1] CRAN (R 4.6.0)
#>  tidyselect                  1.2.1      2024-03-11 [1] CRAN (R 4.6.0)
#>  tidyverse                 * 2.0.0      2023-02-22 [1] CRAN (R 4.6.0)
#>  timechange                  0.4.0      2026-01-29 [1] CRAN (R 4.6.0)
#>  tzdb                        0.5.0      2025-03-15 [1] CRAN (R 4.6.0)
#>  uwot                        0.2.4      2025-11-10 [1] CRAN (R 4.6.0)
#>  vctrs                       0.7.3      2026-04-11 [1] CRAN (R 4.6.0)
#>  viridisLite                 0.4.3      2026-02-04 [1] CRAN (R 4.6.0)
#>  withr                       3.0.2      2024-10-28 [1] CRAN (R 4.6.0)
#>  xfun                        0.57       2026-03-20 [1] CRAN (R 4.6.0)
#>  xtable                      1.8-8      2026-02-22 [1] CRAN (R 4.6.0)
#>  XVector                     0.52.0     2026-04-28 [1] Bioconductor 3.23 (R 4.6.0)
#>  yaml                        2.3.12     2025-12-10 [1] CRAN (R 4.6.0)
#>  zoo                         1.8-15     2025-12-15 [1] CRAN (R 4.6.0)
#> 
#>  [1] /Library/Frameworks/R.framework/Versions/4.6/Resources/library
#>  * ── Packages attached to the search path.
#> 
#> ──────────────────────────────────────────────────────────────────────────────
```

</details>


## PR Seurat Version  
``` r
library(tidyverse)
library(Seurat)
#> Loading required package: SeuratObject
#> Loading required package: sp
#> 
#> Attaching package: 'SeuratObject'
#> The following objects are masked from 'package:base':
#> 
#>     intersect, t

pbmc <- SeuratData::LoadData("pbmc3k")
#> Validating object structure
#> Updating object slots
#> Ensuring keys are in the proper structure
#> Warning: Assay RNA changing from Assay to Assay
#> Ensuring keys are in the proper structure
#> Ensuring feature names don't have underscores or pipes
#> Updating slots in RNA
#> Validating object structure for Assay 'RNA'
#> Object representation is consistent with the most current Seurat version
#> Warning: Assay RNA changing from Assay to Assay5

pbmc <- NormalizeData(object = pbmc, verbose = F) %>% 
  FindVariableFeatures(verbose = F) %>% 
  ScaleData(verbose = F) %>% 
  RunPCA(verbose = F) %>% 
  FindNeighbors(dims = 1:10, verbose = F) %>% 
  FindClusters(verbose = F) %>% 
  RunUMAP(dims = 1:10, verbose = F)
#> Warning: The default method for RunUMAP has changed from calling Python UMAP via reticulate to the R-native UWOT using the cosine metric
#> To use Python UMAP via reticulate, set umap.method to 'umap-learn' and metric to 'correlation'
#> This message will be shown once per session


pbmc <- SketchData(pbmc, ncells = 100)
#> Calcuating Leverage Score
#> Running LeverageScore for layer data
#> No variable features were found in data. Falling back to variable features from counts
#> Attempting to cast layer counts to dgCMatrix
#> Attempting to cast layer data to dgCMatrix

pbmc <- NormalizeData(object = pbmc, verbose = F) %>% 
  FindVariableFeatures(verbose = F) %>% 
  ScaleData(verbose = F) %>% 
  RunPCA(verbose = F) %>% 
  FindNeighbors(dims = 1:10, verbose = F) %>% 
  FindClusters(verbose = F) %>% 
  RunUMAP(dims = 1:10, verbose = F)
#> Warning in simpleLoess(y, x, w, span, degree = degree, parametric = parametric,
#> : pseudoinverse used at -2.0189
#> Warning in simpleLoess(y, x, w, span, degree = degree, parametric = parametric,
#> : neighborhood radius 0.31998
#> Warning in simpleLoess(y, x, w, span, degree = degree, parametric = parametric,
#> : reciprocal condition number 4.0517e-30
#> Warning in simpleLoess(y, x, w, span, degree = degree, parametric = parametric,
#> : There are other near singularities as well. 0.031008
#> Warning in svd.function(A = t(x = object), nv = npcs, ...): You're computing
#> too large a percentage of total singular values, use a standard svd instead.
#> Warning: Number of cells changing from 2700 to 100
#> Warning: Number of cells changing from 2700 to 100

# even though sketch present conversion works fine
marsh_sce <- as.SingleCellExperiment(pbmc, assay = "RNA")

# throws error because uneven cell numbers
marsh_sce <- as.SingleCellExperiment(pbmc)
#> Error in `as.SingleCellExperiment.Seurat()`:
#> ! One or more of assays do not have them same number of cells. Ensure all assays have same number of cells before converting.
```

<sup>Created on 2026-06-29 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

<details style="margin-bottom:10px;">

<summary>

Session info
</summary>

``` r
sessioninfo::session_info()
#> ─ Session info ───────────────────────────────────────────────────────────────
#>  setting  value
#>  version  R version 4.6.0 (2026-04-24)
#>  os       macOS Sequoia 15.7.5
#>  system   aarch64, darwin23
#>  ui       X11
#>  language (EN)
#>  collate  en_US.UTF-8
#>  ctype    en_US.UTF-8
#>  tz       America/New_York
#>  date     2026-06-29
#>  pandoc   3.8.3 @ /Applications/RStudio.app/Contents/Resources/app/quarto/bin/tools/aarch64/ (via rmarkdown)
#>  quarto   1.9.37 @ /Applications/RStudio.app/Contents/Resources/app/quarto/bin/quarto
#> 
#> ─ Packages ───────────────────────────────────────────────────────────────────
#>  package                   * version    date (UTC) lib source
#>  abind                       1.4-8      2024-09-12 [1] CRAN (R 4.6.0)
#>  Biobase                     2.72.0     2026-04-28 [1] Bioconductor 3.23 (R 4.6.0)
#>  BiocGenerics                0.58.0     2026-04-28 [1] Bioconductor 3.23 (R 4.6.0)
#>  bmcite.SeuratData           0.3.0      2026-05-13 [1] local
#>  cli                         3.6.6      2026-04-09 [1] CRAN (R 4.6.0)
#>  cluster                     2.1.8.2    2026-02-05 [1] CRAN (R 4.6.0)
#>  codetools                   0.2-20     2024-03-31 [1] CRAN (R 4.6.0)
#>  cowplot                     1.2.0      2025-07-07 [1] CRAN (R 4.6.0)
#>  crayon                      1.5.3      2024-06-20 [1] CRAN (R 4.6.0)
#>  data.table                  1.18.4     2026-05-06 [1] CRAN (R 4.6.0)
#>  DelayedArray                0.38.1     2026-04-30 [1] Bioconductor 3.23 (R 4.6.0)
#>  deldir                      2.0-4      2024-02-28 [1] CRAN (R 4.6.0)
#>  dichromat                   2.0-0.1    2022-05-02 [1] CRAN (R 4.6.0)
#>  digest                      0.6.39     2025-11-19 [1] CRAN (R 4.6.0)
#>  dotCall64                   1.2        2024-10-04 [1] CRAN (R 4.6.0)
#>  dplyr                     * 1.2.1      2026-04-03 [1] CRAN (R 4.6.0)
#>  evaluate                    1.0.5      2025-08-27 [1] CRAN (R 4.6.0)
#>  farver                      2.1.2      2024-05-13 [1] CRAN (R 4.6.0)
#>  fastDummies                 1.7.6      2026-04-22 [1] CRAN (R 4.6.0)
#>  fastmap                     1.2.0      2024-05-15 [1] CRAN (R 4.6.0)
#>  fitdistrplus                1.2-6      2026-01-24 [1] CRAN (R 4.6.0)
#>  forcats                   * 1.0.1      2025-09-25 [1] CRAN (R 4.6.0)
#>  fs                          2.1.0      2026-04-18 [1] CRAN (R 4.6.0)
#>  future                    * 1.70.0     2026-03-14 [1] CRAN (R 4.6.0)
#>  future.apply                1.20.2     2026-02-20 [1] CRAN (R 4.6.0)
#>  generics                    0.1.4      2025-05-09 [1] CRAN (R 4.6.0)
#>  GenomicRanges               1.64.0     2026-04-28 [1] Bioconductor 3.23 (R 4.6.0)
#>  ggplot2                   * 4.0.3      2026-04-22 [1] CRAN (R 4.6.0)
#>  ggrepel                     0.9.8      2026-03-17 [1] CRAN (R 4.6.0)
#>  ggridges                    0.5.7      2025-08-27 [1] CRAN (R 4.6.0)
#>  globals                     0.19.1     2026-03-13 [1] CRAN (R 4.6.0)
#>  glue                        1.8.1      2026-04-17 [1] CRAN (R 4.6.0)
#>  goftest                     1.2-3      2021-10-07 [1] CRAN (R 4.6.0)
#>  gridExtra                   2.3        2017-09-09 [1] CRAN (R 4.6.0)
#>  gtable                      0.3.6      2024-10-25 [1] CRAN (R 4.6.0)
#>  hcabm40k.SeuratData         3.0.0      2026-05-13 [1] local
#>  hms                         1.1.4      2025-10-17 [1] CRAN (R 4.6.0)
#>  htmltools                   0.5.9      2025-12-04 [1] CRAN (R 4.6.0)
#>  htmlwidgets                 1.6.4      2023-12-06 [1] CRAN (R 4.6.0)
#>  httpuv                      1.6.17     2026-03-18 [1] CRAN (R 4.6.0)
#>  httr                        1.4.8      2026-02-13 [1] CRAN (R 4.6.0)
#>  ica                         1.0-3      2022-07-08 [1] CRAN (R 4.6.0)
#>  ifnb.SeuratData             3.1.0      2026-05-13 [1] local
#>  igraph                      2.3.1      2026-05-04 [1] CRAN (R 4.6.0)
#>  IRanges                     2.46.0     2026-04-28 [1] Bioconductor 3.23 (R 4.6.0)
#>  irlba                       2.3.7      2026-01-30 [1] CRAN (R 4.6.0)
#>  jsonlite                    2.0.0      2025-03-27 [1] CRAN (R 4.6.0)
#>  KernSmooth                  2.23-26    2025-01-01 [1] CRAN (R 4.6.0)
#>  knitr                       1.51       2025-12-20 [1] CRAN (R 4.6.0)
#>  later                       1.4.8      2026-03-05 [1] CRAN (R 4.6.0)
#>  lattice                     0.22-9     2026-02-09 [1] CRAN (R 4.6.0)
#>  lazyeval                    0.2.3      2026-04-04 [1] CRAN (R 4.6.0)
#>  lifecycle                   1.0.5      2026-01-08 [1] CRAN (R 4.6.0)
#>  listenv                     0.10.1     2026-03-10 [1] CRAN (R 4.6.0)
#>  lmtest                      0.9-40     2022-03-21 [1] CRAN (R 4.6.0)
#>  lubridate                 * 1.9.5      2026-02-04 [1] CRAN (R 4.6.0)
#>  magrittr                    2.0.5      2026-04-04 [1] CRAN (R 4.6.0)
#>  MASS                        7.3-65     2025-02-28 [1] CRAN (R 4.6.0)
#>  Matrix                      1.7-5      2026-03-21 [1] CRAN (R 4.6.0)
#>  MatrixGenerics              1.24.0     2026-04-28 [1] Bioconductor 3.23 (R 4.6.0)
#>  matrixStats                 1.5.0      2025-01-07 [1] CRAN (R 4.6.0)
#>  mime                        0.13       2025-03-17 [1] CRAN (R 4.6.0)
#>  miniUI                      0.1.2      2025-04-17 [1] CRAN (R 4.6.0)
#>  mousecortexref.SeuratData   1.0.0      2026-05-13 [1] local
#>  nlme                        3.1-169    2026-03-27 [1] CRAN (R 4.6.0)
#>  otel                        0.2.0      2025-08-29 [1] CRAN (R 4.6.0)
#>  parallelly                  1.47.0     2026-04-17 [1] CRAN (R 4.6.0)
#>  patchwork                   1.3.2      2025-08-25 [1] CRAN (R 4.6.0)
#>  pbapply                     1.7-4      2025-07-20 [1] CRAN (R 4.6.0)
#>  pbmc3k.SeuratData           3.1.4      2026-05-13 [1] local
#>  pbmcMultiome.SeuratData     0.1.4      2026-05-13 [1] local
#>  pbmcref.SeuratData          1.0.0      2026-05-13 [1] local
#>  pbmcsca.SeuratData          3.0.0      2026-05-13 [1] local
#>  pillar                      1.11.1     2025-09-17 [1] CRAN (R 4.6.0)
#>  pkgconfig                   2.0.3      2019-09-22 [1] CRAN (R 4.6.0)
#>  plotly                      4.12.0     2026-01-24 [1] CRAN (R 4.6.0)
#>  plyr                        1.8.9      2023-10-02 [1] CRAN (R 4.6.0)
#>  png                         0.1-9      2026-03-15 [1] CRAN (R 4.6.0)
#>  polyclip                    1.10-7     2024-07-23 [1] CRAN (R 4.6.0)
#>  progressr                   0.19.0     2026-03-31 [1] CRAN (R 4.6.0)
#>  promises                    1.5.0      2025-11-01 [1] CRAN (R 4.6.0)
#>  purrr                     * 1.2.2      2026-04-10 [1] CRAN (R 4.6.0)
#>  R6                          2.6.1      2025-02-15 [1] CRAN (R 4.6.0)
#>  RANN                        2.6.2      2024-08-25 [1] CRAN (R 4.6.0)
#>  rappdirs                    0.3.4      2026-01-17 [1] CRAN (R 4.6.0)
#>  RColorBrewer                1.1-3      2022-04-03 [1] CRAN (R 4.6.0)
#>  Rcpp                        1.1.1-1.1  2026-04-24 [1] CRAN (R 4.6.0)
#>  RcppAnnoy                   0.0.23     2026-01-12 [1] CRAN (R 4.6.0)
#>  RcppHNSW                    0.6.0      2024-02-04 [1] CRAN (R 4.6.0)
#>  readr                     * 2.2.0      2026-02-19 [1] CRAN (R 4.6.0)
#>  reprex                      2.1.1      2024-07-06 [1] CRAN (R 4.6.0)
#>  reshape2                    1.4.5      2025-11-12 [1] CRAN (R 4.6.0)
#>  reticulate                  1.46.0     2026-04-09 [1] CRAN (R 4.6.0)
#>  rlang                       1.2.0      2026-04-06 [1] CRAN (R 4.6.0)
#>  rmarkdown                   2.31       2026-03-26 [1] CRAN (R 4.6.0)
#>  ROCR                        1.0-12     2026-01-23 [1] CRAN (R 4.6.0)
#>  RSpectra                    0.16-2     2024-07-18 [1] CRAN (R 4.6.0)
#>  rstudioapi                  0.18.0     2026-01-16 [1] CRAN (R 4.6.0)
#>  Rtsne                       0.17       2023-12-07 [1] CRAN (R 4.6.0)
#>  S4Arrays                    1.12.0     2026-04-28 [1] Bioconductor 3.23 (R 4.6.0)
#>  S4Vectors                   0.50.0     2026-04-28 [1] Bioconductor 3.23 (R 4.6.0)
#>  S7                          0.2.2      2026-04-22 [1] CRAN (R 4.6.0)
#>  scales                      1.4.0      2025-04-24 [1] CRAN (R 4.6.0)
#>  scattermore                 1.2        2023-06-12 [1] CRAN (R 4.6.0)
#>  sctransform                 0.4.3      2026-01-10 [1] CRAN (R 4.6.0)
#>  Seqinfo                     1.2.0      2026-04-28 [1] Bioconductor 3.23 (R 4.6.0)
#>  sessioninfo                 1.2.3      2025-02-05 [1] CRAN (R 4.6.0)
#>  Seurat                    * 5.5.1.9000 2026-06-29 [1] Github (samuel-marsh/seurat@0652cda)
#>  SeuratData                  0.2.2.9002 2026-05-13 [1] Github (satijalab/seurat-data@3e51f44)
#>  SeuratObject              * 5.4.0      2026-04-11 [1] CRAN (R 4.6.0)
#>  shiny                       1.13.0     2026-02-20 [1] CRAN (R 4.6.0)
#>  SingleCellExperiment        1.34.0     2026-04-28 [1] Bioconductor 3.23 (R 4.6.0)
#>  sp                        * 2.2-1      2026-02-13 [1] CRAN (R 4.6.0)
#>  spam                        2.11-3     2026-01-08 [1] CRAN (R 4.6.0)
#>  SparseArray                 1.12.2     2026-05-01 [1] Bioconductor 3.23 (R 4.6.0)
#>  spatstat.data               3.1-9      2025-10-18 [1] CRAN (R 4.6.0)
#>  spatstat.explore            3.8-0      2026-03-22 [1] CRAN (R 4.6.0)
#>  spatstat.geom               3.7-3      2026-03-23 [1] CRAN (R 4.6.0)
#>  spatstat.random             3.4-5      2026-03-22 [1] CRAN (R 4.6.0)
#>  spatstat.sparse             3.1-0      2024-06-21 [1] CRAN (R 4.6.0)
#>  spatstat.univar             3.1-7      2026-03-18 [1] CRAN (R 4.6.0)
#>  spatstat.utils              3.2-3      2026-05-10 [1] CRAN (R 4.6.0)
#>  ssHippo.SeuratData          3.1.4      2026-05-13 [1] local
#>  stringi                     1.8.7      2025-03-27 [1] CRAN (R 4.6.0)
#>  stringr                   * 1.6.0      2025-11-04 [1] CRAN (R 4.6.0)
#>  stxBrain.SeuratData         0.1.2      2026-05-13 [1] local
#>  stxKidney.SeuratData        0.1.0      2026-05-13 [1] local
#>  SummarizedExperiment        1.42.0     2026-04-28 [1] Bioconductor 3.23 (R 4.6.0)
#>  survival                    3.8-6      2026-01-16 [1] CRAN (R 4.6.0)
#>  tensor                      1.5.1      2025-06-17 [1] CRAN (R 4.6.0)
#>  tibble                    * 3.3.1      2026-01-11 [1] CRAN (R 4.6.0)
#>  tidyr                     * 1.3.2      2025-12-19 [1] CRAN (R 4.6.0)
#>  tidyselect                  1.2.1      2024-03-11 [1] CRAN (R 4.6.0)
#>  tidyverse                 * 2.0.0      2023-02-22 [1] CRAN (R 4.6.0)
#>  timechange                  0.4.0      2026-01-29 [1] CRAN (R 4.6.0)
#>  tzdb                        0.5.0      2025-03-15 [1] CRAN (R 4.6.0)
#>  uwot                        0.2.4      2025-11-10 [1] CRAN (R 4.6.0)
#>  vctrs                       0.7.3      2026-04-11 [1] CRAN (R 4.6.0)
#>  viridisLite                 0.4.3      2026-02-04 [1] CRAN (R 4.6.0)
#>  withr                       3.0.2      2024-10-28 [1] CRAN (R 4.6.0)
#>  xfun                        0.57       2026-03-20 [1] CRAN (R 4.6.0)
#>  xtable                      1.8-8      2026-02-22 [1] CRAN (R 4.6.0)
#>  XVector                     0.52.0     2026-04-28 [1] Bioconductor 3.23 (R 4.6.0)
#>  yaml                        2.3.12     2025-12-10 [1] CRAN (R 4.6.0)
#>  zoo                         1.8-15     2025-12-15 [1] CRAN (R 4.6.0)
#> 
#>  [1] /Library/Frameworks/R.framework/Versions/4.6/Resources/library
#>  * ── Packages attached to the search path.
#> 
#> ──────────────────────────────────────────────────────────────────────────────
```

</details>
