### PR TITLE
Send each worker its block of the data, not the whole matrix

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- `ScaleData` now sends each worker its own block of the data instead of exporting the whole matrix to every worker, which on a moderately sized object exceeds `future.globals.maxSize` before any work starts ([#10420](https://github.com/satijalab/seurat/issues/10420))
+
 - Fixed `ScaleData` giving cells another cell's values when `split.by` is used: the splits were bound back together in split order and the dimnames were then overwritten with the object's own order. This affected every cell whose position moved, with more than one worker, or with any plan when `vars.to.regress` is also given
 
 - Fixed `AddModuleScore` (and `CellCycleScoring`) on v5 objects with on-disk (e.g. BPCells) assays, where each layer was fully densified to an in-memory `dgCMatrix` before scoring; scoring now operates directly on the on-disk matrix

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- Fixed `ScaleData` giving cells another cell's values when `split.by` is used: the splits were bound back together in split order and the dimnames were then overwritten with the object's own order. This affected every cell whose position moved, with more than one worker, or with any plan when `vars.to.regress` is also given
+
 - Fixed `AddModuleScore` (and `CellCycleScoring`) on v5 objects with on-disk (e.g. BPCells) assays, where each layer was fully densified to an in-memory `dgCMatrix` before scoring; scoring now operates directly on the on-disk matrix
 - Fixed bug in `PercentageFeatureSet` where layer data was incorrectly retrieved prior to finding features with requested pattern ([#10438](https://github.com/satijalab/seurat/pull/10438))
 - Updated `as.SingleCellExperiment` to address conversion case where an object has both original and sketched assay / reductions (differing numbers of cells) ([#10419](https://github.com/satijalab/seurat/pull/10419))

--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -5075,6 +5075,59 @@ NormalizeData.Seurat <- function(
   object <- LogSeuratCommand(object = object)
   return(object)
 }
+# Regress latent variables out of one block of data
+#
+# Defined at package level rather than as a closure inside ScaleData.default():
+# a closure created there carries that frame as its environment, and the frame
+# holds the full matrix, so `future` exports the whole dataset to every worker
+# no matter how the data is chunked.
+#
+# @param block A list with the block of data and its latent data
+# @param features.regress Features to regress
+# @param model.use Model to use
+# @param use.umi Regress on UMI count data
+#
+# @return The block with the latent variables regressed out
+#
+.RegressOutBlock <- function(block, features.regress, model.use, use.umi) {
+  return(RegressOutMatrix(
+    data.expr = block$data,
+    latent.data = block$latent,
+    features.regress = features.regress,
+    model.use = model.use,
+    use.umi = use.umi,
+    verbose = FALSE
+  ))
+}
+
+# Center and scale one block of data
+#
+# Defined at package level for the same reason as .RegressOutBlock()
+#
+# @param mat One block of the data
+# @param scale.function The scaling function to apply
+# @param do.scale Scale the data
+# @param do.center Center the data
+# @param scale.max Maximum value in the scaled data
+#
+# @return The scaled block
+#
+.ScaleBlock <- function(mat, scale.function, do.scale, do.center, scale.max) {
+  arg.list <- list(
+    mat = mat,
+    scale = do.scale,
+    center = do.center,
+    scale_max = scale.max,
+    display_progress = FALSE
+  )
+  arg.list <- arg.list[intersect(x = names(x = arg.list), y = names(x = formals(fun = scale.function)))]
+  data.scale <- do.call(what = scale.function, args = arg.list)
+  dimnames(x = data.scale) <- dimnames(x = mat)
+  suppressWarnings(expr = data.scale[is.na(x = data.scale)] <- 0)
+  CheckGC()
+  return(data.scale)
+}
+
 
 #' @importFrom future nbrOfWorkers
 #'
@@ -5177,22 +5230,29 @@ ScaleData.default <- function(
         1:ncol(x = chunk.points),
         stringsAsFactors = FALSE
       )
-      object <- future_lapply(
-        X = 1:nrow(x = chunks),
+      # Split the data before dispatching. Chunking inside the worker function
+      # made it reference `object`, so `future` exported the whole matrix to
+      # every worker rather than each worker receiving its own block
+      blocks <- lapply(
+        X = seq_len(length.out = nrow(x = chunks)),
         FUN = function(i) {
           row <- chunks[i, ]
           group <- row[[1]]
           index <- as.numeric(x = row[[2]])
-          return(RegressOutMatrix(
-            data.expr = object[chunk.points[1, index]:chunk.points[2, index], split.cells[[group]], drop = FALSE],
-            latent.data = latent.data[split.cells[[group]], , drop = FALSE],
-            features.regress = features,
-            model.use = model.use,
-            use.umi = use.umi,
-            verbose = FALSE
+          return(list(
+            data = object[chunk.points[1, index]:chunk.points[2, index], split.cells[[group]], drop = FALSE],
+            latent = latent.data[split.cells[[group]], , drop = FALSE]
           ))
         }
       )
+      object <- future_lapply(
+        X = blocks,
+        FUN = .RegressOutBlock,
+        features.regress = features,
+        model.use = model.use,
+        use.umi = use.umi
+      )
+      rm(blocks)
       if (length(x = split.cells) > 1) {
         merge.indices <- lapply(
           X = 1:length(x = split.cells),
@@ -5265,27 +5325,26 @@ ScaleData.default <- function(
       1:ncol(x = blocks),
       stringsAsFactors = FALSE
     )
-    scaled.data <- future_lapply(
-      X = 1:nrow(x = chunks),
+    # Split the data before dispatching, so that each worker receives its own
+    # block instead of the whole matrix (see .RegressOutBlock above)
+    chunk.data <- lapply(
+      X = seq_len(length.out = nrow(x = chunks)),
       FUN = function(index) {
         row <- chunks[index, ]
         group <- row[[1]]
         block <- as.vector(x = blocks[, as.numeric(x = row[[2]])])
-        arg.list <- list(
-          mat = object[features[block[1]:block[2]], split.cells[[group]], drop = FALSE],
-          scale = do.scale,
-          center = do.center,
-          scale_max = scale.max,
-          display_progress = FALSE
-        )
-        arg.list <- arg.list[intersect(x = names(x = arg.list), y = names(x = formals(fun = scale.function)))]
-        data.scale <- do.call(what = scale.function, args = arg.list)
-        dimnames(x = data.scale) <- dimnames(x = object[features[block[1]:block[2]], split.cells[[group]]])
-        suppressWarnings(expr = data.scale[is.na(x = data.scale)] <- 0)
-        CheckGC()
-        return(data.scale)
+        return(object[features[block[1]:block[2]], split.cells[[group]], drop = FALSE])
       }
     )
+    scaled.data <- future_lapply(
+      X = chunk.data,
+      FUN = .ScaleBlock,
+      scale.function = scale.function,
+      do.scale = do.scale,
+      do.center = do.center,
+      scale.max = scale.max
+    )
+    rm(chunk.data)
     if (length(x = split.cells) > 1) {
       merge.indices <- lapply(
         X = 1:length(x = split.cells),

--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -5207,6 +5207,9 @@ ScaleData.default <- function(
           }
         )
         object <- do.call(what = 'cbind', args = object)
+        # cbind puts the cells in split order, and dimnames are overwritten
+        # with the object's order further down, so put the cells back first
+        object <- object[, match(x = object.names[[2]], table = unlist(x = split.cells, use.names = FALSE)), drop = FALSE]
       } else {
         object <- do.call(what = 'rbind', args = object)
       }
@@ -5228,6 +5231,8 @@ ScaleData.default <- function(
         }
       )
       object <- do.call(what = 'cbind', args = object)
+      # as above, cbind puts the cells in split order
+      object <- object[, match(x = object.names[[2]], table = unlist(x = split.cells, use.names = FALSE)), drop = FALSE]
     }
     dimnames(x = object) <- object.names
     CheckGC()
@@ -5295,6 +5300,9 @@ ScaleData.default <- function(
         }
       )
       scaled.data <- suppressWarnings(expr = do.call(what = 'cbind', args = scaled.data))
+      # cbind puts the cells in split order, and dimnames are overwritten with
+      # the object's order further down, so put the cells back first
+      scaled.data <- scaled.data[, match(x = object.names[[2]], table = unlist(x = split.cells, use.names = FALSE)), drop = FALSE]
     } else {
       suppressWarnings(expr = scaled.data <- do.call(what = 'rbind', args = scaled.data))
     }

--- a/tests/testthat/test_scaledata_parallel.R
+++ b/tests/testthat/test_scaledata_parallel.R
@@ -1,0 +1,98 @@
+set.seed(42)
+
+# ScaleData chunks the data across workers, but the worker functions used to
+# reference `object`, so `future` exported the whole matrix to every worker
+# instead of each worker receiving its own block. That is what runs into
+# future.globals.maxSize, and what makes every worker hold the whole dataset.
+make_object <- function(nfeat = 200L, ncell = 2000L) {
+  counts <- as.sparse(matrix(rpois(nfeat * ncell, lambda = 2), nrow = nfeat))
+  dimnames(counts) <- list(
+    paste0("gene", seq_len(nfeat)),
+    paste0("c", seq_len(ncell))
+  )
+  object <- suppressWarnings(CreateSeuratObject(counts = counts))
+  object$group <- rep(c("a", "b"), length.out = ncell)
+  suppressWarnings(NormalizeData(object, verbose = FALSE))
+}
+
+with_workers <- function(n, expr) {
+  old.plan <- future::plan()
+  on.exit(future::plan(old.plan), add = TRUE)
+  future::plan("multicore", workers = n)
+  force(expr)
+}
+
+scaled <- function(object, ...) {
+  LayerData(suppressWarnings(ScaleData(object, verbose = FALSE, ...)), layer = "scale.data")
+}
+
+test_that("parallel scaling matches sequential", {
+  skip_on_os("windows")
+  skip_if_not(future::supportsMulticore())
+  object <- make_object()
+  future::plan("sequential")
+  sequential <- scaled(object)
+  parallel <- with_workers(4, scaled(object))
+  expect_equal(parallel, sequential)
+
+  # and with the data split, which is the other chunking dimension
+  future::plan("sequential")
+  sequential.split <- scaled(object, split.by = "group")
+  parallel.split <- with_workers(4, scaled(object, split.by = "group"))
+  expect_equal(parallel.split, sequential.split)
+})
+
+test_that("parallel regression matches sequential", {
+  skip_on_os("windows")
+  skip_if_not(future::supportsMulticore())
+  object <- make_object(nfeat = 60L, ncell = 400L)
+  future::plan("sequential")
+  sequential <- scaled(object, vars.to.regress = "nCount_RNA")
+  parallel <- with_workers(4, scaled(object, vars.to.regress = "nCount_RNA"))
+  expect_equal(parallel, sequential)
+})
+
+# The size future reports when the limit is exceeded, in bytes
+exported_size <- function(object, workers = 4, ...) {
+  old.opt <- options(future.globals.maxSize = 1024)
+  on.exit(options(old.opt), add = TRUE)
+  message <- tryCatch(
+    with_workers(workers, scaled(object, ...)),
+    error = function(e) conditionMessage(e)
+  )
+  matched <- regmatches(message, regexpr("is [0-9.]+ [KMG]iB", message))
+  if (!length(matched)) {
+    return(NA_real_)
+  }
+  parts <- strsplit(sub("^is ", "", matched), " ")[[1]]
+  as.numeric(parts[1]) * switch(parts[2], KiB = 1024, MiB = 1024^2, GiB = 1024^3)
+}
+
+test_that("what is sent to workers does not grow with the data", {
+  skip_on_os("windows")
+  skip_if_not(future::supportsMulticore())
+  small <- make_object(nfeat = 200L, ncell = 1000L)
+  large <- make_object(nfeat = 200L, ncell = 8000L)
+  small.data <- as.numeric(object.size(LayerData(small, layer = "data")))
+  large.data <- as.numeric(object.size(LayerData(large, layer = "data")))
+  expect_gt(large.data, small.data * 4)
+
+  small.exported <- exported_size(small)
+  large.exported <- exported_size(large)
+  expect_false(is.na(small.exported))
+  expect_false(is.na(large.exported))
+  # the worker function is a constant; the data travels as chunks, one block
+  # per worker, rather than as a global carrying the entire matrix
+  expect_equal(large.exported, small.exported)
+  expect_lt(large.exported, large.data)
+})
+
+test_that("the sequential path is unchanged", {
+  future::plan("sequential")
+  object <- make_object(nfeat = 50L, ncell = 100L)
+  data <- as.matrix(LayerData(object, layer = "data"))
+  expected <- t(scale(t(data)))
+  expected[expected > 10] <- 10
+  # scale() leaves its centre and scale behind as attributes
+  expect_equal(as.vector(scaled(object)), as.vector(expected), tolerance = 1e-6)
+})

--- a/tests/testthat/test_scaledata_split.R
+++ b/tests/testthat/test_scaledata_split.R
@@ -1,0 +1,63 @@
+set.seed(42)
+
+# With split.by and more than one worker, ScaleData assembled the result by
+# binding the splits together, which puts the cells in split order, and then
+# overwrote the dimnames with the object's own order. Every cell whose position
+# moved was given another cell's scaled values.
+make_object <- function(nfeat = 40L, ncell = 200L) {
+  counts <- as.sparse(matrix(rpois(nfeat * ncell, lambda = 3), nrow = nfeat))
+  dimnames(counts) <- list(
+    paste0("gene", seq_len(nfeat)),
+    paste0("c", seq_len(ncell))
+  )
+  object <- suppressWarnings(CreateSeuratObject(counts = counts))
+  object$group <- rep(c("a", "b"), length.out = ncell)
+  suppressWarnings(NormalizeData(object, verbose = FALSE))
+}
+
+with_workers <- function(n, expr) {
+  old.plan <- future::plan()
+  on.exit(future::plan(old.plan), add = TRUE)
+  future::plan("multicore", workers = n)
+  force(expr)
+}
+
+scaled <- function(object, ...) {
+  LayerData(suppressWarnings(ScaleData(object, verbose = FALSE, ...)), layer = "scale.data")
+}
+
+test_that("split.by scaling gives each cell its own values in parallel", {
+  skip_on_os("windows")
+  skip_if_not(future::supportsMulticore())
+  object <- make_object()
+  future::plan("sequential")
+  sequential <- scaled(object, split.by = "group")
+  parallel <- with_workers(2, scaled(object, split.by = "group"))
+  expect_equal(parallel, sequential)
+
+  # each cell's values are its own, computed within its own split
+  cells.a <- colnames(object)[object$group == "a"]
+  within.a <- scaled(object[, cells.a])
+  expect_equal(parallel[, cells.a], within.a[rownames(parallel), cells.a])
+})
+
+test_that("split.by regression gives each cell its own values in parallel", {
+  skip_on_os("windows")
+  skip_if_not(future::supportsMulticore())
+  object <- make_object(nfeat = 30L, ncell = 120L)
+  future::plan("sequential")
+  sequential <- scaled(object, split.by = "group", vars.to.regress = "nCount_RNA")
+  parallel <- with_workers(2, scaled(object, split.by = "group", vars.to.regress = "nCount_RNA"))
+  expect_equal(parallel, sequential)
+})
+
+# the same assembly runs without any workers when variables are regressed out,
+# so that path mislabels cells whatever the plan
+test_that("split.by regression gives each cell its own values", {
+  future::plan("sequential")
+  object <- make_object(nfeat = 30L, ncell = 120L)
+  result <- scaled(object, split.by = "group", vars.to.regress = "nCount_RNA")
+  cells.a <- colnames(object)[object$group == "a"]
+  within.a <- scaled(object[, cells.a], vars.to.regress = "nCount_RNA")
+  expect_equal(result[, cells.a], within.a[rownames(result), cells.a])
+})


### PR DESCRIPTION
`ScaleData()` exports the whole matrix to every worker, whatever the chunking.

**Based on #10470** (`ScaleData` mislabelling cells under `split.by`), which touches the same block and should go in first; this branch is that one plus one commit. If you would rather have them apart, say so and I will restructure.

## Cause

The worker functions are closures created inside `ScaleData.default()`, so they carry that frame as their environment, and the frame holds the full matrix. The chunking happens inside the worker, so the chunk boundaries are all that changes per task; the data itself is a global. Both parallel paths do this, scaling and regressing variables out.

The visible symptom is the run stopping before any work is done:

```
Error: The total size of the 5 globals exported for future expression ('FUN()')
is 1.09 GiB. This exceeds the maximum allowed size 500.00 MiB
```

and, when the limit is raised enough to get past it, every worker holding a copy of the whole dataset. This is the same failure I hit while trying to reproduce #10420, and the same shape as #10459 for `NormalizeData`.

## Fix

Split the data before dispatching and pass the blocks as `X`, with the work moved into package-level `.ScaleBlock()` and `.RegressOutBlock()` so that what is exported is a constant. Each worker then receives only its own block.

## Tests

`tests/testthat/test_scaledata_parallel.R`: parallel scaling equals sequential, with and without `split.by`; parallel regression equals sequential; the size `future` reports as exported does not grow with the data (measured by setting `future.globals.maxSize` to 1 KiB and reading the reported size out of the error, 8x data gives the same exported size); and the sequential result still matches `t(scale(t(data)))`.

The size tests fail without the change and pass with it. Full suite `NOT_CRAN=true`: 1192 passing, the only 2 failures being the pre-existing `Read10X_Image` ones fixed in #10454.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
