### PR TITLE
Fixing #10354 with informative error

### DIFF
--- a/R/visualization.R
+++ b/R/visualization.R
@@ -2189,10 +2189,15 @@ VariableFeaturePlot <- function(
     method = selection.method,
     status = TRUE
   )
-  if (is.null(hvf.info)){
-    stop("HVFinfo() failed to retrieve variable feature information.
-          Perhaps, these are not available because FindVariableFeatures() is run on split layers and the layers are subsequently joined.
-          It is not recommended to run split layers when a global feature variance is requested.")  
+  if (is.null(hvf.info)) {
+    stop(
+      paste0(
+        "VariableFeaturePlot() cannot be generated because no variable feature information is available (HVFInfo() returned NULL).\n",
+        "This can occur when FindVariableFeatures() is run on split layers and the layers are subsequently joined.\n",
+        "Re-run FindVariableFeatures() after JoinLayers(), or avoid joining layers before plotting."
+      ),
+      call. = FALSE
+    )
   }
   status.col <- colnames(hvf.info)[grepl("variable", colnames(hvf.info))][[1]]
   var.status <- c('no', 'yes')[unlist(hvf.info[[status.col]]) + 1]

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -2189,6 +2189,11 @@ VariableFeaturePlot <- function(
     method = selection.method,
     status = TRUE
   )
+  if (is.null(hvf.info)){
+    stop("HVFinfo() failed to retrieve variable feature information.
+          Perhaps, these are not available because FindVariableFeatures() is run on split layers and the layers are subsequently joined.
+          It is not recommended to run split layers when a global feature variance is requested.")  
+  }
   status.col <- colnames(hvf.info)[grepl("variable", colnames(hvf.info))][[1]]
   var.status <- c('no', 'yes')[unlist(hvf.info[[status.col]]) + 1]
   if (colnames(x = hvf.info)[3] == 'dispersion.scaled') {


### PR DESCRIPTION
# Summary
This PR adds an explicit check for missing HVF information and stops with a more informative error message explaining that `VariableFeaturePlot()` cannot be generated in this situation.

## Type of change
<!-- Check the relevant option -->
- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (existing functionality changed or removed)
- [ ] Documentation update
- [ ] Other (please explain below)

## Motivation
As described by Elaude in #10354, `HVFInfo()` returns `NULL` when global HVF information is requested after splitting layers, running `FindVariableFeatures()`, and subsequently joining layers. This currently results in an uninformative error in `VariableFeaturePlot()`.

## Tests & examples
<!-- Provide reproducible examples demonstrating the functionality -->
<!-- Include example code using built-in (pbmc_small) or readily available (SeuratData, etc.) datasets -->

```r
# Code from the seurat integration vignette:
obj <- LoadData("pbmcsca")
obj <- subset(obj, nFeature_RNA > 1000)
obj[["RNA"]] <- split(obj[["RNA"]], f = obj$Method)

obj <- NormalizeData(obj)
obj <- FindVariableFeatures(obj)
obj <- ScaleData(obj)
obj <- RunPCA(obj)
obj <- JoinLayers(obj) # Works without split, but not after
plot1 <- Seurat::VariableFeaturePlot(obj, assay = "RNA") # Doesn't work
```

## Related issues
Closes #10354

## Checklist

- [x] Branch is named appropriately (`feat/*`, `fix/*`, `docs/*`)
- [x] Code follows Seurat [style guidelines](https://github.com/satijalab/seurat/wiki/Contributor%27s-Guide)
- [x] Documentation and comments have been updated
- [ ] `devtools::document()` has been run
- [ ] `devtools::check()` passes with no errors or warnings
- [ ] Test case demonstrating new functionality is included
- [x] Maintainers are allowed to edit this PR
