### PR TITLE
Require uwot >= 0.2.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -89,7 +89,7 @@ Imports:
     tibble,
     tools,
     utils,
-    uwot (>= 0.1.10)
+    uwot (>= 0.2.1)
 Suggests:
     ape,
     arrow,

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 - Fixed bug in `PercentageFeatureSet` where layer data was incorrectly retrieved prior to finding features with requested pattern ([#10438](https://github.com/satijalab/seurat/pull/10438))
 - Updated `as.SingleCellExperiment` to address conversion case where an object has both original and sketched assay / reductions (differing numbers of cells) ([#10419](https://github.com/satijalab/seurat/pull/10419))
 - Fixed bugs in behavior of `RidgePlot` parameters `fill.by`, `y.max`, and `same.y.lims` ([#10424](https://github.com/satijalab/seurat/pull/10424))
+- Fixed naming of combined p-value column in output of `FindConservedMarkers` when a non-default `meta.method` is specified ([#10429](https://github.com/satijalab/seurat/pull/10429))
+- Updated minimum required `uwot` version to `0.2.1` ([#10447](https://github.com/satijalab/seurat/pull/10447))
 
 # Seurat 5.5.1
 


### PR DESCRIPTION
# Summary

Update the minimum required version of `uwot` from 0.1.10 to 0.2.1.

## Type of change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (existing functionality changed or removed)
- [ ] Documentation update
- [ ] Other (please explain below)

## Motivation

Seurat imports `uwot::umap2`, but `umap2` was introduced in uwot 0.2.1. The current dependency declaration (`uwot >= 0.1.10`) therefore permits versions of uwot that do not export `umap2`.

This change updates the minimum required uwot version to match the API required by Seurat.

## Tests & examples

Not applicable; this is a dependency metadata-only change.