### PR TITLE
Say why no variable features can be selected

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- `FindVariableFeatures` now says why it cannot select features when no feature has non-zero variance, such as on a single cell, instead of failing inside `loess` with \dQuote{invalid 'x'}; a variance of `NA` is also no longer treated as non-constant ([#191](https://github.com/satijalab/seurat-object/issues/191))
+
 - Fixed `AddModuleScore` (and `CellCycleScoring`) on v5 objects with on-disk (e.g. BPCells) assays, where each layer was fully densified to an in-memory `dgCMatrix` before scoring; scoring now operates directly on the on-disk matrix
 - Fixed bug in `PercentageFeatureSet` where layer data was incorrectly retrieved prior to finding features with requested pattern ([#10438](https://github.com/satijalab/seurat/pull/10438))
 - Updated `as.SingleCellExperiment` to address conversion case where an object has both original and sketched assay / reductions (differing numbers of cells) ([#10419](https://github.com/satijalab/seurat/pull/10419))

--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -4351,6 +4351,29 @@ SubsetByBarcodeInflections <- function(object) {
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 # Methods for Seurat-defined generics
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+# Explain that variable features cannot be selected
+#
+# Every variance is zero, so the loess fit that follows has nothing to fit and
+# fails with \dQuote{invalid 'x'}, which says nothing about the data
+#
+# @param ncells The number of cells the data has
+#
+# @return Stops with a message
+#
+.NoFeatureVariance <- function(ncells) {
+  msg <- "Cannot select variable features: no feature has non-zero variance"
+  if (ncells < 2L) {
+    msg <- paste0(
+      msg,
+      ", as the data has ",
+      ncells,
+      " cell",
+      if (ncells == 1L) "" else "s"
+    )
+  }
+  stop(msg, call. = FALSE)
+}
+
 
 #' @param selection.method How to choose top variable features. Choose one of :
 #' \itemize{
@@ -4428,7 +4451,10 @@ FindVariableFeatures.V3Matrix <- function(
     )
     hvf.info$variance.expected <- 0
     hvf.info$variance.standardized <- 0
-    not.const <- hvf.info$variance > 0
+    not.const <- !is.na(x = hvf.info$variance) & hvf.info$variance > 0
+    if (!any(not.const)) {
+      .NoFeatureVariance(ncells = ncol(x = object))
+    }
     fit <- loess(
       formula = log10(x = variance) ~ log10(x = mean),
       data = hvf.info[not.const, ],

--- a/R/preprocessing5.R
+++ b/R/preprocessing5.R
@@ -502,7 +502,10 @@ VST.IterableMatrix <- function(
   # Calculate feature variance
   hvf.info$variance <- hvf.stats['variance', ]
   hvf.info$variance.expected <- 0L
-  not.const <- hvf.info$variance > 0
+  not.const <- !is.na(x = hvf.info$variance) & hvf.info$variance > 0
+  if (!any(not.const)) {
+    .NoFeatureVariance(ncells = ncol(x = data))
+  }
   fit <- loess(
     formula = log10(x = variance) ~ log10(x = mean),
     data = hvf.info[not.const, , drop = TRUE],
@@ -559,7 +562,10 @@ VST.dgCMatrix <- function(
     display_progress = verbose
   )
   hvf.info$variance.expected <- 0L
-  not.const <- hvf.info$variance > 0
+  not.const <- !is.na(x = hvf.info$variance) & hvf.info$variance > 0
+  if (!any(not.const)) {
+    .NoFeatureVariance(ncells = ncol(x = data))
+  }
   fit <- loess(
     formula = log10(x = variance) ~ log10(x = mean),
     data = hvf.info[not.const, , drop = TRUE],
@@ -972,7 +978,10 @@ DISP <- function(
     verbose = verbose
   )
   hvf.info$variance.expected <- 0L
-  not.const <- hvf.info$variance > 0
+  not.const <- !is.na(x = hvf.info$variance) & hvf.info$variance > 0
+  if (!any(not.const)) {
+    .NoFeatureVariance(ncells = ncol(x = data))
+  }
   fit <- loess(
     formula = log10(x = variance) ~ log10(x = mean),
     data = hvf.info[not.const, , drop = TRUE],

--- a/tests/testthat/test_variable_features_variance.R
+++ b/tests/testthat/test_variable_features_variance.R
@@ -1,0 +1,45 @@
+set.seed(42)
+
+# With one cell every variance is NA, and with constant data every variance is
+# zero, so the loess fit had nothing to fit and failed with "invalid 'x'"
+make_object <- function(counts) {
+  object <- suppressWarnings(CreateSeuratObject(counts = as.sparse(counts)))
+  suppressWarnings(NormalizeData(object, verbose = FALSE))
+}
+
+test_that("a single cell says why no variable features can be found", {
+  counts <- matrix(
+    sample(1:5, 50, replace = TRUE),
+    ncol = 2,
+    dimnames = list(paste0("gene", 1:25), c("Cell1", "Cell2"))
+  )
+  object <- make_object(counts)
+  one <- subset(object, cells = "Cell1")
+  expect_error(
+    suppressWarnings(FindVariableFeatures(one, verbose = FALSE)),
+    "no feature has non-zero variance, as the data has 1 cell"
+  )
+})
+
+test_that("constant data says why no variable features can be found", {
+  counts <- matrix(3, nrow = 25, ncol = 4,
+                   dimnames = list(paste0("gene", 1:25), paste0("c", 1:4)))
+  expect_error(
+    suppressWarnings(FindVariableFeatures(make_object(counts), verbose = FALSE)),
+    "no feature has non-zero variance"
+  )
+})
+
+test_that("features with no variance do not stop the rest being ranked", {
+  counts <- matrix(
+    rpois(25 * 20, lambda = 3),
+    nrow = 25,
+    dimnames = list(paste0("gene", 1:25), paste0("c", 1:20))
+  )
+  # a handful of features held constant across every cell
+  counts[1:5, ] <- 2
+  object <- make_object(counts)
+  object <- suppressWarnings(FindVariableFeatures(object, nfeatures = 10, verbose = FALSE))
+  expect_length(VariableFeatures(object), 10L)
+  expect_false(any(paste0("gene", 1:5) %in% VariableFeatures(object)))
+})


### PR DESCRIPTION
Found while working through satijalab/seurat-object#191, on single-cell objects.

`FindVariableFeatures()` fits a loess to the features that vary:

```r
not.const <- hvf.info$variance > 0
fit <- loess(log10(variance) ~ log10(mean), data = hvf.info[not.const, ], span = span)
```

When nothing varies the fit is handed no rows and fails with

```
Error: invalid 'x'
```

which says nothing about the data, and comes from inside `loess`'s C code so the traceback does not help either.

Two ways to reach it:

- **a single cell**, where the variance of one value is `NA`. `NA` then slips into the subset as well, so `hvf.info[not.const, ]` carries rows of `NA` instead of dropping them, and on the way to `loess` you can also get `missing value where TRUE/FALSE needed`.
- **constant data**, where every variance is 0. Small subsets and control panels hit this.

## Fix

Treat `NA` as no variance, and stop with what is actually wrong:

```
Cannot select variable features: no feature has non-zero variance, as the data has 1 cell
Cannot select variable features: no feature has non-zero variance
```

Applied in all four places that fit this loess: `FindVariableFeatures.V3Matrix`, and the dense, sparse and BPCells paths of the v5 method.

No behaviour changes for data that has any variance at all: the call that used to fail still fails, and the call that used to work still works.

## Tests

`tests/testthat/test_variable_features_variance.R`: the single-cell message, the constant-data message, and a mixed object where five constant features are simply ranked out while the other twenty are selected normally.

Two assertions fail without the change. Full suite `NOT_CRAN=true`: 1183 passing, the only 2 failures being the pre-existing `Read10X_Image` ones fixed in #10454.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
