### PR TITLE
Fix FindConservedMarkers meta method labels

### DIFF
--- a/R/differential_expression.R
+++ b/R/differential_expression.R
@@ -420,9 +420,24 @@ FindConservedMarkers <- function(
         return(meta.method(clean_x)$p)
       }
     ))
-    meta.method.name <- as.character(x = formals()$meta.method)
-    if (length(x = meta.method.name) == 3) {
-      meta.method.name <- meta.method.name[3]
+    meta.method.name <- getNamespaceExports(ns = "metap")
+    meta.method.name <- meta.method.name[vapply(
+      X = meta.method.name,
+      FUN = function(method) {
+        identical(
+          x = meta.method,
+          y = getExportedValue(ns = "metap", name = method)
+        )
+      },
+      FUN.VALUE = logical(1)
+    )]
+    if (length(x = meta.method.name) != 1) {
+      meta.method.expression <- substitute(expr = meta.method)
+      meta.method.name <- if (is.symbol(x = meta.method.expression)) {
+        as.character(x = meta.method.expression)
+      } else {
+        "custom"
+      }
     }
     colnames(x = combined.pval) <- paste0(meta.method.name, "_p_val")
     markers.combined <- cbind(markers.combined, combined.pval)

--- a/tests/testthat/test_differential_expression.R
+++ b/tests/testthat/test_differential_expression.R
@@ -652,6 +652,32 @@ if (requireNamespace('metap', quietly = TRUE)) {
     expect_equal(markers[, "max_pval"], unname(obj = apply(X = markers, MARGIN = 1, FUN = function(x) max(x[c("g1_p_val", "g2_p_val")]))))
   })
 
+  test_that("FindConservedMarkers names the supplied meta method", {
+    markers.sumlog <- suppressWarnings(FindConservedMarkers(
+      object = pbmc_small,
+      ident.1 = 0,
+      grouping.var = "groups",
+      meta.method = metap::sumlog,
+      verbose = FALSE,
+      base = exp(1),
+      pseudocount.use = 1
+    ))
+    stored.method <- metap::sumlog
+    markers.stored <- suppressWarnings(FindConservedMarkers(
+      object = pbmc_small,
+      ident.1 = 0,
+      grouping.var = "groups",
+      meta.method = stored.method,
+      verbose = FALSE,
+      base = exp(1),
+      pseudocount.use = 1
+    ))
+
+    expect_true("sumlog_p_val" %in% colnames(x = markers.sumlog))
+    expect_false("minimump_p_val" %in% colnames(x = markers.sumlog))
+    expect_equal(markers.sumlog, markers.stored)
+  })
+
   test_that("FindConservedMarkers errors when expected", {
     expect_error(FindConservedMarkers(pbmc_small))
     expect_error(FindConservedMarkers(pbmc_small, ident.1 = 0))


### PR DESCRIPTION
## Summary

- name the combined p-value column after the supplied `metap` method instead of the default formal argument
- resolve exported `metap` functions by identity so stored function references receive the correct label
- add regression coverage for direct and stored non-default methods while preserving the default label

## Tests

- focused `FindConservedMarkers` regression test with `pbmc_small`
- parsed the modified source and test files successfully

Closes #9100