### PR TITLE
Avoid densifying on-disk assays in AddModuleScore.StdAssay

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Fixed `AddModuleScore` (and `CellCycleScoring`) on v5 objects with on-disk (e.g. BPCells) assays, where each layer was fully densified to an in-memory `dgCMatrix` before scoring; scoring now operates directly on the on-disk matrix
 - Fixed bug in `PercentageFeatureSet` where layer data was incorrectly retrieved prior to finding features with requested pattern ([#10438](https://github.com/satijalab/seurat/pull/10438))
 - Updated `as.SingleCellExperiment` to address conversion case where an object has both original and sketched assay / reductions (differing numbers of cells) ([#10419](https://github.com/satijalab/seurat/pull/10419))
 - Fixed bugs in behavior of `RidgePlot` parameters `fill.by`, `y.max`, and `same.y.lims` ([#10424](https://github.com/satijalab/seurat/pull/10424))

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -232,29 +232,25 @@ AddModuleScore.StdAssay <- function(
     ...
 ) {
   layer_names <- Layers(object, search = slot)
-  input_list <- lapply(
+  output_list <- lapply(
     layer_names,
     function(layer_name) {
+      # Operate on the layer's matrix directly. For on-disk (e.g. BPCells)
+      # matrices this keeps the data lazy: the scoring only needs row/column
+      # reductions, so wrapping in CreateAssayObject() (which densifies the
+      # whole matrix to a dgCMatrix) is unnecessary.
       layer_data <- LayerData(object, layer = layer_name)
-      layer_object <- CreateAssayObject(layer_data)
-      return (layer_object)
-    }
-  )
-  output_list <- lapply(
-    input_list,
-    function(input) {
-      AddModuleScore(object = input,
-                     features = features,
-                     kmeans.obj = kmeans.obj,
-                     pool = pool,
-                     nbin = nbin,
-                     ctrl = ctrl,
-                     k = k,
-                     name = name,
-                     seed = seed,
-                     search = search,
-                     slot = slot,
-                     ...)
+      .AddModuleScore(data = layer_data,
+                      features = features,
+                      kmeans.obj = kmeans.obj,
+                      pool = pool,
+                      nbin = nbin,
+                      ctrl = ctrl,
+                      k = k,
+                      name = name,
+                      seed = seed,
+                      search = search,
+                      ...)
     }
   )
   features.scores.use <- do.call(rbind,output_list)
@@ -268,8 +264,6 @@ AddModuleScore.StdAssay <- function(
 #' @concept utilities
 #' @rdname AddModuleScore
 #' @method AddModuleScore Assay
-#'
-#' @importFrom ggplot2 cut_number
 #'
 AddModuleScore.Assay <- function(
     object,
@@ -286,6 +280,48 @@ AddModuleScore.Assay <- function(
     ...
 ) {
   assay.data <- GetAssayData(object = object, layer = slot)
+  .AddModuleScore(
+    data = assay.data,
+    features = features,
+    kmeans.obj = kmeans.obj,
+    pool = pool,
+    nbin = nbin,
+    ctrl = ctrl,
+    k = k,
+    name = name,
+    seed = seed,
+    search = search,
+    ...
+  )
+}
+
+# Core AddModuleScore computation, operating directly on an expression matrix.
+#
+# Accepts any matrix supporting row/column reductions and row subsetting
+# (dgCMatrix, matrix, or an on-disk BPCells IterableMatrix), so callers can
+# avoid densifying on-disk data. Returns a data.frame of module scores (cells
+# as rows).
+#
+#' @importFrom ggplot2 cut_number
+#'
+#' @keywords internal
+#'
+#' @noRd
+#'
+.AddModuleScore <- function(
+    data,
+    features,
+    kmeans.obj,
+    pool = NULL,
+    nbin = 24,
+    ctrl = 100,
+    k = FALSE,
+    name = 'Cluster',
+    seed = 1,
+    search = FALSE,
+    ...
+) {
+  assay.data <- data
   features.old <- features
   if (k) {
     .NotYetUsed(arg = 'k')
@@ -301,7 +337,7 @@ AddModuleScore.Assay <- function(
     features <- lapply(
       X = features,
       FUN = function(x) {
-        missing.features <- setdiff(x = x, y = rownames(x = object))
+        missing.features <- setdiff(x = x, y = rownames(x = data))
         if (length(x = missing.features) > 0) {
           warning(
             "The following features are not present in the object: ",
@@ -332,7 +368,7 @@ AddModuleScore.Assay <- function(
                 )
               }
             )
-            missing.features <- setdiff(x = x, y = rownames(x = object))
+            missing.features <- setdiff(x = x, y = rownames(x = data))
             if (length(x = missing.features) > 0) {
               warning(
                 "The following features are still not present in the object: ",
@@ -343,7 +379,7 @@ AddModuleScore.Assay <- function(
             }
           }
         }
-        return(intersect(x = x, y = rownames(x = object)))
+        return(intersect(x = x, y = rownames(x = data)))
       }
     )
     cluster.length <- length(x = features)
@@ -357,7 +393,7 @@ AddModuleScore.Assay <- function(
     features <- lapply(
       X = features.old,
       FUN = CaseMatch,
-      match = rownames(x = object)
+      match = rownames(x = data)
     )
   }
   if (!all(LengthCheck(values = features))) {
@@ -367,7 +403,7 @@ AddModuleScore.Assay <- function(
       'exiting...'
     ))
   }
-  pool <- pool %||% rownames(x = object)
+  pool <- pool %||% rownames(x = data)
   data.avg <- Matrix::rowMeans(x = assay.data[pool, ])
   data.avg <- data.avg[order(data.avg)]
   data.cut <- cut_number(x = data.avg + rnorm(n = length(data.avg))/1e30, n = nbin, labels = FALSE, right = FALSE)
@@ -391,7 +427,7 @@ AddModuleScore.Assay <- function(
   ctrl.scores <- matrix(
     data = numeric(length = 1L),
     nrow = length(x = ctrl.use),
-    ncol = ncol(x = object)
+    ncol = ncol(x = data)
   )
   for (i in 1:length(ctrl.use)) {
     features.use <- ctrl.use[[i]]
@@ -400,7 +436,7 @@ AddModuleScore.Assay <- function(
   features.scores <- matrix(
     data = numeric(length = 1L),
     nrow = cluster.length,
-    ncol = ncol(x = object)
+    ncol = ncol(x = data)
   )
   for (i in 1:cluster.length) {
     features.use <- features[[i]]
@@ -410,7 +446,7 @@ AddModuleScore.Assay <- function(
   features.scores.use <- features.scores - ctrl.scores
   rownames(x = features.scores.use) <- paste0(name, 1:cluster.length)
   features.scores.use <- as.data.frame(x = t(x = features.scores.use))
-  rownames(x = features.scores.use) <- colnames(x = object)
+  rownames(x = features.scores.use) <- colnames(x = data)
   return(features.scores.use)
 }
 

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -280,19 +280,17 @@ AddModuleScore.Assay <- function(
     ...
 ) {
   assay.data <- GetAssayData(object = object, layer = slot)
-  .AddModuleScore(
-    data = assay.data,
-    features = features,
-    kmeans.obj = kmeans.obj,
-    pool = pool,
-    nbin = nbin,
-    ctrl = ctrl,
-    k = k,
-    name = name,
-    seed = seed,
-    search = search,
-    ...
-  )
+  return(.AddModuleScore(data = assay.data,
+                        features = features,
+                        kmeans.obj = kmeans.obj,
+                        pool = pool,
+                        nbin = nbin,
+                        ctrl = ctrl,
+                        k = k,
+                        name = name,
+                        seed = seed,
+                        search = search,
+                        ...))
 }
 
 # Core AddModuleScore computation, operating directly on an expression matrix.

--- a/tests/testthat/test_utilities.R
+++ b/tests/testthat/test_utilities.R
@@ -443,6 +443,20 @@ test_that("AddModuleScore works in the multi-layer case", {
   )
 })
 
+test_that("AddModuleScore preserves IterableMatrix layers", {
+  skip_if_not_installed("BPCells")
+  library(BPCells)
+  library(Matrix)
+  mat_bpcells <- t(as(t(object[['RNA']]$counts ), "IterableMatrix"))
+  object[["RNA"]]$counts <- mat_bpcells
+  object <- NormalizeData(object)
+  mod_features <- list(c('CD79B','CD79A','CD3D','CD2','CD3E','CD7',
+                        'CD14','CD68','CD247'))
+  object2 <- AddModuleScore(object = object, features = mod_features, ctrl = 5)
+  expect_s4_class(object2[['RNA']]$counts, "IterableMatrix")
+  expect_s4_class(object2[['RNA']]$data, "IterableMatrix")
+})
+
 test_that("PercentageFeatureSet works with v5 layers", {
   counts <- LayerData(object, assay = "RNA", layer = "counts")
   counts <- rbind(counts, rep(5, ncol(counts)))


### PR DESCRIPTION
This is relevant to this reported bug https://github.com/satijalab/seurat/issues/10435. 

AddModuleScore.StdAssay wrapped each layer in CreateAssayObject(), which coerces the whole IterableMatrix to an in-memory dgCMatrix before scoring. For BPCells-backed v5 objects this densification dominates runtime and defeats on-disk storage, even though scoring only needs row/column reductions over a handful of gene rows.

The fix:
Extract the core scoring math into an internal .AddModuleScore() helper that operates directly on an expression matrix. AddModuleScore.Assay now delegates to it via GetAssayData(), and AddModuleScore.StdAssay runs it per layer on the raw LayerData() matrix, keeping on-disk data lazy.
