### PR TITLE
Fix handling of v5 objects inside `PercentageFeatureSet`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: Seurat
-Version: 5.5.1.9000
+Version: 5.5.1.9001
 Title: Tools for Single Cell Genomics
 Description: A toolkit for quality control, analysis, and exploration of single cell RNA sequencing data. 'Seurat' aims to enable users to identify and interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse types of single cell data. See Satija R, Farrell J, Gennert D, et al (2015) <doi:10.1038/nbt.3192>, Macosko E, Basu A, Satija R, et al (2015) <doi:10.1016/j.cell.2015.05.002>, Stuart T, Butler A, et al (2019) <doi:10.1016/j.cell.2019.05.031>, and Hao, Hao, et al (2020) <doi:10.1101/2020.10.12.335331> for more details.
 Authors@R: c(

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- Fixed bug in `PercentageFeatureSet` where layer data was incorrectly retrieved prior to finding features with requested pattern
+
 # Seurat 5.5.1
 
 ### Additions

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -1286,13 +1286,13 @@ PercentageFeatureSet <- function(
   layers <- Layers(object = object, assay = assay, search = "counts")
   for (i in seq_along(along.with = layers)) {
     layer <- layers[i]
-    features.layer <- features %||% grep(
-      pattern = pattern,
-      x = rownames(x = object[[assay]][layer]),
-      value = TRUE)
     layer.data <- LayerData(object = object,
                             assay = assay,
                             layer = layer)
+    features.layer <- features %||% grep(
+      pattern = pattern,
+      x = rownames(x = layer.data),
+      value = TRUE)
     features.layer <- intersect(features.layer, rownames(layer.data))
     layer.sums <- colSums(x = layer.data[features.layer, , drop = FALSE])
     layer.perc <- layer.sums / object[[]][colnames(layer.data), paste0("nCount_", assay)] * 100

--- a/tests/testthat/test_utilities.R
+++ b/tests/testthat/test_utilities.R
@@ -442,3 +442,21 @@ test_that("AddModuleScore works in the multi-layer case", {
     all(object1$CD_Features1 == object2$CD_Features1)
   )
 })
+
+test_that("PercentageFeatureSet works with v5 layers", {
+  counts <- LayerData(object, assay = "RNA", layer = "counts")
+  counts <- rbind(counts, rep(5, ncol(counts)))
+
+  # Test with pattern matching on counts layer
+  result <- PercentageFeatureSet(object = object, pattern = "^HLA-", assay = "RNA")
+  
+  # Should return a numeric vector with one value per cell
+  expect_is(result, "numeric")
+  expect_equal(length(result), ncol(object))
+  
+  # Test with explicit features parameter
+  result_features <- PercentageFeatureSet(object = object, features = "HLA-DRB1", assay = "RNA")
+  
+  expect_is(result_features, "numeric")
+  expect_equal(length(result_features), ncol(object))
+})


### PR DESCRIPTION
### Update `PercentageFeatureSet()` to properly access Seurat v5 layers

This had been reported on an old issue thread at https://github.com/satijalab/seurat/issues/8082#issuecomment-3199128810, and resurfaced as an issue when running Azimuth 0.5.1 https://github.com/satijalab/azimuth/issues/299.

The error at https://github.com/satijalab/azimuth/issues/299 occurs because the bracket subsetting `object[[assay]][layer]` misinterprets the layer name "counts" as a feature selector rather than a layer identifier.

We were already calling `LayerData`; this PR just moves that line up to before feature retrieval.