### PR TITLE
Fix behavior of `fill.by` / `y.max` / `same.y.lims` parameters in `RidgePlot`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: Seurat
-Version: 5.5.1.9002
+Version: 5.5.1.9003
 Title: Tools for Single Cell Genomics
 Description: A toolkit for quality control, analysis, and exploration of single cell RNA sequencing data. 'Seurat' aims to enable users to identify and interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse types of single cell data. See Satija R, Farrell J, Gennert D, et al (2015) <doi:10.1038/nbt.3192>, Macosko E, Basu A, Satija R, et al (2015) <doi:10.1016/j.cell.2015.05.002>, Stuart T, Butler A, et al (2019) <doi:10.1016/j.cell.2019.05.031>, and Hao, Hao, et al (2020) <doi:10.1101/2020.10.12.335331> for more details.
 Authors@R: c(

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,8 +4,9 @@
 
 ### Fixes
 
-- Fixed bug in `PercentageFeatureSet` where layer data was incorrectly retrieved prior to finding features with requested pattern
-- Updated `as.SingleCellExperiment` to address conversion case where an object has both original and sketched assay / reductions (differing numbers of cells)
+- Fixed bug in `PercentageFeatureSet` where layer data was incorrectly retrieved prior to finding features with requested pattern ([#10438](https://github.com/satijalab/seurat/pull/10438))
+- Updated `as.SingleCellExperiment` to address conversion case where an object has both original and sketched assay / reductions (differing numbers of cells) ([#10419](https://github.com/satijalab/seurat/pull/10419))
+- Fixed bugs in behavior of `RidgePlot` parameters `fill.by`, `y.max`, and `same.y.lims` ([#10424](https://github.com/satijalab/seurat/pull/10424))
 
 # Seurat 5.5.1
 

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -9074,7 +9074,7 @@ SingleExIPlot <- function(
     type <- 'violin'
   } else {
     vln.geom <- geom_violin
-    fill <- 'ident'
+    fill <- fill.by
   }
   switch(
     EXPR = type,

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -551,7 +551,7 @@ RidgePlot <- function(
   layer = 'data',
   stack = FALSE,
   combine = TRUE,
-  fill.by = 'feature'
+  fill.by = NULL
 ) {
   if (is_present(arg = slot)) {
     deprecate_soft(
@@ -561,6 +561,7 @@ RidgePlot <- function(
     )
     layer <- slot %||% layer
   }
+  fill.by <- fill.by %||% if (stack) 'feature' else 'ident'
   return(ExIPlot(
     object = object,
     type = 'ridge',

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -7296,7 +7296,30 @@ ExIPlot <- function(
   if (!(fill.by %in% c("feature", "ident"))) {
     stop("`fill.by` must be either `feature` or `ident`")
   }
-  if (same.y.lims && is.null(x = y.max)) {
+  # for ridge plots, figure out the y-axis limits for all features if requested
+  ridge.axis.lims <- NULL
+  if (same.y.lims && type == 'ridge') {
+    data.lims <- vapply(
+      X = features,
+      FUN = function(feature) {
+        values <- data[[feature]]
+        # add noise following logic in MultiExIPlot
+        if (log) {
+          noise <- rnorm(n = nrow(x = data)) / 200
+          values <- values + 1
+        } else {
+          noise <- rnorm(n = nrow(x = data)) / 100000
+        }
+        values <- if (add.noise) values + noise else values
+        range(values, finite = TRUE)
+      },
+      FUN.VALUE = numeric(length = 2L)
+    )
+    ridge.axis.lims <- c(min(data.lims[1, ]), max(data.lims[2, ]))
+    if (!is.null(x = y.max)) {
+      ridge.axis.lims[[2]] <- y.max
+    }
+  } else if (same.y.lims && is.null(x = y.max)) {
     y.max <- max(data)
   }
   if (isTRUE(x = stack)) {
@@ -7338,6 +7361,15 @@ ExIPlot <- function(
       ))
     }
   )
+  # apply the same y-axis limits to all ridge plots if requested
+  if (type == 'ridge' && !is.null(x = ridge.axis.lims)) {
+    plots <- lapply(
+      X = plots,
+      FUN = function(plot) {
+        plot + (if (log) scale_x_log10(expand = c(0, 0), limits = ridge.axis.lims) else scale_x_continuous(expand = c(0, 0), limits = ridge.axis.lims))
+      }
+    )
+  }
   label.fxn <- switch(
     EXPR = type,
     'violin' = if (stack) {

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -9157,7 +9157,9 @@ SingleExIPlot <- function(
         scale_y_discrete(expand = c(0.01, 0))
       )
       jitter <- geom_jitter(width = 0, size = pt.size, alpha = alpha, show.legend = FALSE)
-      log.scale <- scale_x_log10(expand = c(0, 0))
+      log.scale <- function(x.min, x.max) {
+        scale_x_log10(expand = c(0, 0), limits = c(x.min, x.max))
+      }
       axis.scale <- function(x.min, x.max) {
         scale_x_continuous(expand = c(0, 0), limits = c(x.min, x.max))
       }
@@ -9175,7 +9177,7 @@ SingleExIPlot <- function(
     plot <- plot + layer
   }
   plot <- plot + if (log) {
-    log.scale
+    log.scale(min(data[, feature]), y.max)
   } else {
     axis.scale(min(data[, feature]), y.max)
   }

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -7292,6 +7292,9 @@ ExIPlot <- function(
       type <- "violin"
     }
   }
+  if (!(fill.by %in% c("feature", "ident"))) {
+    stop("`fill.by` must be either `feature` or `ident`")
+  }
   if (same.y.lims && is.null(x = y.max)) {
     y.max <- max(data)
   }
@@ -7327,6 +7330,7 @@ ExIPlot <- function(
         pt.size = pt.size,
         alpha = alpha,
         log = log,
+        fill.by = fill.by,
         add.noise = add.noise,
         raster = raster,
         raster.dpi = raster.dpi

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -9033,6 +9033,7 @@ SingleExIPlot <- function(
   }
   feature <- colnames(x = data)
   data$ident <- idents
+  data$feature <- factor(x = feature, levels = feature)
   if ((is.character(x = sort) && nchar(x = sort) > 0) || sort) {
     data$ident <- factor(
       x = data$ident,

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -8967,6 +8967,7 @@ SingleDimPlot <- function(
 #' @param cols Colors to use for plotting
 #' @param seed.use Random seed to use. If NULL, don't set a seed
 #' @param log plot Y axis on log10 scale
+#' @param fill.by Color violins/ridges based on either 'feature' or 'ident'
 #' @param add.noise determine if adding small noise for plotting
 #' @param raster Convert points to raster format. Requires 'ggrastr' to be installed.
 #' default is \code{NULL} which automatically rasterizes if ggrastr is installed and
@@ -9000,6 +9001,7 @@ SingleExIPlot <- function(
   cols = NULL,
   seed.use = 42,
   log = FALSE,
+  fill.by = 'ident',
   add.noise = TRUE,
   raster = NULL,
   raster.dpi = NULL

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -9121,13 +9121,12 @@ SingleExIPlot <- function(
       geom <- list(
         geom_density_ridges(scale = 4),
         theme_ridges(),
-        scale_y_discrete(expand = c(0.01, 0)),
-        scale_x_continuous(expand = c(0, 0))
+        scale_y_discrete(expand = c(0.01, 0))
       )
       jitter <- geom_jitter(width = 0, size = pt.size, alpha = alpha, show.legend = FALSE)
-      log.scale <- scale_x_log10()
-      axis.scale <- function(...) {
-        invisible(x = NULL)
+      log.scale <- scale_x_log10(expand = c(0, 0))
+      axis.scale <- function(x.min, x.max) {
+        scale_x_continuous(expand = c(0, 0), limits = c(x.min, x.max))
       }
     },
     stop("Unknown plot type: ", type)

--- a/man/RidgePlot.Rd
+++ b/man/RidgePlot.Rd
@@ -20,7 +20,7 @@ RidgePlot(
   layer = "data",
   stack = FALSE,
   combine = TRUE,
-  fill.by = "feature"
+  fill.by = NULL
 )
 }
 \arguments{

--- a/man/SingleExIPlot.Rd
+++ b/man/SingleExIPlot.Rd
@@ -17,6 +17,7 @@ SingleExIPlot(
   cols = NULL,
   seed.use = 42,
   log = FALSE,
+  fill.by = "ident",
   add.noise = TRUE,
   raster = NULL,
   raster.dpi = NULL
@@ -47,6 +48,8 @@ expression of the attribute being potted}
 \item{seed.use}{Random seed to use. If NULL, don't set a seed}
 
 \item{log}{plot Y axis on log10 scale}
+
+\item{fill.by}{Color violins/ridges based on either 'feature' or 'ident'}
 
 \item{add.noise}{determine if adding small noise for plotting}
 


### PR DESCRIPTION
## Summary

Closes #10421 by @samuel-marsh.

This PR proposes the following:

- Change the default value of the `fill.by` parameter.
  - The default value in the documentation was "feature", but due to overrides by `ExIPlot`, the default was actually "ident". Changing this to NULL, and picking a different default inside the function (ident if stack if FALSE, feature otherwise) helps to clarify this behavior.
- Compute y axis limits properly if `same.y.lims = TRUE`. Add noise as necessary, following logic in `MultiExIPlot`, then apply this to all plots.
- Add parameter `fill.by` to `SingleExIPlot`. The default is "ident" so complete backwards compatibility is maintained (across calls to this function, for example in other visualization functions).
- Apply the proper limits to the axis as requested.

## Reprex

``` r
suppressPackageStartupMessages({
  library(SeuratData)
  library(dplyr)
  library(patchwork)
})
#> Warning: package 'dplyr' was built under R version 4.5.2

# must be on this branch
devtools::load_all("~/seurat", quiet = TRUE)
#> Warning: package 'sp' was built under R version 4.5.2

pbmc <- suppressWarnings(suppressMessages(UpdateSeuratObject(pbmc3k.final))) %>% subset(seurat_annotations %in% c("Platelet", "DC", "CD8 T", "CD14+ Mono"))

# fill.by
# note that fill.by = "feature" is not informative unless stack = TRUE
RidgePlot(pbmc, features = "CD3E", fill.by = "ident") /
  RidgePlot(pbmc, features = "CD3E", fill.by = "feature")
#> Picking joint bandwidth of 0.0808
#> Picking joint bandwidth of 0.0808
```

![](https://i.imgur.com/mroG4HM.png)<!-- -->

``` r

# same.y.lims
RidgePlot(pbmc, features = c("CD3E", "LYZ"), same.y.lims = FALSE) /
  RidgePlot(pbmc, features = c("CD3E", "LYZ"), same.y.lims = TRUE)
#> Scale for x is already present.
#> Adding another scale for x, which will replace the existing scale.
#> Scale for x is already present.
#> Adding another scale for x, which will replace the existing scale.
#> Picking joint bandwidth of 0.0808
#> 
#> Picking joint bandwidth of 0.376
#> 
#> Picking joint bandwidth of 0.0808
#> 
#> Picking joint bandwidth of 0.376
#> Warning: Removed 1 row containing non-finite outside the scale range
#> (`stat_density_ridges()`).
```

![](https://i.imgur.com/UaP57Dx.png)<!-- -->

``` r

# y.max
RidgePlot(pbmc, features = "CCL5") /
  RidgePlot(pbmc, features = "CCL5", y.max = 3)
#> Picking joint bandwidth of 0.176
#> Picking joint bandwidth of 0.201
#> Warning: Removed 250 rows containing non-finite outside the scale range
#> (`stat_density_ridges()`).
```

![](https://i.imgur.com/Q8pb1cK.png)<!-- -->

``` r

# stacked fill.by
RidgePlot(pbmc, features = c("CCL5", "LYZ", "CD3E"), stack = TRUE, fill.by = "ident") /
  RidgePlot(pbmc, features = c("CCL5", "LYZ", "CD3E"), stack = TRUE, fill.by = "feature")
#> Picking joint bandwidth of 0.176
#> Picking joint bandwidth of 0.376
#> Picking joint bandwidth of 0.0808
#> Picking joint bandwidth of 0.176
#> Picking joint bandwidth of 0.376
#> Picking joint bandwidth of 0.0808
```

![](https://i.imgur.com/0MW8BVR.png)<!-- -->

``` r

# stacked same.y.lims
RidgePlot(pbmc, features = c("CCL5", "LYZ", "CD3E"), stack = TRUE, same.y.lims = TRUE)
#> Picking joint bandwidth of 0.176
#> Picking joint bandwidth of 0.376
#> Picking joint bandwidth of 0.0808
```

![](https://i.imgur.com/1Vii58H.png)<!-- -->

<sup>Created on 2026-07-13 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>