### PR TITLE
Keep the metadata column ReadNanostring was asked for

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- Fixed `ReadNanostring` returning nothing usable when a single `metadata` column is requested, and deciding whether the counts are sparse from the number of columns rather than the number of values ([#8812](https://github.com/satijalab/seurat/issues/8812))
+
 - Fixed `AddModuleScore` (and `CellCycleScoring`) on v5 objects with on-disk (e.g. BPCells) assays, where each layer was fully densified to an in-memory `dgCMatrix` before scoring; scoring now operates directly on the on-disk matrix
 - Fixed bug in `PercentageFeatureSet` where layer data was incorrectly retrieved prior to finding features with requested pattern ([#10438](https://github.com/satijalab/seurat/pull/10438))
 - Updated `as.SingleCellExperiment` to address conversion case where an object has both original and sketched assay / reductions (differing numbers of cells) ([#10419](https://github.com/satijalab/seurat/pull/10419))

--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -2460,7 +2460,8 @@ ReadNanostring <- function(
         tx <- tx[, which(colSums(tx) != 0)]
         ratio <- getOption(x = 'Seurat.input.sparse_ratio', default = 0.4)
 
-        if ((sum(tx == 0) / length(x = tx)) > ratio) {
+        # tx is a data frame here, so length() is its number of columns
+        if ((sum(tx == 0) / prod(dim(x = tx))) > ratio) {
           ptx(
             message = 'Converting counts to sparse matrix',
             class = 'sticky',
@@ -2511,7 +2512,9 @@ ReadNanostring <- function(
           amount = 0
         )
         pmeta(type = 'finish')
-        df <- md[,metadata]
+        # a single column would otherwise come back as a vector, and the cell
+        # names assigned just below would be dropped
+        df <- md[, metadata, drop = FALSE]
         df$cell <- paste0(as.character(md$cell_ID), "_", md$fov)
         df
       },

--- a/tests/testthat/test_read_nanostring.R
+++ b/tests/testthat/test_read_nanostring.R
@@ -1,0 +1,114 @@
+set.seed(7)
+
+# Writes a small CosMx export: an expression matrix, per cell metadata,
+# transcript coordinates and cell boundaries, named the way ReadNanostring
+# looks for them
+write_cosmx <- function(dir, ncell = 6L, ngene = 12L, fovs = 1:2) {
+  dir.create(path = dir, showWarnings = FALSE, recursive = TRUE)
+  genes <- paste0("Gene", seq_len(ngene))
+  grid <- expand.grid(cell_ID = seq_len(ncell), fov = fovs)
+  counts <- function(n) {
+    as.data.frame(matrix(
+      rpois(n * ngene, lambda = 3),
+      ncol = ngene,
+      dimnames = list(NULL, genes)
+    ))
+  }
+  expression <- cbind(grid[, c("fov", "cell_ID")], counts(nrow(grid)))
+  # molecules not assigned to a cell are recorded against cell_ID 0
+  unassigned <- cbind(data.frame(fov = fovs, cell_ID = 0), counts(length(fovs)))
+  write.csv(rbind(expression, unassigned), file.path(dir, "run_exprMat_file.csv"), row.names = FALSE)
+
+  metadata <- data.frame(
+    fov = grid$fov,
+    cell_ID = grid$cell_ID,
+    Area = runif(nrow(grid), 100, 200),
+    CenterX_global_px = runif(nrow(grid), 0, 1000),
+    CenterY_global_px = runif(nrow(grid), 0, 1000)
+  )
+  write.csv(metadata, file.path(dir, "run_metadata_file.csv"), row.names = FALSE)
+
+  write.csv(
+    data.frame(
+      fov = rep(grid$fov, each = 5),
+      cell_ID = rep(grid$cell_ID, each = 5),
+      x_global_px = runif(nrow(grid) * 5, 0, 1000),
+      y_global_px = runif(nrow(grid) * 5, 0, 1000),
+      target = sample(genes, nrow(grid) * 5, replace = TRUE)
+    ),
+    file.path(dir, "run_tx_file.csv"),
+    row.names = FALSE
+  )
+
+  boundaries <- do.call(what = rbind, args = lapply(
+    X = seq_len(nrow(grid)),
+    FUN = function(i) {
+      angle <- seq(0, 2 * pi, length.out = 9)[1:8]
+      data.frame(
+        fov = grid$fov[i],
+        cellID = grid$cell_ID[i],
+        x_global_px = metadata$CenterX_global_px[i] + 10 * cos(angle),
+        y_global_px = metadata$CenterY_global_px[i] + 10 * sin(angle)
+      )
+    }
+  ))
+  write.csv(boundaries, file.path(dir, "run-polygons.csv"), row.names = FALSE)
+  metadata
+}
+
+test_that("ReadNanostring reads a CosMx export", {
+  skip_if_not_installed("data.table")
+  dir <- file.path(tempdir(), "cosmx")
+  on.exit(unlink(dir, recursive = TRUE), add = TRUE)
+  write_cosmx(dir)
+
+  data <- ReadNanostring(data.dir = dir, type = c("centroids", "segmentations"))
+  expect_equal(dim(data$matrix), c(12L, 12L))
+  expect_identical(rownames(data$matrix), paste0("Gene", 1:12))
+  # cells are named cell_ID_fov, and the unassigned rows are dropped
+  expect_identical(colnames(data$matrix), paste0(rep(1:6, 2), "_", rep(1:2, each = 6)))
+  expect_setequal(data$centroids$cell, colnames(data$matrix))
+})
+
+# md[, metadata] drops to a vector when one column is asked for, and the cell
+# names assigned to it afterwards went nowhere
+test_that("ReadNanostring returns a single metadata column with its cells", {
+  skip_if_not_installed("data.table")
+  dir <- file.path(tempdir(), "cosmx-metadata")
+  on.exit(unlink(dir, recursive = TRUE), add = TRUE)
+  written <- write_cosmx(dir)
+
+  one <- ReadNanostring(data.dir = dir, metadata = "Area")$metadata
+  expect_identical(colnames(one), c("Area", "cell"))
+  expect_setequal(one$cell, paste0(written$cell_ID, "_", written$fov))
+
+  two <- ReadNanostring(data.dir = dir, metadata = c("Area", "fov"))$metadata
+  expect_identical(colnames(two), c("Area", "fov", "cell"))
+  expect_equal(one$Area, two$Area)
+})
+
+# the denominator was length(), which for a data frame is its column count, so
+# the zero fraction was compared against the wrong total
+test_that("dense counts are left dense", {
+  skip_if_not_installed("data.table")
+  dir <- file.path(tempdir(), "cosmx-dense")
+  on.exit(unlink(dir, recursive = TRUE), add = TRUE)
+  # lambda 3 gives about 5% zeros, well under the 0.4 ratio
+  write_cosmx(dir, ncell = 20L, ngene = 30L)
+
+  data <- ReadNanostring(data.dir = dir)
+  expect_lt(sum(data$matrix == 0) / prod(dim(data$matrix)), 0.4)
+  expect_false(inherits(data$matrix, "sparseMatrix"))
+})
+
+test_that("LoadNanostring builds an object with a matching field of view", {
+  skip_if_not_installed("data.table")
+  dir <- file.path(tempdir(), "cosmx-load")
+  on.exit(unlink(dir, recursive = TRUE), add = TRUE)
+  write_cosmx(dir)
+
+  object <- suppressWarnings(LoadNanostring(data.dir = dir, fov = "test"))
+  expect_identical(Images(object), "test")
+  expect_setequal(Cells(object[["test"]]), colnames(object))
+  expect_identical(rownames(object), paste0("Gene", 1:12))
+})


### PR DESCRIPTION
Two defects in `ReadNanostring`, found while working on #8812.

## A requested metadata column comes back empty

```r
> colnames(ReadNanostring(data.dir = d, metadata = "Area")$metadata)
character(0)
```

`md[, metadata]` drops to a vector when one column is asked for, so `df$cell <- ...` on the next line has nothing to attach to and the caller receives a metadata frame with no columns. `drop = FALSE`.

## Dense counts are always made sparse

```r
(sum(tx == 0) / length(x = tx)) > ratio
```

`tx` is a data frame at that point, so `length()` is its number of **columns**, not its number of values. The zero fraction comes out roughly `nrow` times too large, so the test passes whatever the data holds and dense counts are converted regardless. The two other readers run the same test on a matrix, where `length()` is correct, so only this one is affected.

## Tests

`tests/testthat/test_read_nanostring.R` writes a CosMx export to a temporary directory (expression matrix including the `cell_ID == 0` rows, per cell metadata, transcript coordinates, cell boundaries), so it needs no vendor data. It covers both defects plus the basic read and `LoadNanostring`, and pins the cell naming (`cell_ID_fov`) and the dropping of unassigned rows.

Three assertions fail without the change. Full suite `NOT_CRAN=true`: 1192 passing, the only 2 failures being the pre-existing `Read10X_Image` ones fixed in #10454.

## On the rest of #8812

The reporter's other two symptoms are separate. The `less than 4 coordinates in polygon` warnings are addressed in satijalab/seurat-object#303, which names the cells instead of leaving two anonymous `sp` warnings. The missing dimnames I could not reproduce from a well-formed export; a fixture built to the documented layout reads back with the correct row and column names, which this test now pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
