### PR TITLE
Remove `future_lapply` from `AnnoySearch`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: Seurat
-Version: 5.5.1.9000
+Version: 5.5.1.9001
 Title: Tools for Single Cell Genomics
 Description: A toolkit for quality control, analysis, and exploration of single cell RNA sequencing data. 'Seurat' aims to enable users to identify and interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse types of single cell data. See Satija R, Farrell J, Gennert D, et al (2015) <doi:10.1038/nbt.3192>, Macosko E, Basu A, Satija R, et al (2015) <doi:10.1016/j.cell.2015.05.002>, Stuart T, Butler A, et al (2019) <doi:10.1016/j.cell.2019.05.031>, and Hao, Hao, et al (2020) <doi:10.1101/2020.10.12.335331> for more details.
 Authors@R: c(

--- a/R/clustering.R
+++ b/R/clustering.R
@@ -977,19 +977,12 @@ AnnoyBuildIndex <- function(data, metric = "euclidean", n.trees = 50) {
 # nearest k elements in the index) and 'nn.dists' (the distances of the nearest
 # k elements)
 #
-#' @importFrom future plan
-#' @importFrom future.apply future_lapply
-#
 AnnoySearch <- function(index, query, k, search.k = -1, include.distance = TRUE) {
   n <- nrow(x = query)
   idx <- matrix(nrow = n,  ncol = k)
   dist <- matrix(nrow = n, ncol = k)
   convert <- methods::is(index, "Rcpp_AnnoyAngular")
-  if (!inherits(x = plan(), what = "multicore")) {
-    oplan <- plan(strategy = "sequential")
-    on.exit(plan(oplan), add = TRUE)
-  }
-  res <- future_lapply(X = 1:n, FUN = function(x) {
+  res <- lapply(X = 1:n, FUN = function(x) {
     res <- index$getNNsByVectorList(query[x, ], k, search.k, include.distance)
     # Convert from Angular to Cosine distance
     if (convert) {

--- a/tests/testthat/test_integration5.R
+++ b/tests/testthat/test_integration5.R
@@ -226,6 +226,28 @@ test_that("IntegrateLayers works with RPCAIntegration", {
   expect_equal(Embeddings(integrated_overflow), Embeddings(integrated))
 })
 
+if (is_not_cran_submission) {
+  test_that("IntegrateLayers with RPCAIntegration completes under multicore futures", {
+    skip_if_not(future::supportsMulticore())
+    oplan <- future::plan()
+    on.exit(future::plan(oplan), add = TRUE)
+    future::plan(strategy = "multicore", workers = 2)
+
+    integrated <- suppressWarnings(
+      IntegrateLayers(
+        test.data.std,
+        method = RPCAIntegration,
+        orig.reduction = "pca",
+        new.reduction = "integrated",
+        verbose = FALSE,
+        k.weight = 10
+      )
+    )
+
+    expect_equal(dim(integrated[["integrated"]]), dim(integrated[["pca"]]))
+  })
+}
+
 test_that("IntegrateLayers works with JointPCAIntegration", {
   integrated <- suppressWarnings(
     IntegrateLayers(


### PR DESCRIPTION
`IntegrateLayers` hangs on multicore plans (reported at #10420) - seems to no longer reproduce, needs more investigation.