### PR TITLE
Fix PCAPlot/TSNEPlot/UMAPPlot outside a bare call

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- Fixed `PCAPlot`, `TSNEPlot` and `UMAPPlot` failing unless called by their bare name: the reduction was inferred from the calling function's name in the call stack, so `Seurat::UMAPPlot(obj)`, an alias, `do.call()` and `lapply()` all looked up the wrong reduction. Each now names its reduction explicitly ([#9436](https://github.com/satijalab/seurat/issues/9436))
+
 - Fixed `AddModuleScore` (and `CellCycleScoring`) on v5 objects with on-disk (e.g. BPCells) assays, where each layer was fully densified to an in-memory `dgCMatrix` before scoring; scoring now operates directly on the on-disk matrix
 - Fixed bug in `PercentageFeatureSet` where layer data was incorrectly retrieved prior to finding features with requested pattern ([#10438](https://github.com/satijalab/seurat/pull/10438))
 - Updated `as.SingleCellExperiment` to address conversion case where an object has both original and sketched assay / reductions (differing numbers of cells) ([#10419](https://github.com/satijalab/seurat/pull/10419))

--- a/R/convenience.R
+++ b/R/convenience.R
@@ -302,7 +302,7 @@ PCHeatmap <- function(object, ...) {
 #' @export
 #'
 PCAPlot <- function(object, ...) {
-  return(SpecificDimPlot(object = object, ...))
+  return(SpecificDimPlot(object = object, name = 'pca', ...))
 }
 
 #' @rdname SpatialPlot
@@ -422,7 +422,7 @@ SpatialFeaturePlot <- function(
 #' @export
 #'
 TSNEPlot <- function(object, ...) {
-  return(SpecificDimPlot(object = object, ...))
+  return(SpecificDimPlot(object = object, name = 'tsne', ...))
 }
 
 #' @rdname DimPlot
@@ -430,7 +430,7 @@ TSNEPlot <- function(object, ...) {
 #' @export
 #'
 UMAPPlot <- function(object, ...) {
-  return(SpecificDimPlot(object = object, ...))
+  return(SpecificDimPlot(object = object, name = 'umap', ...))
 }
 
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -447,10 +447,7 @@ UMAPPlot <- function(object, ...) {
 
 # @rdname DimPlot
 #
-SpecificDimPlot <- function(object, ...) {
-  funs <- sys.calls()
-  name <- as.character(x = funs[[length(x = funs) - 1]])[1]
-  name <- tolower(x = gsub(pattern = 'Plot', replacement = '', x = name))
+SpecificDimPlot <- function(object, name, ...) {
   args <- list('object' = object)
   args <- c(args, list(...))
   reduc <- grep(

--- a/tests/testthat/test_convenience_dimplots.R
+++ b/tests/testthat/test_convenience_dimplots.R
@@ -1,0 +1,55 @@
+# PCAPlot/TSNEPlot/UMAPPlot used to infer their reduction from the name of the
+# calling function in the call stack, so any call that was not a bare
+# `PCAPlot(obj)` looked up the wrong reduction.
+obj <- suppressWarnings(pbmc_small)
+
+# A DimPlot's data columns are named from the reduction's key (PC_1, tSNE_1),
+# so they identify which reduction was actually used
+used_reduction <- function(plot) {
+  colnames(plot$data)[1]
+}
+
+test_that("PCAPlot uses the pca reduction however it is called", {
+  expected <- used_reduction(suppressWarnings(PCAPlot(obj)))
+  expect_true(nzchar(expected))
+  expect_identical(used_reduction(suppressWarnings(Seurat::PCAPlot(obj))), expected)
+  aliased <- PCAPlot
+  expect_identical(used_reduction(suppressWarnings(aliased(obj))), expected)
+  expect_identical(
+    used_reduction(suppressWarnings(do.call(PCAPlot, list(obj)))),
+    expected
+  )
+  expect_identical(
+    used_reduction(suppressWarnings(lapply(list(obj), PCAPlot)[[1]])),
+    expected
+  )
+})
+
+test_that("TSNEPlot uses the tsne reduction however it is called", {
+  expected <- used_reduction(suppressWarnings(TSNEPlot(obj)))
+  expect_true(nzchar(expected))
+  expect_identical(used_reduction(suppressWarnings(Seurat::TSNEPlot(obj))), expected)
+  expect_identical(
+    used_reduction(suppressWarnings(do.call(TSNEPlot, list(obj)))),
+    expected
+  )
+})
+
+test_that("PCAPlot and TSNEPlot pick different reductions", {
+  expect_false(identical(
+    used_reduction(suppressWarnings(PCAPlot(obj))),
+    used_reduction(suppressWarnings(TSNEPlot(obj)))
+  ))
+})
+
+test_that("extra arguments still reach DimPlot", {
+  plot <- suppressWarnings(PCAPlot(obj, group.by = "letter.idents"))
+  expect_s3_class(plot, "ggplot")
+  expect_true("letter.idents" %in% colnames(plot$data))
+  expect_setequal(as.character(unique(plot$data$letter.idents)), c("A", "B"))
+  # and the reduction is still the pca one
+  expect_identical(used_reduction(plot), used_reduction(suppressWarnings(PCAPlot(obj))))
+
+  subset <- suppressWarnings(PCAPlot(obj, cells = colnames(obj)[1:10]))
+  expect_equal(nrow(subset$data), 10L)
+})


### PR DESCRIPTION
Fixes #9436.

## The bug

`PCAPlot()`, `TSNEPlot()` and `UMAPPlot()` work only when called by their bare name. As the reporter found:

```r
Seurat::UMAPPlot(obj)
#> Error in object[[reduction]] : 'seurat::umap' not found in this Seurat object
```

It is not limited to namespace-qualified calls. Every ordinary way of passing the function around breaks, each differently:

| call | error on `main` |
| --- | --- |
| `Seurat::PCAPlot(obj)` | `'seurat::pca' not found in this Seurat object` |
| `f <- PCAPlot; f(obj)` | `'f' not found in this Seurat object` |
| `lapply(list(obj), PCAPlot)` | `'fun' not found in this Seurat object` |
| `do.call(PCAPlot, list(obj))` | `invalid regular expression 'function (object, ...) { return(specificdim(object = object, ...)) }'` |

The last one deparses the function itself and uses its source as a regular expression, which is where the guess stops resembling a reduction name at all.

## Root cause

All three forward to the internal `SpecificDimPlot()`, which works out which reduction to use by reading the name of its caller out of the call stack:

```r
funs <- sys.calls()
name <- as.character(x = funs[[length(x = funs) - 1]])[1]
name <- tolower(x = gsub(pattern = 'Plot', replacement = '', x = name))
```

That holds only for a literal `PCAPlot(obj)`. Anything else supplies a different string, which is then used both as the reduction name and as a `grep` pattern.

## The change

Each wrapper passes its reduction name explicitly, and `SpecificDimPlot()` takes it as an argument. The function is internal with no other callers, so the call-stack inference is removed rather than kept as a fallback.

Everything downstream is untouched: the name is still matched against the object's reductions and filtered by default assay exactly as before, so objects with `umap.rna`-style names keep working.

## Tests

New `tests/testthat/test_convenience_dimplots.R` checks the reduction that was actually used, via the plot's data columns, rather than only that the call did not error. It covers the bare call, the namespace-qualified call, an alias, `do.call()` and `lapply()`, for both `PCAPlot` and `TSNEPlot`, asserts the two pick different reductions, and confirms that extra arguments such as `group.by` and `cells` still reach `DimPlot`.

Of the eight call forms, six fail on `main` and all eight pass here. Against `main` the new file reports 2 errors and 8 passes; with this change, 14 passes. Full suite 541 passing; the 2 failures (`test_load_10X.R`) are present unchanged on `main` and are addressed separately in #10454.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
