### PR TITLE
Apply the Xenium transcript quality threshold again

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- Fixed `ReadXenium` (and therefore `LoadXenium`) ignoring `mols.qv.threshold`: the quality column was not among those read and no filtering was applied, so every threshold returned the same transcripts ([#10155](https://github.com/satijalab/seurat/issues/10155))
+
 - Fixed `AddModuleScore` (and `CellCycleScoring`) on v5 objects with on-disk (e.g. BPCells) assays, where each layer was fully densified to an in-memory `dgCMatrix` before scoring; scoring now operates directly on the on-disk matrix
 - Fixed bug in `PercentageFeatureSet` where layer data was incorrectly retrieved prior to finding features with requested pattern ([#10438](https://github.com/satijalab/seurat/pull/10438))
 - Updated `as.SingleCellExperiment` to address conversion case where an object has both original and sketched assay / reductions (differing numbers of cells) ([#10419](https://github.com/satijalab/seurat/pull/10419))

--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -2844,7 +2844,17 @@ ReadXenium <- function(
           y_location = letters[25-flip.xy],
           feature_name = 'gene'
         )
+        # `mols.qv.threshold` was documented and accepted but never applied,
+        # because the quality column was not among those read. Ask for it, and
+        # fall back to reading without it for outputs that lack it
+        qv.wanted <- is.numeric(x = mols.qv.threshold) &&
+          length(x = mols.qv.threshold) == 1L &&
+          !is.na(x = mols.qv.threshold)
+        if (qv.wanted) {
+          col.use <- c(col.use, qv = 'qv')
+        }
 
+        read.transcripts <- function(col.use) {
         for(option in Filter(function(x) x$req, list(
           list(
             filename = "transcripts.parquet",
@@ -2861,6 +2871,31 @@ ReadXenium <- function(
           transcripts <- try(suppressWarnings(option$fn(file.path(data.dir, option$filename))))
           if(!inherits(transcripts, "try-error")) { break }
         }
+          return(transcripts)
+        }
+
+        transcripts <- read.transcripts(col.use = col.use)
+        # Outputs without a quality column either fail the read (readers that
+        # select columns) or return a frame without it (readers that do not).
+        # Handle both: fall back and say the threshold could not be honoured,
+        # rather than filtering silently or failing on a missing column
+        if (qv.wanted) {
+          missing.qv <- inherits(x = transcripts, what = 'try-error') ||
+            !'qv' %in% colnames(x = transcripts)
+          if (missing.qv) {
+            col.use <- col.use[setdiff(x = names(x = col.use), y = 'qv')]
+            qv.wanted <- FALSE
+            transcripts <- read.transcripts(col.use = col.use)
+            if (!inherits(x = transcripts, what = 'try-error')) {
+              warning(
+                "No 'qv' column in the transcripts file; 'mols.qv.threshold' ",
+                "was not applied.",
+                call. = FALSE,
+                immediate. = TRUE
+              )
+            }
+          }
+        }
 
         if(!exists('transcripts') || inherits(transcripts, "try-error")) {
           hint <- ""
@@ -2873,6 +2908,12 @@ ReadXenium <- function(
 
         transcripts <- transcripts[, names(col.use)]
         colnames(transcripts) <- col.use
+
+        if (qv.wanted) {
+          keep <- !is.na(x = transcripts$qv) & transcripts$qv >= mols.qv.threshold
+          transcripts <- transcripts[keep, , drop = FALSE]
+          transcripts$qv <- NULL
+        }
 
         transcripts$gene <- binary_to_string(transcripts$gene)
 

--- a/tests/testthat/test_read_xenium_qv.R
+++ b/tests/testthat/test_read_xenium_qv.R
@@ -1,0 +1,71 @@
+set.seed(42)
+
+# ReadXenium accepts and documents `mols.qv.threshold`, but the quality column
+# was not among those read and no filtering was applied, so every threshold
+# returned the same transcripts.
+write_xenium <- function(dir, with.qv = TRUE, n = 200L, n.low = 60L) {
+  dir.create(dir, recursive = TRUE, showWarnings = FALSE)
+  transcripts <- data.frame(
+    x_location = runif(n) * 100,
+    y_location = runif(n) * 100,
+    feature_name = sample(paste0("gene", 1:5), n, replace = TRUE),
+    stringsAsFactors = FALSE
+  )
+  if (with.qv) {
+    transcripts$qv <- c(rep(5, n.low), rep(30, n - n.low))
+  }
+  con <- gzfile(file.path(dir, "transcripts.csv.gz"), "w")
+  write.csv(transcripts, con, row.names = FALSE)
+  close(con)
+  cells <- data.frame(
+    cell_id = paste0("cell", seq_len(20)),
+    x_centroid = runif(20) * 100,
+    y_centroid = runif(20) * 100,
+    stringsAsFactors = FALSE
+  )
+  con <- gzfile(file.path(dir, "cells.csv.gz"), "w")
+  write.csv(cells, con, row.names = FALSE)
+  close(con)
+  invisible(dir)
+}
+
+read_microns <- function(dir, ...) {
+  suppressWarnings(ReadXenium(dir, outs = "microns", type = "centroids", ...))$microns
+}
+
+test_that("mols.qv.threshold removes low-quality transcripts", {
+  dir <- write_xenium(tempfile("xenium"), n = 200L, n.low = 60L)
+  expect_equal(nrow(read_microns(dir, mols.qv.threshold = 0)), 200L)
+  expect_equal(nrow(read_microns(dir, mols.qv.threshold = 20)), 140L)
+  expect_equal(nrow(read_microns(dir, mols.qv.threshold = 40)), 0L)
+})
+
+test_that("different thresholds give different results", {
+  dir <- write_xenium(tempfile("xenium"))
+  expect_false(identical(
+    nrow(read_microns(dir, mols.qv.threshold = 0)),
+    nrow(read_microns(dir, mols.qv.threshold = 20))
+  ))
+})
+
+test_that("the returned columns are unchanged", {
+  dir <- write_xenium(tempfile("xenium"))
+  microns <- read_microns(dir, mols.qv.threshold = 20)
+  expect_identical(colnames(microns), c("x", "y", "gene"))
+  expect_false("qv" %in% colnames(microns))
+})
+
+test_that("outputs without a qv column still load, with a warning", {
+  dir <- write_xenium(tempfile("xenium"), with.qv = FALSE)
+  expect_warning(
+    ReadXenium(dir, outs = "microns", type = "centroids", mols.qv.threshold = 20),
+    "no 'qv' column|No 'qv' column"
+  )
+  expect_equal(nrow(read_microns(dir, mols.qv.threshold = 20)), 200L)
+})
+
+test_that("the default threshold filters", {
+  dir <- write_xenium(tempfile("xenium"), n = 200L, n.low = 60L)
+  # the documented default is 20
+  expect_equal(nrow(read_microns(dir)), 140L)
+})


### PR DESCRIPTION
Fixes #10155.

## The bug

`ReadXenium()` accepts `mols.qv.threshold`, documents it as removing low-quality transcript molecules, and `LoadXenium()` passes it through. It has no effect.

The reporter's reading of the code is exactly right: the quality column is not among those read, and nothing filters on it.

```r
col.use = c(
  x_location   = letters[24 + flip.xy],
  y_location   = letters[25 - flip.xy],
  feature_name = 'gene'
)
```

`grep -rn "mols.qv.threshold" R/` finds it only in the two signatures, the two doc blocks, and the pass-through from `LoadXenium()`. Never in a function body.

Nothing warns, so the result looks like filtered data. Anyone who has been relying on the documented default of 20 since the regression has been analysing unfiltered transcripts.

## Demonstration

Synthetic Xenium output, 200 molecules of which 60 are below the threshold:

| threshold | `main` | this PR |
| --- | --- | --- |
| 0 | 200 rows | 200 rows |
| 20 (the default) | **200 rows** | 140 rows |
| 40 | **200 rows** | 0 rows |

## The change

Read `qv` alongside the coordinates, drop the molecules below the threshold, then drop the column again so the returned frame keeps its current shape of `x`, `y`, `gene`. Nothing downstream sees a different structure.

Outputs without a quality column are handled both ways they can fail, since the three readers behave differently: `arrow` and `data.table::fread` select columns and error on a missing one, while `read.csv` returns a frame without it. Either way the transcripts are re-read without `qv` and a warning says the threshold was not applied, rather than filtering silently or failing on a missing column.

## Tests

New `tests/testthat/test_read_xenium_qv.R`, which writes a small synthetic Xenium directory rather than needing real output: thresholds of 0, 20 and 40 give 200, 140 and 0 molecules, different thresholds give different results, the returned columns are unchanged and carry no `qv`, an output without a `qv` column still loads and warns, and the documented default of 20 does filter.

Against `origin/main`: 5 failures. With this change: 9 passes. Full suite 536 passing; the 2 failures (`test_load_10X.R`) are present unchanged on `main` and are addressed separately in #10454. `R CMD check` Status OK.

## Note

This restores the documented behaviour. It does not revisit whether 20 is the right default, or whether `LoadXenium` should report how many molecules were dropped, both of which seem worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
