### PR TITLE
Send each worker its block of data, not the whole matrix

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- Fixed `NormalizeData` sending the entire matrix to every worker when `future` has more than one worker, so it consumed memory proportional to the number of workers and failed outright on moderately sized objects with \dQuote{The total size of the ... globals exported for future expression}. Each worker now receives only its own block ([#10406](https://github.com/satijalab/seurat/issues/10406))
+
 - Fixed `AddModuleScore` (and `CellCycleScoring`) on v5 objects with on-disk (e.g. BPCells) assays, where each layer was fully densified to an in-memory `dgCMatrix` before scoring; scoring now operates directly on the on-disk matrix
 - Fixed bug in `PercentageFeatureSet` where layer data was incorrectly retrieved prior to finding features with requested pattern ([#10438](https://github.com/satijalab/seurat/pull/10438))
 - Updated `as.SingleCellExperiment` to address conversion case where an object has both original and sketched assay / reductions (differing numbers of cells) ([#10419](https://github.com/satijalab/seurat/pull/10419))

--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -4885,6 +4885,35 @@ LogNormalize.V3Matrix <- function(
   return(norm.data)
 }
 
+# Normalize a single block of data
+#
+# Defined at package level rather than as a closure inside
+# NormalizeData.default(): a closure created there carries that frame as its
+# environment, and the frame holds the full matrix, so `future` exports the
+# whole dataset to every worker no matter how the data is chunked.
+#
+# @param data One block of the data
+# @param norm.function The normalization function to apply
+# @param scale.factor Scale factor for normalization
+# @param margin Margin to normalize over
+#
+# @return The normalized block
+#
+.NormalizeBlock <- function(data, norm.function, scale.factor, margin) {
+  clr_function <- function(x) {
+    return(log1p(x = x / (exp(x = sum(log1p(x = x[x > 0]), na.rm = TRUE) / length(x = x)))))
+  }
+  args <- list(
+    data = data,
+    scale.factor = scale.factor,
+    verbose = FALSE,
+    custom_function = clr_function,
+    margin = margin
+  )
+  args <- args[names(x = formals(fun = norm.function))]
+  return(do.call(what = norm.function, args = args))
+}
+
 #' @importFrom future.apply future_lapply
 #' @importFrom future nbrOfWorkers
 #'
@@ -4949,30 +4978,27 @@ NormalizeData.V3Matrix <- function(
       dsize = dsize,
       csize = block.size %||% ceiling(x = dsize / nbrOfWorkers())
     )
-    normalized.data <- future_lapply(
-      X = 1:ncol(x = chunk.points),
+    # Split the data before dispatching. Iterating over block indices instead
+    # made the worker function reference `object`, so the whole matrix was
+    # exported to every worker rather than each worker receiving its own block;
+    # on a moderately sized object that alone exceeds future.globals.maxSize
+    blocks <- lapply(
+      X = seq_len(length.out = ncol(x = chunk.points)),
       FUN = function(i) {
         block <- chunk.points[, i]
-        data <- if (margin == 1) {
+        if (margin == 1) {
           object[block[1]:block[2], , drop = FALSE]
         } else {
           object[, block[1]:block[2], drop = FALSE]
         }
-        clr_function <- function(x) {
-          return(log1p(x = x / (exp(x = sum(log1p(x = x[x > 0]), na.rm = TRUE) / length(x = x)))))
-        }
-        args <- list(
-          data = data,
-          scale.factor = scale.factor,
-          verbose = FALSE,
-          custom_function = clr_function, margin = margin
-        )
-        args <- args[names(x = formals(fun = norm.function))]
-        return(do.call(
-          what = norm.function,
-          args = args
-        ))
       }
+    )
+    normalized.data <- future_lapply(
+      X = blocks,
+      FUN = .NormalizeBlock,
+      norm.function = norm.function,
+      scale.factor = scale.factor,
+      margin = margin
     )
     do.call(
       what = switch(

--- a/tests/testthat/test_normalize_parallel.R
+++ b/tests/testthat/test_normalize_parallel.R
@@ -1,0 +1,82 @@
+set.seed(42)
+
+# NormalizeData chunks the data across workers, but the worker function used to
+# reference `object`, so `future` exported the whole matrix to every worker
+# instead of each worker receiving its own block.
+make_object <- function(nfeat = 200L, ncell = 2000L) {
+  counts <- as.sparse(matrix(rpois(nfeat * ncell, lambda = 2), nrow = nfeat))
+  dimnames(counts) <- list(
+    paste0("gene", seq_len(nfeat)),
+    paste0("c", seq_len(ncell))
+  )
+  suppressWarnings(CreateSeuratObject(counts = counts))
+}
+
+with_workers <- function(n, expr) {
+  old.plan <- future::plan()
+  on.exit(future::plan(old.plan), add = TRUE)
+  future::plan("multicore", workers = n)
+  force(expr)
+}
+
+test_that("parallel normalization matches sequential", {
+  skip_on_os("windows")
+  skip_if_not(future::supportsMulticore())
+  object <- make_object()
+  for (method in c("LogNormalize", "CLR", "RC")) {
+    future::plan("sequential")
+    sequential <- LayerData(
+      suppressWarnings(NormalizeData(object, normalization.method = method, verbose = FALSE)),
+      layer = "data"
+    )
+    parallel <- with_workers(4, LayerData(
+      suppressWarnings(NormalizeData(object, normalization.method = method, verbose = FALSE)),
+      layer = "data"
+    ))
+    expect_equal(as.matrix(parallel), as.matrix(sequential), info = method)
+  }
+})
+
+# The size future reports when the limit is exceeded, in bytes
+exported_size <- function(object, workers = 4) {
+  old.opt <- options(future.globals.maxSize = 1024)
+  on.exit(options(old.opt), add = TRUE)
+  message <- tryCatch(
+    with_workers(workers, suppressWarnings(NormalizeData(object, verbose = FALSE))),
+    error = function(e) conditionMessage(e)
+  )
+  matched <- regmatches(message, regexpr("is [0-9.]+ [KMG]iB", message))
+  if (!length(matched)) {
+    return(NA_real_)
+  }
+  parts <- strsplit(sub("^is ", "", matched), " ")[[1]]
+  as.numeric(parts[1]) * switch(parts[2], KiB = 1024, MiB = 1024^2, GiB = 1024^3)
+}
+
+test_that("what is sent to workers does not grow with the data", {
+  skip_on_os("windows")
+  skip_if_not(future::supportsMulticore())
+  small <- make_object(nfeat = 200L, ncell = 1000L)
+  large <- make_object(nfeat = 200L, ncell = 8000L)
+  small.counts <- as.numeric(object.size(LayerData(small, layer = "counts")))
+  large.counts <- as.numeric(object.size(LayerData(large, layer = "counts")))
+  expect_gt(large.counts, small.counts * 4)
+
+  small.exported <- exported_size(small)
+  large.exported <- exported_size(large)
+  expect_false(is.na(small.exported))
+  expect_false(is.na(large.exported))
+  # the worker function is a constant; the data travels as chunks, one block
+  # per worker, rather than as a global carrying the entire matrix
+  expect_equal(large.exported, small.exported)
+  expect_lt(large.exported, large.counts)
+})
+
+test_that("the sequential path is unchanged", {
+  future::plan("sequential")
+  object <- make_object(nfeat = 50L, ncell = 100L)
+  normalized <- suppressWarnings(NormalizeData(object, verbose = FALSE))
+  counts <- as.matrix(LayerData(object, layer = "counts"))
+  expected <- log1p(sweep(counts, 2, colSums(counts), "/") * 1e4)
+  expect_equal(as.matrix(LayerData(normalized, layer = "data")), expected)
+})


### PR DESCRIPTION
Fixes #10406.

## The bug

With more than one `future` worker, `NormalizeData()` fails on a moderately sized object:

```r
plan("multicore", workers = 4)
obj <- CreateSeuratObject(counts = <2000 x 14000 dgCMatrix>)
NormalizeData(obj)
#> Error: The total size of the 6 globals exported for future expression ('FUN()')
#>   is 1.09 GiB. This exceeds the maximum allowed size 500.00 MiB
```

The revealing part is what the globals are. `FUN` alone accounts for **697 MiB, for a function**.

## Root cause

The data is chunked, but `future_lapply()` iterated over block *indices* and the worker function referenced `object`:

```r
normalized.data <- future_lapply(
  X = 1:ncol(x = chunk.points),
  FUN = function(i) {
    block <- chunk.points[, i]
    data <- object[, block[1]:block[2], drop = FALSE]   # <- object
    ...
  }
)
```

So every worker was sent the entire matrix and then subset it locally. Memory scaled with the number of workers rather than staying flat, which is the report in #10406, and past a certain size `future`'s export limit rejects the job outright.

## The change

Two parts, because the first alone was not enough:

1. **Split before dispatching**, and iterate over the blocks, so each worker receives only its own. This dropped the globals from six to four and left the size unchanged at 836 MiB.
2. **Move the worker body to a package-level `.NormalizeBlock()`.** A closure defined inside `NormalizeData.default()` carries that frame as its environment, and the frame holds the matrix, so the data followed the function no matter how the iteration was written.

Measured on a 2000 x 14000 object with four workers:

| | globals | exported | result |
| --- | --- | --- | --- |
| `origin/main` | 6 | 1.09 GiB | fails |
| after step 1 only | 4 | 836 MiB | fails |
| this PR | 1 | **2.63 MiB** | completes |

The remaining 2.63 MiB is the function itself and does not grow with the data.

## Tests

New `tests/testthat/test_normalize_parallel.R`:

- `LogNormalize`, `CLR` and `RC` give results identical to the sequential path under four workers.
- **What is sent to workers does not grow with the data.** Rather than asserting a fixed number, this measures the reported export size for a small and an eight-times-larger object and requires them to be equal, and to be smaller than the matrix. That is the invariant this PR restores.
- The sequential path still matches a hand-computed log-normalization.

Guarded with `skip_on_os("windows")` and `future::supportsMulticore()`, and the plan and options are restored on exit.

Against `origin/main`: 2 failures. With this change: 9 passes. Full suite 536 passing; the 2 failures (`test_load_10X.R`) are present unchanged on `main` and are addressed separately in #10454. `R CMD check` Status OK.

## Note on #10420

I could not reproduce the `IntegrateLayers` infinite loop reported there: with four workers it completes in 1.8 s on synthetic data at 600 cells, and at 14 000 cells the run stops at the export-limit error above rather than hanging. If that report is on a version predating the limit, or with `future.globals.maxSize` raised, this fix would remove the transfer that stalls it, but I have not been able to confirm that and am not claiming it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
