### PR TITLE
Recorrect the features and cells the counts assay still has

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- Fixed `PrepSCTFindMarkers` failing with \dQuote{subscript out of bounds} on objects whose features or cells were subset after `SCTransform`: an SCT model records what it was fit on, subsetting does not prune that record, and the counts assay was then indexed with features it no longer has ([#9112](https://github.com/satijalab/seurat/issues/9112))
+
 - Fixed `AddModuleScore` (and `CellCycleScoring`) on v5 objects with on-disk (e.g. BPCells) assays, where each layer was fully densified to an in-memory `dgCMatrix` before scoring; scoring now operates directly on the on-disk matrix
 - Fixed bug in `PercentageFeatureSet` where layer data was incorrectly retrieved prior to finding features with requested pattern ([#10438](https://github.com/satijalab/seurat/pull/10438))
 - Updated `as.SingleCellExperiment` to address conversion case where an object has both original and sketched assay / reductions (differing numbers of cells) ([#10419](https://github.com/satijalab/seurat/pull/10419))

--- a/R/differential_expression.R
+++ b/R/differential_expression.R
@@ -2265,6 +2265,20 @@ PrepSCTFindMarkers <- function(object, assay = "SCT", verbose = TRUE) {
   names(set_median_umi) <- levels(x = object[[assay]])
   set_median_umi <- as.list(set_median_umi)
   all_genes <- rownames(x = object[[assay]])
+  # features the SCT assay carries but the counts assay does not cannot be
+  # recorrected at all, and would silently come back as zeros
+  no.counts <- setdiff(x = all_genes, y = rownames(x = raw_umi))
+  if (length(x = no.counts) > 0) {
+    warning(
+      length(x = no.counts),
+      " features of assay '", assay, "' are not in assay '", umi.assay,
+      "' and cannot be recorrected, so their counts are set to zero: ",
+      paste(head(x = no.counts, n = 5L), collapse = ", "),
+      if (length(x = no.counts) > 5) ", ...",
+      call. = FALSE,
+      immediate. = TRUE
+    )
+  }
   # correct counts
   # Recorrect raw UMI counts for one SCT model at a shared target depth
   # We only recorrect genes whose fitted SCT parameters are all finite
@@ -2283,13 +2297,20 @@ PrepSCTFindMarkers <- function(object, assay = "SCT", verbose = TRUE) {
       is.finite(pars[, "log_umi"])
     ]
 
-    cells <- rownames(cell_attr[[model_name]])
+    # A model records the features and cells it was fit on, and subsetting the
+    # object does not prune that record, so a model can name features or cells
+    # that the counts assay no longer has. Recorrect what is still there.
+    valid_genes <- intersect(x = valid_genes, y = rownames(x = raw_umi))
+    cells <- intersect(
+      x = rownames(x = cell_attr[[model_name]]),
+      y = colnames(x = raw_umi)
+    )
     # Prepare input list for correct_counts function
     x <- list(
       model_str = model_str[[model_name]],
       arguments = arguments[[model_name]],
       model_pars_fit = as.matrix(pars[valid_genes, , drop = FALSE]),
-      cell_attr = cell_attr[[model_name]]
+      cell_attr = cell_attr[[model_name]][cells, , drop = FALSE]
     )
     # Retrieve raw UMI counts for valid genes and cells
     umi <- raw_umi[valid_genes, cells, drop = FALSE]

--- a/tests/testthat/test_differential_expression.R
+++ b/tests/testthat/test_differential_expression.R
@@ -416,6 +416,39 @@ if (is_not_cran_submission) {
     expect_true(all(is.finite(result_counts@x)))
   })
 
+  # models record the features and cells they were fit on, and subsetting does
+  # not prune that record, so PrepSCTFindMarkers indexed the counts assay with
+  # features it no longer has and failed with "subscript out of bounds"
+  test_that("PrepSCTFindMarkers works after features are removed", {
+    kept <- rownames(sct_merged[["SCT"]])[1:50]
+    sct_subset <- subset(sct_merged, features = kept)
+    expect_true(any(!rownames(SCTResults(sct_subset[["SCT"]], slot = "feature.attributes")[[1]]) %in%
+                      rownames(sct_subset[["RNA"]])))
+
+    result <- expect_no_error(PrepSCTFindMarkers(sct_subset, verbose = FALSE))
+    full <- PrepSCTFindMarkers(sct_merged, verbose = FALSE)
+
+    # the retained features are corrected exactly as they are on the full object
+    expect_equal(
+      as.matrix(GetAssayData(result, assay = "SCT", layer = "counts")),
+      as.matrix(GetAssayData(full, assay = "SCT", layer = "counts")[rownames(result[["SCT"]]), colnames(result)])
+    )
+  })
+
+  test_that("PrepSCTFindMarkers works when a model names cells the object lost", {
+    sct_test <- sct_merged
+    model <- slot(sct_test[["SCT"]], name = "SCTModel.list")[["model1"]]
+    attributes <- slot(model, name = "cell.attributes")
+    # a cell the counts assay does not have
+    ghost <- attributes[1, , drop = FALSE]
+    rownames(ghost) <- "ghost_cell"
+    slot(slot(sct_test[["SCT"]], name = "SCTModel.list")[["model1"]],
+         name = "cell.attributes") <- rbind(attributes, ghost)
+
+    result <- expect_no_error(PrepSCTFindMarkers(sct_test, verbose = FALSE))
+    expect_identical(colnames(result), colnames(sct_test))
+  })
+
   test_that("PrepSCTFindMarkers drops rows with NaN corrected counts", {
     sct_test <- sct_merged
     model_name <- "model1.1"


### PR DESCRIPTION
Fixes #9112, `subscript out of bounds` from `PrepSCTFindMarkers()`.

## Cause

An SCT model records the features and cells it was fit on, and subsetting the object does not prune that record. `my.correct_counts()` then indexes the counts assay with the model's features:

```r
umi <- raw_umi[valid_genes, cells, drop = FALSE]
```

so as soon as a feature named by the model is no longer in the counts assay, indexing fails:

```r
> sub <- subset(obj, features = rownames(obj)[1:50])
> PrepSCTFindMarkers(sub)
Found 2 SCT models. Recorrecting SCT counts using minimum median counts: 143
Error in .subscript.2ary(x, i, j, drop = TRUE) : subscript out of bounds
```

That is the error in the report, and it arrives at the same place, just as the progress bar starts.

## Fix

Intersect the model's features and cells with the counts assay before indexing it, and subset `cell.attributes` to match so it still lines up with the umi matrix column for column.

Recorrected values do not change: `correct_counts()` works per gene from that gene's fitted parameters, so a gene corrects identically whether or not its neighbours are present. The test asserts this, comparing against the full-object recorrection on the retained genes.

Features that the **SCT** assay carries but the counts assay does not are a different matter, since those come back as zeros rather than being skipped. That case now warns and names them instead of passing silently.

## Tests

Three cases, all on the existing two-model `sct_merged` fixture: features removed (the reported failure, plus equality with the full-object recorrection), and a model naming a cell the object no longer has, which is the same failure through the other index.

Both fail without the change and pass with it. Full suite `NOT_CRAN=true`: 1184 passing, the only 2 failures being the pre-existing `Read10X_Image` ones fixed in #10454.

## Note

#10468 fixes a second, independent way `PrepSCTFindMarkers()` fails after subsetting. The two do not overlap; this one is the hard error, that one is the silent skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
