### PR TITLE
Fix GetResidual() for multi-model SCT assays 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: Seurat
-Version: 5.5.1.9003
+Version: 5.5.1.9004
 Title: Tools for Single Cell Genomics
 Description: A toolkit for quality control, analysis, and exploration of single cell RNA sequencing data. 'Seurat' aims to enable users to identify and interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse types of single cell data. See Satija R, Farrell J, Gennert D, et al (2015) <doi:10.1038/nbt.3192>, Macosko E, Basu A, Satija R, et al (2015) <doi:10.1016/j.cell.2015.05.002>, Stuart T, Butler A, et al (2019) <doi:10.1016/j.cell.2019.05.031>, and Hao, Hao, et al (2020) <doi:10.1101/2020.10.12.335331> for more details.
 Authors@R: c(

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,8 @@
 
 ### Fixes
 
-- Fixed `AddModuleScore` (and `CellCycleScoring`) on v5 objects with on-disk (e.g. BPCells) assays, where each layer was fully densified to an in-memory `dgCMatrix` before scoring; scoring now operates directly on the on-disk matrix
+- Fixed `AddModuleScore` (and `CellCycleScoring`) on v5 objects with on-disk (e.g. BPCells) assays, where each layer was fully densified to an in-memory `dgCMatrix` before scoring; scoring now operates directly on the on-disk matrix ([#10448](https://github.com/satijalab/seurat/pull/10448))
+- Fixed `GetResidual()` to correctly handle multi-model SCT assays with partial feature overlap ([#10541](https://github.com/satijalab/seurat/pull/10451))
 - Fixed bug in `PercentageFeatureSet` where layer data was incorrectly retrieved prior to finding features with requested pattern ([#10438](https://github.com/satijalab/seurat/pull/10438))
 - Updated `as.SingleCellExperiment` to address conversion case where an object has both original and sketched assay / reductions (differing numbers of cells) ([#10419](https://github.com/satijalab/seurat/pull/10419))
 - Fixed bugs in behavior of `RidgePlot` parameters `fill.by`, `y.max`, and `same.y.lims` ([#10424](https://github.com/satijalab/seurat/pull/10424))

--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -445,8 +445,10 @@ GetResidual <- function(
     new.residuals <- lapply(
       X = sct.models,
       FUN = function(x) {
+        model.cells <- Cells(x = slot(object = object[[assay]], name = "SCTModel.list")[[x]])
         FetchResidualSCTModel(object = object[[assay]],
                               umi.object = object[[umi.assay]],
+                              layer.cells = model.cells,
                               SCTModel = x,
                               new_features = features,
                               replace.value = replace.value,

--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -5972,9 +5972,8 @@ GetResidualSCTModel <- function(
   }
   diff_features <- setdiff(x = features_to_compute, y = model.features)
   intersect_features <- intersect(x = features_to_compute, y = model.features)
-  features_to_compute_model <- features_to_compute
   if (length(x = diff_features) == 0) {
-    umi <- GetAssayData(object = object, assay = umi.assay, layer = "counts" )[features_to_compute_model, model.cells, drop = FALSE]
+    umi <- GetAssayData(object = object, assay = umi.assay, layer = "counts" )[features_to_compute, model.cells, drop = FALSE]
   } else {
     warning(
       "In the SCTModel ", SCTModel, ", the following ", length(x = diff_features),
@@ -5988,8 +5987,7 @@ GetResidualSCTModel <- function(
         dimnames = list(features_to_compute, model.cells)
       )
     } else {
-      features_to_compute_model <- intersect_features
-      umi <- GetAssayData(object = object, assay = umi.assay, layer = "counts")[features_to_compute_model, model.cells, drop = FALSE]
+      umi <- GetAssayData(object = object, assay = umi.assay, layer = "counts")[intersect_features, model.cells, drop = FALSE]
     }
   }
   clip.max <- max(clip.range)
@@ -6027,14 +6025,14 @@ GetResidualSCTModel <- function(
   } else if (!exists(x = "new_residual", inherits = FALSE)) {
     new_residual <- matrix(data = NA, nrow = 0, ncol = length(x = model.cells), dimnames = list(c(), model.cells))
   }
-  if (length(x = diff_features) > 0) {
+  if (length(x = diff_features) > 0 && length(x = intersect_features) > 0) {
     padded_residual <- matrix(
       data = NA,
       nrow = length(x = features_to_compute),
       ncol = length(x = model.cells),
       dimnames = list(features_to_compute, model.cells)
     )
-    padded_residual[features_to_compute_model, colnames(x = new_residual)] <- new_residual
+    padded_residual[rownames(x = new_residual), colnames(x = new_residual)] <- new_residual
     new_residual <- padded_residual
   }
   old.features <- setdiff(x = new_features, y = features_to_compute)

--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -5972,26 +5972,29 @@ GetResidualSCTModel <- function(
   }
   diff_features <- setdiff(x = features_to_compute, y = model.features)
   intersect_features <- intersect(x = features_to_compute, y = model.features)
+  features_to_compute_model <- features_to_compute
   if (length(x = diff_features) == 0) {
-    umi <- GetAssayData(object = object, assay = umi.assay, layer = "counts" )[features_to_compute, model.cells, drop = FALSE]
+    umi <- GetAssayData(object = object, assay = umi.assay, layer = "counts" )[features_to_compute_model, model.cells, drop = FALSE]
   } else {
     warning(
       "In the SCTModel ", SCTModel, ", the following ", length(x = diff_features),
       " features do not exist in the counts slot: ", paste(diff_features, collapse = ", ")
     )
     if (length(x = intersect_features) == 0) {
-      return(matrix(
+      new_residual <- matrix(
         data = NA,
         nrow = length(x = features_to_compute),
         ncol = length(x = model.cells),
         dimnames = list(features_to_compute, model.cells)
-      ))
+      )
+    } else {
+      features_to_compute_model <- intersect_features
+      umi <- GetAssayData(object = object, assay = umi.assay, layer = "counts")[features_to_compute_model, model.cells, drop = FALSE]
     }
-    umi <- GetAssayData(object = object, assay = umi.assay, layer = "counts")[intersect_features, model.cells, drop = FALSE]
   }
   clip.max <- max(clip.range)
   clip.min <- min(clip.range)
-  if (nrow(x = umi) > 0) {
+  if (exists(x = "umi") && nrow(x = umi) > 0) {
     vst_out <- SCTModel_to_vst(SCTModel = slot(object = object[[assay]], name = "SCTModel.list")[[SCTModel]])
     if (verbose) {
       message("sct.model: ", SCTModel)
@@ -6006,8 +6009,18 @@ GetResidualSCTModel <- function(
     new_residual <- as.matrix(x = new_residual)
     # centered data
     new_residual <- new_residual - rowMeans(x = new_residual)
-  } else {
+  } else if (!exists(x = "new_residual")) {
     new_residual <- matrix(data = NA, nrow = 0, ncol = length(x = model.cells), dimnames = list(c(), model.cells))
+  }
+  if (length(x = diff_features) > 0) {
+    padded_residual <- matrix(
+      data = NA,
+      nrow = length(x = features_to_compute),
+      ncol = length(x = model.cells),
+      dimnames = list(features_to_compute, model.cells)
+    )
+    padded_residual[features_to_compute_model, colnames(x = new_residual)] <- new_residual
+    new_residual <- padded_residual
   }
   old.features <- setdiff(x = new_features, y = features_to_compute)
   if (length(x = old.features) > 0) {

--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -6007,8 +6007,23 @@ GetResidualSCTModel <- function(
       verbosity = as.numeric(x = verbose) * 2
     )
     new_residual <- as.matrix(x = new_residual)
+    if (!identical(dim(x = new_residual), dim(x = umi))) {
+      new_residual <- matrix(
+        data = new_residual,
+        nrow = nrow(x = umi),
+        ncol = ncol(x = umi),
+        dimnames = dimnames(x = umi)
+      )
+    } else {
+      dimnames(x = new_residual) <- dimnames(x = umi)
+    }
     # centered data
-    new_residual <- new_residual - rowMeans(x = new_residual)
+    new_residual <- sweep(
+      x = new_residual,
+      MARGIN = 1,
+      STATS = rowMeans(x = new_residual),
+      FUN = "-"
+    )
   } else if (!exists(x = "new_residual")) {
     new_residual <- matrix(data = NA, nrow = 0, ncol = length(x = model.cells), dimnames = list(c(), model.cells))
   }
@@ -6025,7 +6040,15 @@ GetResidualSCTModel <- function(
   old.features <- setdiff(x = new_features, y = features_to_compute)
   if (length(x = old.features) > 0) {
     old_residuals <- GetAssayData(object = object[[assay]], layer = "scale.data")[old.features, model.cells, drop = FALSE]
-    new_residual <- rbind(new_residual, old_residuals)[new_features, ]
+    combined_residual <- matrix(
+      data = NA,
+      nrow = length(x = new_features),
+      ncol = length(x = model.cells),
+      dimnames = list(new_features, model.cells)
+    )
+    combined_residual[rownames(x = new_residual), colnames(x = new_residual)] <- new_residual
+    combined_residual[rownames(x = old_residuals), colnames(x = old_residuals)] <- old_residuals
+    new_residual <- combined_residual
   }
   return(new_residual)
 }

--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -5994,7 +5994,7 @@ GetResidualSCTModel <- function(
   }
   clip.max <- max(clip.range)
   clip.min <- min(clip.range)
-  if (exists(x = "umi") && nrow(x = umi) > 0) {
+  if (exists(x = "umi", inherits = FALSE) && nrow(x = umi) > 0) {
     vst_out <- SCTModel_to_vst(SCTModel = slot(object = object[[assay]], name = "SCTModel.list")[[SCTModel]])
     if (verbose) {
       message("sct.model: ", SCTModel)
@@ -6024,7 +6024,7 @@ GetResidualSCTModel <- function(
       STATS = rowMeans(x = new_residual),
       FUN = "-"
     )
-  } else if (!exists(x = "new_residual")) {
+  } else if (!exists(x = "new_residual", inherits = FALSE)) {
     new_residual <- matrix(data = NA, nrow = 0, ncol = length(x = model.cells), dimnames = list(c(), model.cells))
   }
   if (length(x = diff_features) > 0) {

--- a/R/preprocessing5.R
+++ b/R/preprocessing5.R
@@ -1554,10 +1554,6 @@ FetchResidualSCTModel <- function(
     features_to_compute <- character()
   }
 
-  # these features do not have feature attriutes
-  diff_features <- setdiff(x = features_to_compute, y = model.features)
-  intersect_features <- intersect(x = features_to_compute, y = model.features)
-  features_to_compute_model <- features_to_compute
   if (sct.method == "reference") {
     vst_out <- SCTModel_to_vst(SCTModel = reference.SCT.model)
 
@@ -1565,15 +1561,17 @@ FetchResidualSCTModel <- function(
     clip.range <- vst_out$arguments$sct.clip.range
     # get rid of the cell attributes
     vst_out$cell_attr <- NULL
-    all.features <- intersect(
-      x = rownames(x = vst_out$gene_attr),
-      y = features_to_compute
-    )
-    vst_out$gene_attr <- vst_out$gene_attr[all.features, , drop = FALSE]
-    vst_out$model_pars_fit <- vst_out$model_pars_fit[all.features, , drop = FALSE]
   } else {
     vst_out <- SCTModel_to_vst(SCTModel = slot(object, name = "SCTModel.list")[[SCTModel]])
     clip.range <- vst_out$arguments$sct.clip.range
+  }
+  # these features do not have feature attriutes
+  model.features <- intersect(x = rownames(x = vst_out$gene_attr), y = rownames(x = vst_out$model_pars_fit))
+  diff_features <- setdiff(x = features_to_compute, y = model.features)
+  intersect_features <- intersect(x = features_to_compute, y = model.features)
+  if (sct.method == "reference") {
+    vst_out$gene_attr <- vst_out$gene_attr[intersect_features, , drop = FALSE]
+    vst_out$model_pars_fit <- vst_out$model_pars_fit[intersect_features, , drop = FALSE]
   }
   clip.max <- max(clip.range)
   clip.min <- min(clip.range)
@@ -1593,8 +1591,6 @@ FetchResidualSCTModel <- function(
         ncol = length(x = layer.cells),
         dimnames = list(features_to_compute, layer.cells)
       )
-    } else {
-      features_to_compute_model <- intersect_features
     }
   }
   if (!exists(x = "new_residual", inherits = FALSE)) {
@@ -1605,6 +1601,11 @@ FetchResidualSCTModel <- function(
     )
     cells.vector <- 1:length(x = layer.cells)
     cells.grid <- split(x = cells.vector, f = ceiling(x = seq_along(along.with = cells.vector)/chunk_size))
+    umi_features <- if (length(x = diff_features) == 0) {
+      features_to_compute
+    } else {
+      intersect_features
+    }
     new_residuals <- list()
 
     for (i in seq_len(length.out = length(x = cells.grid))) {
@@ -1619,7 +1620,7 @@ FetchResidualSCTModel <- function(
         nz_median <- median(umi.all@x)
         min_var_custom <- (nz_median / 5)^2
       }
-      umi <- umi.all[features_to_compute_model, , drop = FALSE]
+      umi <- umi.all[umi_features, , drop = FALSE]
 
       ## Add cell_attr for missing cells
       cell_attr <- data.frame(
@@ -1714,14 +1715,14 @@ FetchResidualSCTModel <- function(
         FUN = "-"
       )
     }
-    if (length(x = diff_features) > 0) {
+    if (length(x = diff_features) > 0 && length(x = intersect_features) > 0) {
       padded_residual <- matrix(
         data = NA,
         nrow = length(x = features_to_compute),
         ncol = length(x = layer.cells),
         dimnames = list(features_to_compute, layer.cells)
       )
-      padded_residual[features_to_compute_model, colnames(x = new_residual)] <- new_residual
+      padded_residual[rownames(x = new_residual), colnames(x = new_residual)] <- new_residual
       new_residual <- padded_residual
     }
   }

--- a/R/preprocessing5.R
+++ b/R/preprocessing5.R
@@ -1557,6 +1557,7 @@ FetchResidualSCTModel <- function(
   # these features do not have feature attriutes
   diff_features <- setdiff(x = features_to_compute, y = model.features)
   intersect_features <- intersect(x = features_to_compute, y = model.features)
+  features_to_compute_model <- features_to_compute
   if (sct.method == "reference") {
     vst_out <- SCTModel_to_vst(SCTModel = reference.SCT.model)
 
@@ -1578,7 +1579,25 @@ FetchResidualSCTModel <- function(
   clip.min <- min(clip.range)
 
   layer.cells <- layer.cells %||% Cells(umi.object, layer = layer)
-  if (length(x = diff_features) == 0) {
+  if (length(x = diff_features) > 0) {
+    #  Some features do not exist
+    warning(
+      "In the SCTModel ", SCTModel, ", the following ", length(x = diff_features),
+      " features do not exist in the counts slot: ", paste(diff_features, collapse = ", ")
+    )
+    if (length(x = intersect_features) == 0) {
+      # No features exist
+      new_residual <- matrix(
+        data = NA,
+        nrow = length(x = features_to_compute),
+        ncol = length(x = model.cells),
+        dimnames = list(features_to_compute, model.cells)
+      )
+    } else {
+      features_to_compute_model <- intersect_features
+    }
+  }
+  if (!exists(x = "new_residual")) {
     counts <- LayerData(
       umi.object,
       layer = layer,
@@ -1600,7 +1619,7 @@ FetchResidualSCTModel <- function(
         nz_median <- median(umi.all@x)
         min_var_custom <- (nz_median / 5)^2
       }
-      umi <- umi.all[features_to_compute, , drop = FALSE]
+      umi <- umi.all[features_to_compute_model, , drop = FALSE]
 
       ## Add cell_attr for missing cells
       cell_attr <- data.frame(
@@ -1680,21 +1699,15 @@ FetchResidualSCTModel <- function(
         FUN = "-"
       )
     }
-    # return (new_residuals)
-  } else {
-    #  Some features do not exist
-    warning(
-      "In the SCTModel ", SCTModel, ", the following ", length(x = diff_features),
-      " features do not exist in the counts slot: ", paste(diff_features, collapse = ", ")
-    )
-    if (length(x = intersect_features) == 0) {
-      # No features exist
-      return(matrix(
+    if (length(x = diff_features) > 0) {
+      padded_residual <- matrix(
         data = NA,
         nrow = length(x = features_to_compute),
-        ncol = length(x = model.cells),
-        dimnames = list(features_to_compute, model.cells)
-      ))
+        ncol = length(x = layer.cells),
+        dimnames = list(features_to_compute, layer.cells)
+      )
+      padded_residual[features_to_compute_model, colnames(x = new_residual)] <- new_residual
+      new_residual <- padded_residual
     }
   }
   old.features <- setdiff(x = new_features, y = features_to_compute)

--- a/R/preprocessing5.R
+++ b/R/preprocessing5.R
@@ -1679,12 +1679,27 @@ FetchResidualSCTModel <- function(
         ))
       }
       new_residual <- as.matrix(x = new_residual)
+      if (!identical(dim(x = new_residual), dim(x = umi))) {
+        new_residual <- matrix(
+          data = new_residual,
+          nrow = nrow(x = umi),
+          ncol = ncol(x = umi),
+          dimnames = dimnames(x = umi)
+        )
+      } else {
+        dimnames(x = new_residual) <- dimnames(x = umi)
+      }
       new_residuals[[i]] <- new_residual
     }
     new_residual <- do.call(what = cbind, args = new_residuals)
     # centered data if no reference model is provided
     if (is.null(x = reference.SCT.model)){
-      new_residual <- new_residual - rowMeans(x = new_residual)
+      new_residual <- sweep(
+        x = new_residual,
+        MARGIN = 1,
+        STATS = rowMeans(x = new_residual),
+        FUN = "-"
+      )
     } else {
       # subtract residual mean from reference model
       if (verbose){
@@ -1713,7 +1728,15 @@ FetchResidualSCTModel <- function(
   old.features <- setdiff(x = new_features, y = features_to_compute)
   if (length(x = old.features) > 0) {
     old_residuals <- GetAssayData(object, layer = "scale.data")[old.features, model.cells, drop = FALSE]
-    new_residual <- rbind(new_residual, old_residuals)[new_features, ]
+    combined_residual <- matrix(
+      data = NA,
+      nrow = length(x = new_features),
+      ncol = length(x = model.cells),
+      dimnames = list(new_features, model.cells)
+    )
+    combined_residual[rownames(x = new_residual), colnames(x = new_residual)] <- new_residual
+    combined_residual[rownames(x = old_residuals), colnames(x = old_residuals)] <- old_residuals
+    new_residual <- combined_residual
   }
   return(new_residual)
 }

--- a/R/preprocessing5.R
+++ b/R/preprocessing5.R
@@ -1590,8 +1590,8 @@ FetchResidualSCTModel <- function(
       new_residual <- matrix(
         data = NA,
         nrow = length(x = features_to_compute),
-        ncol = length(x = model.cells),
-        dimnames = list(features_to_compute, model.cells)
+        ncol = length(x = layer.cells),
+        dimnames = list(features_to_compute, layer.cells)
       )
     } else {
       features_to_compute_model <- intersect_features
@@ -1727,12 +1727,12 @@ FetchResidualSCTModel <- function(
   }
   old.features <- setdiff(x = new_features, y = features_to_compute)
   if (length(x = old.features) > 0) {
-    old_residuals <- GetAssayData(object, layer = "scale.data")[old.features, model.cells, drop = FALSE]
+    old_residuals <- GetAssayData(object, layer = "scale.data")[old.features, layer.cells, drop = FALSE]
     combined_residual <- matrix(
       data = NA,
       nrow = length(x = new_features),
-      ncol = length(x = model.cells),
-      dimnames = list(new_features, model.cells)
+      ncol = length(x = layer.cells),
+      dimnames = list(new_features, layer.cells)
     )
     combined_residual[rownames(x = new_residual), colnames(x = new_residual)] <- new_residual
     combined_residual[rownames(x = old_residuals), colnames(x = old_residuals)] <- old_residuals

--- a/R/preprocessing5.R
+++ b/R/preprocessing5.R
@@ -1597,7 +1597,7 @@ FetchResidualSCTModel <- function(
       features_to_compute_model <- intersect_features
     }
   }
-  if (!exists(x = "new_residual")) {
+  if (!exists(x = "new_residual", inherits = FALSE)) {
     counts <- LayerData(
       umi.object,
       layer = layer,

--- a/tests/testthat/test_preprocessing.R
+++ b/tests/testthat/test_preprocessing.R
@@ -427,6 +427,31 @@ if (is_not_cran_submission) {
     expect_warning(GetResidual(object, features = "asd"))
   })
 
+  test_that("GetResidual handles features modeled in only one SCT model when na.rm is FALSE", {
+    set.seed(1)
+    obj1 <- suppressWarnings(SCTransform(pbmc_small[, 1:40], verbose = FALSE))
+    obj2 <- suppressWarnings(SCTransform(pbmc_small[, 41:80], verbose = FALSE))
+    merged <- merge(x = obj1, y = obj2)
+
+    only1 <- setdiff(x = VariableFeatures(obj1), y = VariableFeatures(obj2))[[1]] # gene modeled in obj1 only
+    both <- intersect(x = VariableFeatures(obj1), y = VariableFeatures(obj2))[[1]] # gene modeled in both obj1 and obj2
+
+    result <- expect_warning(
+      GetResidual(object = merged, features = c(only1, both), assay = "SCT", na.rm = FALSE, verbose = FALSE),
+      "features do not exist in the counts slot",
+      fixed = TRUE
+    )
+    residuals <- GetAssayData(object = result, assay = "SCT", layer = "scale.data")
+    sct_models <- levels(x = result[["SCT"]])
+    model1.cells <- Cells(x = slot(object = result[["SCT"]], name = "SCTModel.list")[[sct_models[[1]]]])
+    model2.cells <- Cells(x = slot(object = result[["SCT"]], name = "SCTModel.list")[[sct_models[[2]]]])
+
+    expect_true(all(c(only1, both) %in% rownames(x = residuals)))
+    expect_false(anyNA(residuals[only1, model1.cells]))
+    expect_true(all(is.na(residuals[only1, model2.cells])))
+    expect_false(anyNA(residuals[both, c(model1.cells, model2.cells)]))
+  })
+
   test_that("SCTransform v2 works as expected", {
     skip_if_not_installed("glmGamPoi")
     object <- suppressWarnings(SCTransform(object = object, verbose = FALSE, vst.flavor = "v2",  seed.use = 1448145))


### PR DESCRIPTION
Fixes #10441 

This PR fixes GetResidual() behaviour for SCT assays that contain multiple SCT models that resulted from separate runs of SCTransform(). 

Previously, GetResidual() behaved incorrectly when requested features were not modeled in every SCT model in a Seurat object; when its parameter na.rm was set to FALSE, this should normally remove all genes with NAs from the residual matrix. However, without these changes, this would instead result in a crash with the following error: `# Error: number of rows of matrices must match (see arg 2)`. 

Reproducible example (thank you @pwwang!): 
```
library(Seurat)
data("pbmc_small", package = "SeuratObject")
set.seed(1)
obj1 <- SCTransform(pbmc_small[, 1:40], verbose = FALSE)
obj2 <- SCTransform(pbmc_small[, 41:80], verbose = FALSE)
merged <- merge(obj1, obj2)

# a gene modeled in obj1 only, and one modeled in both objects
only1 <- setdiff(VariableFeatures(obj1), VariableFeatures(obj2))[1]  # e.g. "TCL1A"
both  <- intersect(VariableFeatures(obj1), VariableFeatures(obj2))[1]

# na.rm = FALSE: crashes
GetResidual(merged, features = c(only1, both), assay = "SCT", na.rm = FALSE)
# Error: number of rows of matrices must match (see arg 2)
```

This PR introduces some changes to GetResidual(), GetResidualSCTModel(), and FetchResidualSCTModel() that addresses these issues. 

GetResidual() is normally supposed to loop over each SCT model in an object and call the GetResidual/FetchResidual helpers to recompute any missing residuals. However the previous code just passed the object's entire set of cells, making the output structurally inconsistent. GetResiduals() now passes the current model's cells into the residual calculator helpers, such that each SCT model correctly computes residuals for its own cells.

GetResidualSCTModel() and FetchResidualSCTModel() now explicitly handle partial feature overlap better by only computing residuals for features present in a model, and padding any missing features with NAs. 

With these changes, the residual matrix for the above reprex now generates correctly:
```
#Print residuals for 4 cells, of which 2 cells lack the TCL1A feature in their SCT model
> residual_mat[c(only1, both), 39:42]
      GGCATATGCTTATC CATTACACCAACTG TAGGGACTGAACTC GCTCCATGAGAAGT
TCL1A     -0.2626143      -0.325272             NA             NA
GNLY       1.3417045       1.341705       1.302976     -0.1981292
```

Simple example of the problem: 
Suppose GetResidual is called for features **A** and **B** across an SCT assay with two SCT models. model1 contains both A and B, but model2 contains only B. model1 contains cells c1, c2, while model2 contains cells c3, c4. Under healthy GetResidual na.rm = FALSE behaviour, we would expect the residual matrix to look something like:

```text
      c1   c2   c3   c4
A    0.2  0.1   NA   NA
B    0.1  0.2  0.3  0.1
```
Without these changes, running Get/FetchResidualSCTModel would return

```text
      c1   c2
A    0.2  0.1
B    0.1 0.2
```

for model1 and

```text
      c3   c4
B    0.3 0.1
```
for model two, with inconsistent row sets that cause GetResidual to error. After this change, each model computes residuals only for the features it contains, however the helper functions now also pad missing features with NA:

```text
      c1   c2
A    0.2  0.1
B    0.1  0.2
```
for model1 and 

```text
      c3  c4
A    NA  NA
B    0.3  0.1
```
for model 2. This would eventually combine into the full residual matrix that can now be returned by GetResidual():

```text
      c1   c2   c3   c4
A    0.2  0.1   NA   NA
B    0.1  0.2  0.3 0.1
```