### PR TITLE
Keep the array coordinates a Visium run records

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- `Load10X_Spatial` now keeps the array coordinates from the tissue positions file as `array_row`, `array_col` and `in_tissue` meta data. A `VisiumV2` image stores only the pixel position of each spot, so these were dropped on load, while a `VisiumV1` image kept all five columns in its `coordinates` slot ([#229](https://github.com/satijalab/seurat-object/issues/229))
+
 - Fixed `AddModuleScore` (and `CellCycleScoring`) on v5 objects with on-disk (e.g. BPCells) assays, where each layer was fully densified to an in-memory `dgCMatrix` before scoring; scoring now operates directly on the on-disk matrix
 - Fixed bug in `PercentageFeatureSet` where layer data was incorrectly retrieved prior to finding features with requested pattern ([#10438](https://github.com/satijalab/seurat/pull/10438))
 - Updated `as.SingleCellExperiment` to address conversion case where an object has both original and sketched assay / reductions (differing numbers of cells) ([#10419](https://github.com/satijalab/seurat/pull/10419))

--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -488,6 +488,43 @@ GetResidual <- function(
   }
   return(object)
 }
+# Keep the array coordinates a Visium tissue positions file carries
+#
+# A VisiumV2 image holds only the pixel position of each spot, so the array row
+# and column, and whether the spot is over tissue, are dropped when the image is
+# built. A VisiumV1 image kept all five columns in its `coordinates` slot, and
+# tools that read them have no way to recover them from the object.
+#
+# @param object A Seurat object
+# @param image.dir The spatial directory the image was read from
+# @param filter.matrix Filter to spots over tissue, as for the image
+#
+# @return \code{object} with array_row, array_col and in_tissue meta data,
+# unchanged if the file has none of them
+#
+.AddArrayCoordinates <- function(object, image.dir, filter.matrix = TRUE) {
+  positions <- Sys.glob(paths = file.path(image.dir, "*tissue_positions*"))
+  if (!length(x = positions)) {
+    return(object)
+  }
+  coordinates <- tryCatch(
+    expr = Read10X_Coordinates(
+      filename = positions[1L],
+      filter.matrix = filter.matrix
+    ),
+    error = function(...) NULL
+  )
+  columns <- c(array_row = 'row', array_col = 'col', in_tissue = 'tissue')
+  columns <- columns[columns %in% colnames(x = coordinates)]
+  cells <- intersect(x = colnames(x = object), y = rownames(x = coordinates))
+  if (!length(x = columns) || !length(x = cells)) {
+    return(object)
+  }
+  md <- coordinates[cells, columns, drop = FALSE]
+  colnames(x = md) <- names(x = columns)
+  return(AddMetaData(object = object, metadata = md))
+}
+
 
 #' Load a 10x Genomics Visium Spatial Experiment into a \code{Seurat} object
 #'
@@ -647,23 +684,41 @@ Load10X_Spatial <- function (
     # for each counts matrix, build a Seurat object
     object.list <- mapply(CreateSeuratObject, counts.list, assay = assay.names)
     # associate each counts matrix with its corresponding image
+    # the directory each image was read from, so the array coordinates it holds
+    # can be kept; NA when the caller supplied the images themselves
+    image.dirs <- if (is.null(x = image)) {
+      file.path(data.dirs, "spatial")
+    } else {
+      rep_len(x = NA_character_, length.out = length(x = image.list))
+    }
     object.list <- mapply(
       function(
         .object,
         .image,
         .assay,
-        .slice
+        .slice,
+        .dir
       ) {
         # align the image's identifiers with the object's
         .image <- .image[Cells(.object)]
         # add the image to the corresponding Seurat instance
         .object[[.slice]] <- .image
+        # a VisiumV2 image keeps only the pixel positions, so hold on to the
+        # array coordinates the tissue positions file carries
+        if (!is.na(x = .dir)) {
+          .object <- .AddArrayCoordinates(
+            object = .object,
+            image.dir = .dir,
+            filter.matrix = filter.matrix
+          )
+        }
         return (.object)
       },
       object.list,
       image.list,
       assay.names,
-      slice.names
+      slice.names,
+      image.dirs
     )
     # merge the Seurat instances - each assay should have unique Cell identifiers
     object <- merge(

--- a/tests/testthat/test_visium_array_coordinates.R
+++ b/tests/testthat/test_visium_array_coordinates.R
@@ -1,0 +1,60 @@
+set.seed(42)
+
+# A VisiumV2 image holds only the pixel position of each spot, so the array row
+# and column, and whether the spot is over tissue, were dropped on load. A
+# VisiumV1 image kept all five columns in its `coordinates` slot
+image.dir <- file.path("../testdata/visium/spatial")
+
+build_object <- function() {
+  image <- Read10X_Image(image.dir = image.dir, image.name = "tissue_lowres_image.png")
+  cells <- Cells(image)
+  counts <- as.sparse(matrix(
+    rpois(30 * length(cells), lambda = 3),
+    nrow = 30,
+    dimnames = list(paste0("gene", seq_len(30)), cells)
+  ))
+  object <- suppressWarnings(CreateSeuratObject(counts = counts, assay = "Spatial"))
+  DefaultAssay(image) <- "Spatial"
+  object[["slice1"]] <- image
+  object
+}
+
+test_that("the array coordinates are kept", {
+  object <- build_object()
+  added <- Seurat:::.AddArrayCoordinates(object = object, image.dir = image.dir)
+  expect_true(all(c("array_row", "array_col", "in_tissue") %in% colnames(added[[]])))
+
+  positions <- Read10X_Coordinates(
+    filename = Sys.glob(paths = file.path(image.dir, "*tissue_positions*"))[1],
+    filter.matrix = TRUE
+  )
+  expect_equal(unname(added$array_row), unname(positions[colnames(added), "row"]))
+  expect_equal(unname(added$array_col), unname(positions[colnames(added), "col"]))
+  expect_true(all(added$in_tissue == 1))
+  # and the pixel positions the image holds are unchanged
+  expect_identical(
+    GetTissueCoordinates(added[["slice1"]]),
+    GetTissueCoordinates(object[["slice1"]])
+  )
+})
+
+test_that("a directory with no tissue positions leaves the object alone", {
+  object <- build_object()
+  empty <- file.path(tempdir(), "no-positions")
+  dir.create(path = empty, showWarnings = FALSE)
+  on.exit(unlink(empty, recursive = TRUE), add = TRUE)
+  expect_identical(
+    colnames(Seurat:::.AddArrayCoordinates(object = object, image.dir = empty)[[]]),
+    colnames(object[[]])
+  )
+})
+
+test_that("Load10X_Spatial keeps the array coordinates", {
+  skip_if_not_installed("hdf5r")
+  object <- suppressWarnings(Load10X_Spatial(
+    data.dir = file.path("../testdata/visium"),
+    filename = "filtered_feature_bc_matrix.h5"
+  ))
+  expect_true(all(c("array_row", "array_col", "in_tissue") %in% colnames(object[[]])))
+  expect_false(anyNA(object$array_row))
+})


### PR DESCRIPTION
Addresses satijalab/seurat-object#229, where a spatial object loaded on 5.0.2 no longer carries what it did on 5.0.1.

## What is lost

A `VisiumV1` image kept all five columns of the tissue positions file in its `coordinates` slot:

```
                   tissue row col imagerow imagecol
AACAATGGAACCACAT-1      1  54  32     1293      657
```

A `VisiumV2` image is an `FOV`, which holds only the pixel position of each spot. `Read10X_Image` reads all five columns and passes two of them on:

```r
fov <- CreateFOV(coordinates[, c("imagecol", "imagerow")], type = "centroids", ...)
```

So the array row and column, and whether the spot is over tissue, are dropped at load and recorded nowhere in the object. Measured on the repository's own Visium fixture:

| | columns |
| --- | --- |
| tissue positions file | `tissue, row, col, imagerow, imagecol` |
| `VisiumV1@coordinates` | `tissue, row, col, imagerow, imagecol` |
| `GetTissueCoordinates(VisiumV2)` | `x, y, cell` |

with `x` equal to `imagecol` and `y` equal to `imagerow`, both verified against the file.

The array indices are not derivable from the pixel positions, so a tool that used them, such as the one in that issue, has nothing to fall back on.

## Change

`Load10X_Spatial` adds them to the object's meta data as `array_row`, `array_col` and `in_tissue`, named as spaceranger names them. The image is untouched, so plotting is unaffected, and this is additive: nothing that exists today changes.

An object built from a supplied `image =`, or from a directory whose tissue positions file is missing or unreadable, is left exactly as it was.

## Tests

`tests/testthat/test_visium_array_coordinates.R`, against the fixture already in the repository: the columns are added and match the file spot for spot, the image's own coordinates are unchanged, a directory with no positions file is a no-op, and `Load10X_Spatial` produces them end to end (skipped where no HDF5 reader is installed).

Full suite `NOT_CRAN=true`: 1185 passing, the only 2 failures being the pre-existing `Read10X_Image` ones fixed in #10454.

## If you would rather not

The alternative reading is that this is by design and the answer to that issue is a documented recipe:

```r
positions <- Read10X_Coordinates(Sys.glob(file.path(dir, "spatial", "*tissue_positions*"))[1], filter.matrix = TRUE)
object <- AddMetaData(object, positions[colnames(object), c("row", "col")])
```

I am happy to close this and send a documentation note instead; the loss is real either way, and the recipe is not obvious from the manual pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
