### PR TITLE
Choose variable features from the ones that were scaled

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@
 
 ### Fixes
 
+- Fixed `SCTransform` on a split assay returning variable features that have no residuals, so that `RunPCA` warned they had not been scaled and ran without them; variable features are now chosen from the features that were scaled ([#8880](https://github.com/satijalab/seurat/issues/8880))
+- Fixed `SCTransform` failing on a split assay with `variable.features.n = NULL` and a `variable.features.rv.th` cutoff ([#9189](https://github.com/satijalab/seurat/issues/9189))
+
 - Fixed `AddModuleScore` (and `CellCycleScoring`) on v5 objects with on-disk (e.g. BPCells) assays, where each layer was fully densified to an in-memory `dgCMatrix` before scoring; scoring now operates directly on the on-disk matrix
 - Fixed bug in `PercentageFeatureSet` where layer data was incorrectly retrieved prior to finding features with requested pattern ([#10438](https://github.com/satijalab/seurat/pull/10438))
 - Updated `as.SingleCellExperiment` to address conversion case where an object has both original and sketched assay / reductions (differing numbers of cells) ([#10419](https://github.com/satijalab/seurat/pull/10419))

--- a/R/preprocessing5.R
+++ b/R/preprocessing5.R
@@ -1235,12 +1235,31 @@ SCTransform.StdAssay <- function(
   )
   LayerData(assay_out, layer = "scale.data") <- residuals
 
-  # Set the output's variable features.
-  VariableFeatures(assay_out) <- VariableFeatures(
-    assay_out, 
-    use.var.features = FALSE,
-    nfeatures = variable.features.n
-  )
+  # Set the output's variable features. A variable feature with no residuals is
+  # dropped by everything downstream, silently apart from a PrepDR warning, so
+  # choose them from the features that were actually scaled.
+  scaled.features <- rownames(x = residuals)
+  if (is.null(x = variable.features.n)) {
+    # each layer chose its own features by residual variance threshold, so
+    # there is no number of features to rank down to; keep what they chose
+    variable.features <- Reduce(
+      f = union,
+      x = lapply(X = output_list, FUN = VariableFeatures)
+    )
+    VariableFeatures(assay_out) <- variable.features[
+      variable.features %in% scaled.features
+    ]
+  } else {
+    ranked <- VariableFeatures(
+      assay_out, 
+      use.var.features = FALSE,
+      nfeatures = nrow(x = assay_out)
+    )
+    VariableFeatures(assay_out) <- head(
+      x = ranked[ranked %in% scaled.features],
+      n = variable.features.n
+    )
+  }
 
   return (assay_out)
 }

--- a/tests/testthat/test_sctransform_variable_features.R
+++ b/tests/testthat/test_sctransform_variable_features.R
@@ -1,0 +1,54 @@
+set.seed(42)
+
+# SCTransform on a split assay picks its variable features from the union of
+# what the layers chose, but only features present in every layer are scaled.
+# Features variable in one layer and absent from another were returned as
+# variable while having no residuals, so PrepDR dropped them from PCA.
+split_object <- function() {
+  data("pbmc_small", package = "SeuratObject", envir = environment())
+  object <- pbmc_small
+  object$stim <- rep(c("CTRL", "STIM"), length.out = ncol(object))
+  object[["RNA"]] <- split(object[["RNA"]], f = object$stim)
+  object
+}
+
+test_that("every variable feature has been scaled", {
+  skip_if_not_installed("sctransform")
+  object <- suppressWarnings(SCTransform(split_object(), verbose = FALSE))
+  scaled <- rownames(LayerData(object[["SCT"]], layer = "scale.data"))
+  expect_gt(length(VariableFeatures(object)), 0)
+  expect_true(all(VariableFeatures(object) %in% scaled))
+  # and PCA runs on all of them, rather than warning that some were not scaled
+  warnings <- testthat::capture_warnings(RunPCA(object, npcs = 5, verbose = FALSE))
+  expect_false(any(grepl("have not been scaled", warnings)))
+})
+
+test_that("a feature missing from one layer is not returned as variable", {
+  skip_if_not_installed("sctransform")
+  object <- split_object()
+  counts <- LayerData(object, layer = "counts.CTRL")
+  # silence genes in one batch only, so that layer's model has nothing for them
+  silenced <- rownames(counts)[1:20]
+  counts[silenced, ] <- 0
+  LayerData(object, layer = "counts.CTRL") <- counts
+
+  object <- suppressWarnings(SCTransform(object, verbose = FALSE))
+  scaled <- rownames(LayerData(object[["SCT"]], layer = "scale.data"))
+  expect_true(all(VariableFeatures(object) %in% scaled))
+})
+
+# variable.features.n = NULL selects by residual variance threshold instead of
+# by count, and asking for zero features errored
+test_that("SCTransform accepts a residual variance threshold on split data", {
+  skip_if_not_installed("sctransform")
+  object <- expect_no_error(suppressWarnings(SCTransform(
+    split_object(),
+    vst.flavor = "v2",
+    variable.features.n = NULL,
+    variable.features.rv.th = 1.3,
+    verbose = FALSE
+  )))
+  scaled <- rownames(LayerData(object[["SCT"]], layer = "scale.data"))
+  expect_gt(length(VariableFeatures(object)), 0)
+  expect_true(all(VariableFeatures(object) %in% scaled))
+})


### PR DESCRIPTION
Fixes #8880 and #9189, both about which variable features come out of `SCTransform` on a split assay.

## Variable features that were never scaled (#8880)

The features are ranked over the union of what the layers chose, but only features present in **every** layer are scaled:

```r
scale_data_features <- intersect(all_features_intersect, var_features_union)
```

So a feature that is variable in one layer and absent from another is returned as variable while having no residuals. `PrepDR` warns, `RunPCA` runs without it, and the object keeps claiming it as variable:

```
> s <- SCTransform(split.object)
variable features: 191   in scale.data: 155   missing: 36
```

That is `pbmc_small` split in two, not a contrived object; the reporter counted 47 on their own data, and others in the thread 149.

The fix selects the variable features from the rows of the residual matrix, which is whatever was actually scaled, on either branch of `return.only.var.genes`. Afterwards every variable feature has residuals, and the count reflects what is usable rather than overstating it.

## A residual variance threshold on split data (#9189)

`variable.features.n = NULL` selects by `variable.features.rv.th` instead of by count. That is documented and works on an unsplit object. On a split assay:

```r
> SCTransform(ifnb, vst.flavor = "v2", variable.features.n = NULL, variable.features.rv.th = 1.3)
Error: 'nfeatures' must be a single positive integer
```

because the missing count is passed to a ranking that requires one. With no count to rank down to, the features the layers selected by their own threshold are what the user asked for, so those are kept.

## Tests

`tests/testthat/test_sctransform_variable_features.R`: every variable feature is in `scale.data` and `RunPCA` does not warn that features were not scaled; a feature silenced in one layer is not returned as variable; and the threshold path runs and produces features that are all scaled.

Four assertions fail without the change. Full suite `NOT_CRAN=true`: 1179 passing, the only 2 failures being the pre-existing `Read10X_Image` ones fixed in #10454.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
