### PR TITLE
Recorrect SCT counts when a model sits above the shared depth

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- Fixed `PrepSCTFindMarkers` skipping the objects that need it most: after cells are removed, a model's observed median UMI can fall below the depth its `median_umi` records, and those objects were returned untouched with \dQuote{Minimum UMI unchanged}, after which `FindMarkers` refused to run on them with \dQuote{Object contains multiple models with unequal library sizes} ([#9130](https://github.com/satijalab/seurat/issues/9130))
+
 - Fixed `AddModuleScore` (and `CellCycleScoring`) on v5 objects with on-disk (e.g. BPCells) assays, where each layer was fully densified to an in-memory `dgCMatrix` before scoring; scoring now operates directly on the on-disk matrix
 - Fixed bug in `PercentageFeatureSet` where layer data was incorrectly retrieved prior to finding features with requested pattern ([#10438](https://github.com/satijalab/seurat/pull/10438))
 - Updated `as.SingleCellExperiment` to address conversion case where an object has both original and sketched assay / reductions (differing numbers of cells) ([#10419](https://github.com/satijalab/seurat/pull/10419))

--- a/R/differential_expression.R
+++ b/R/differential_expression.R
@@ -2217,7 +2217,9 @@ PrepSCTFindMarkers <- function(object, assay = "SCT", verbose = TRUE) {
   }
   model_median_umis <- SCTResults(object = object[[assay]], slot = "median_umi")
   min_median_umi <- min(unlist(x = observed_median_umis), na.rm = TRUE)
-  if (all(unlist(x = model_median_umis) > min_median_umi)){
+  # nothing to do only when every model already sits at the shared depth;
+  # models above it are exactly the ones FindMarkers() rejects
+  if (all(unlist(x = model_median_umis) == min_median_umi)){
     if (verbose){
       message("Minimum UMI unchanged. Skipping re-correction.")
     }

--- a/tests/testthat/test_differential_expression.R
+++ b/tests/testthat/test_differential_expression.R
@@ -416,6 +416,34 @@ if (is_not_cran_submission) {
     expect_true(all(is.finite(result_counts@x)))
   })
 
+  # subsetting cells lowers the observed median UMI of a model below the depth
+  # its stored median_umi records. PrepSCTFindMarkers() skipped those objects,
+  # and FindMarkers() then refused to run on them, so neither could be used
+  test_that("PrepSCTFindMarkers recorrects after cells are removed", {
+    attributes <- SCTResults(sct_merged[["SCT"]], slot = "cell.attributes")
+    lowest <- rownames(attributes[["model1.1"]])[
+      order(attributes[["model1.1"]][, "umi"])
+    ][1:10]
+    sct_subset <- subset(sct_merged, cells = c(rownames(attributes[["model1"]]), lowest))
+    observed <- sapply(
+      X = SCTResults(sct_subset[["SCT"]], slot = "cell.attributes"),
+      FUN = function(x) median(x[, "umi"])
+    )
+    # every stored median now sits above the shared depth
+    expect_true(all(unlist(SCTResults(sct_subset[["SCT"]], slot = "median_umi")) > min(observed)))
+
+    result <- PrepSCTFindMarkers(sct_subset, verbose = FALSE)
+    expect_equal(unname(unlist(SCTResults(result[["SCT"]], slot = "median_umi"))),
+                 rep(min(observed), 2))
+    Idents(result) <- rep(c("a", "b"), length.out = ncol(result))
+    expect_no_error(suppressWarnings(FindMarkers(result, ident.1 = "a", ident.2 = "b", verbose = FALSE)))
+  })
+
+  test_that("PrepSCTFindMarkers skips work when every model is at the shared depth", {
+    prepped <- PrepSCTFindMarkers(sct_merged, verbose = FALSE)
+    expect_message(PrepSCTFindMarkers(prepped), "Skipping re-correction")
+  })
+
   test_that("PrepSCTFindMarkers drops rows with NaN corrected counts", {
     sct_test <- sct_merged
     model_name <- "model1.1"


### PR DESCRIPTION
Fixes #9130, where `PrepSCTFindMarkers()` and `FindMarkers()` contradict each other and leave no way to run differential expression on the object:

```r
> sub <- PrepSCTFindMarkers(sub)
Minimum UMI unchanged. Skipping re-correction.
> FindMarkers(sub, ident.1 = "a", ident.2 = "b")
Error: Object contains multiple models with unequal library sizes.
Run `PrepSCTFindMarkers()` before running `FindMarkers()`.
```

## Cause

`PrepSCTFindMarkers()` returns early when

```r
all(unlist(x = model_median_umis) > min_median_umi)
```

`min_median_umi` is the smallest median UMI observed across the models' cells, and the models sitting **above** it are precisely the ones whose counts are on the wrong scale. So this skips the objects that need recorrecting. The test for "nothing to do" is equality: every model already at the shared depth. It was `==` until d97a5f6f.

`FindMarkers.SCTAssay()` meanwhile requires `model_median_umis == min(observed_median_umis)`, so an object that takes the early return is rejected by the very function it was being prepared for.

## When it is reached

Whenever cells are removed after `SCTransform`. The observed medians are recomputed from the remaining cells, while each model's `median_umi` keeps the depth recorded at fit time, so dropping low-UMI cells from one sample can put every stored median above the new minimum. That matches the reports in #9130: merge, SCTransform, then subset, and every subsequent `PrepSCTFindMarkers()` is a no-op.

## Test

Two tests on the existing two-model `sct_merged` fixture: subsetting to the ten lowest-UMI cells of one model puts both stored medians above the shared depth; after the fix `PrepSCTFindMarkers()` brings both to it and `FindMarkers()` runs. The second test pins the early return that should happen: an already-prepared object still reports `Skipping re-correction`.

Both fail without the change (3 failures) and pass with it. Full suite `NOT_CRAN=true`: 1183 passing, the only 2 failures being the pre-existing `Read10X_Image` ones fixed in #10454.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
