### PR TITLE
Name the Xenium column that is missing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- `ReadXenium` now names the file and the columns it lacks, instead of failing with \dQuote{undefined columns selected} when a cells or transcripts file does not carry the expected column names ([#8265](https://github.com/satijalab/seurat/issues/8265))
+
 - Fixed `AddModuleScore` (and `CellCycleScoring`) on v5 objects with on-disk (e.g. BPCells) assays, where each layer was fully densified to an in-memory `dgCMatrix` before scoring; scoring now operates directly on the on-disk matrix
 - Fixed bug in `PercentageFeatureSet` where layer data was incorrectly retrieved prior to finding features with requested pattern ([#10438](https://github.com/satijalab/seurat/pull/10438))
 - Updated `as.SingleCellExperiment` to address conversion case where an object has both original and sketched assay / reductions (differing numbers of cells) ([#10419](https://github.com/satijalab/seurat/pull/10419))

--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -2552,6 +2552,32 @@ ReadNanostring <- function(
   }
   return(outs)
 }
+# Check that a Xenium output file has the columns it is about to be read for
+#
+# The readers select the columns they need by name. When the file does not have
+# them, the selection fails with \dQuote{undefined columns selected}, which
+# names neither the file nor the column.
+#
+# @param df The data read from the file
+# @param wanted The columns the reader needs
+# @param filename The file the data came from
+#
+# @return Invisibly \code{NULL}, stopping when a column is missing
+#
+.CheckXeniumColumns <- function(df, wanted, filename) {
+  missing <- setdiff(x = wanted, y = colnames(x = df))
+  if (!length(x = missing)) {
+    return(invisible(x = NULL))
+  }
+  stop(
+    "The Xenium ", filename, " has no ",
+    paste(sQuote(x = missing), collapse = ", "),
+    " column", if (length(x = missing) > 1) "s" else "",
+    ". Columns found: ", paste(colnames(x = df), collapse = ", "),
+    call. = FALSE
+  )
+}
+
 
 #' Read and Load 10x Genomics Xenium in-situ data
 #'
@@ -2741,6 +2767,12 @@ ReadXenium <- function(
           stop("Xenium outputs were incomplete: missing cells")
         }
 
+        .CheckXeniumColumns(
+          df = cell_info,
+          wanted = names(x = col.use),
+          filename = "cells file"
+        )
+
         cell_info$cell_id <- binary_to_string(cell_info$cell_id)
 
         cell_info <- cell_info[, names(col.use)]
@@ -2870,6 +2902,12 @@ ReadXenium <- function(
 
           stop(paste0("Xenium outputs were incomplete: missing transcripts", hint))
         }
+
+        .CheckXeniumColumns(
+          df = transcripts,
+          wanted = names(x = col.use),
+          filename = "transcripts file"
+        )
 
         transcripts <- transcripts[, names(col.use)]
         colnames(transcripts) <- col.use

--- a/tests/testthat/test_readxenium_columns.R
+++ b/tests/testthat/test_readxenium_columns.R
@@ -1,0 +1,58 @@
+set.seed(42)
+
+# The readers select the columns they need by name, so a cells or transcripts
+# file that does not have them failed with "undefined columns selected", which
+# names neither the file nor the column
+write_xenium <- function(cells.columns, transcripts.columns) {
+  dir <- tempfile("xenium")
+  dir.create(path = dir, recursive = TRUE)
+  cells <- data.frame(
+    cell_id = paste0("cell", seq_len(10)),
+    x_centroid = runif(10) * 100,
+    y_centroid = runif(10) * 100
+  )
+  connection <- gzfile(file.path(dir, "cells.csv.gz"), "w")
+  write.csv(cells[, cells.columns, drop = FALSE], connection, row.names = FALSE)
+  close(connection)
+
+  transcripts <- data.frame(
+    x_location = runif(20) * 100,
+    y_location = runif(20) * 100,
+    feature_name = paste0("g", sample(5, 20, replace = TRUE)),
+    qv = 30
+  )
+  connection <- gzfile(file.path(dir, "transcripts.csv.gz"), "w")
+  write.csv(transcripts[, transcripts.columns, drop = FALSE], connection, row.names = FALSE)
+  close(connection)
+  dir
+}
+
+all.cells <- c("cell_id", "x_centroid", "y_centroid")
+all.transcripts <- c("x_location", "y_location", "feature_name", "qv")
+
+test_that("a cells file with no centroids names the columns it lacks", {
+  dir <- write_xenium("cell_id", all.transcripts)
+  on.exit(unlink(dir, recursive = TRUE), add = TRUE)
+  expect_error(
+    suppressWarnings(ReadXenium(dir, type = "centroids", outs = "microns")),
+    "cells file has no .x_centroid., .y_centroid. columns"
+  )
+})
+
+test_that("a transcripts file with no feature names says so", {
+  dir <- write_xenium(all.cells, c("x_location", "y_location"))
+  on.exit(unlink(dir, recursive = TRUE), add = TRUE)
+  expect_error(
+    suppressWarnings(ReadXenium(dir, type = "centroids", outs = "microns")),
+    "transcripts file has no .feature_name. column"
+  )
+})
+
+test_that("a complete pair of files still reads", {
+  dir <- write_xenium(all.cells, all.transcripts)
+  on.exit(unlink(dir, recursive = TRUE), add = TRUE)
+  data <- suppressWarnings(ReadXenium(dir, type = "centroids", outs = "microns"))
+  expect_identical(colnames(data$centroids), c("x", "y", "cell"))
+  expect_identical(nrow(data$centroids), 10L)
+  expect_identical(colnames(data$microns), c("x", "y", "gene"))
+})


### PR DESCRIPTION
Addresses #8265, and the class of failure behind several other Xenium loading reports.

`ReadXenium()` selects the columns it needs by name:

```r
cell_info <- cell_info[, names(col.use)]
```

so a cells or transcripts file that does not carry them fails with

```
Error in `[.data.frame`(cell_info, , names(col.use)) : undefined columns selected
```

which names neither the file nor the column. Depending on which of the three readers (`arrow`, `data.table`, `read.csv`) got there first, the same input instead reaches `CreateCentroids()` and stops with `argument is of length zero`, which is exactly the traceback in #8265:

```
3: CreateCentroids.default(data$centroids)
2: CreateCentroids(data$centroids)
```

Neither message gives the user anything to check, which is why that thread ends in a suggestion to `debug()` the reader.

## Change

Check before selecting, and name the file and the columns:

```
The Xenium cells file has no 'x_centroid', 'y_centroid' columns. Columns found: cell_id

The Xenium transcripts file has no 'feature_name' column. Columns found: x_location, y_location
```

No behaviour changes for well-formed outputs: the same files read, and the same files fail, they just say why.

## Tests

`tests/testthat/test_readxenium_columns.R` writes Xenium-layout `cells.csv.gz` and `transcripts.csv.gz` files to a temporary directory, so no vendor data and no HDF5 reader is needed: a cells file with no centroids, a transcripts file with no feature names, and a complete pair still reading with the expected columns.

Two assertions fail without the change. Full suite `NOT_CRAN=true`: 1184 passing, the only 2 failures being the pre-existing `Read10X_Image` ones fixed in #10454.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
