### PR TITLE
Plot a repeated feature once, and say when cells have no identity

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- Fixed `DotPlot` failing with \dQuote{factor level [n] is duplicated} when a feature is named twice, and with \dQuote{duplicate 'row.names' are not allowed} when some cells have no identity; those cells are now left out with a warning
+
 - Fixed `AddModuleScore` (and `CellCycleScoring`) on v5 objects with on-disk (e.g. BPCells) assays, where each layer was fully densified to an in-memory `dgCMatrix` before scoring; scoring now operates directly on the on-disk matrix
 - Fixed bug in `PercentageFeatureSet` where layer data was incorrectly retrieved prior to finding features with requested pattern ([#10438](https://github.com/satijalab/seurat/pull/10438))
 - Updated `as.SingleCellExperiment` to address conversion case where an object has both original and sketched assay / reductions (differing numbers of cells) ([#10419](https://github.com/satijalab/seurat/pull/10419))

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -4898,6 +4898,8 @@ DotPlot <- function(
     names(x = feature.groups) <- features
   }
   cells <- unlist(x = CellsByIdentities(object = object, cells = colnames(object[[assay]]), idents = idents))
+  # cells with no identity come back as NA, which FetchData cannot look up
+  cells <- cells[!is.na(x = cells)]
   data.features <- FetchData(object = object, vars = features, cells = cells)
   data.features$id <- if (is.null(x = group.by)) {
     Idents(object = object)[cells, drop = TRUE]
@@ -4909,6 +4911,19 @@ DotPlot <- function(
   }
   id.levels <- levels(x = data.features$id)
   data.features$id <- as.vector(x = data.features$id)
+  # cells with no identity would be summarised into a group named NA, and the
+  # frames built per group then fail to bind with "duplicate 'row.names'"
+  keep <- !is.na(x = data.features$id)
+  if (!all(keep)) {
+    warning(
+      sum(!keep),
+      " cells have no identity and are not shown",
+      call. = FALSE,
+      immediate. = TRUE
+    )
+    data.features <- data.features[keep, , drop = FALSE]
+    cells <- cells[keep]
+  }
   if (!is.null(x = split.by)) {
     splits <- FetchData(object = object, vars = split.by)[cells, split.by]
     if (split.colors) {
@@ -4994,7 +5009,9 @@ DotPlot <- function(
   data.plot$avg.exp.scaled <- avg.exp.scaled
   data.plot$features.plot <- factor(
     x = data.plot$features.plot,
-    levels = features
+    # a feature named twice, which happens when marker lists are combined,
+    # would be a duplicated factor level
+    levels = unique(x = features)
   )
   data.plot$pct.exp[data.plot$pct.exp < dot.min] <- NA
   data.plot$pct.exp <- data.plot$pct.exp * 100

--- a/tests/testthat/test_dotplot_features_idents.R
+++ b/tests/testthat/test_dotplot_features_idents.R
@@ -1,0 +1,39 @@
+set.seed(42)
+
+# A feature named twice, which happens when marker lists are combined, became a
+# duplicated factor level; cells with no identity came back from
+# CellsByIdentities as NA and reached FetchData
+data("pbmc_small", package = "SeuratObject", envir = environment())
+features <- rownames(pbmc_small)[1:3]
+
+test_that("a feature named twice is plotted once", {
+  plot <- DotPlot(pbmc_small, features = c(features, features[1]))
+  expect_s3_class(plot, "ggplot")
+  expect_setequal(levels(plot$data$features.plot), features)
+})
+
+test_that("a feature repeated across named groups is plotted", {
+  plot <- DotPlot(pbmc_small, features = list(a = features, b = features[1]))
+  expect_s3_class(plot, "ggplot")
+})
+
+test_that("cells with no identity are left out and reported", {
+  object <- pbmc_small
+  identities <- as.character(Idents(object))
+  identities[1:3] <- NA
+  Idents(object) <- factor(identities)
+
+  plot <- expect_warning(
+    DotPlot(object, features = features),
+    "3 cells have no identity"
+  )
+  expect_s3_class(plot, "ggplot")
+  expect_false(anyNA(as.character(plot$data$id)))
+  expect_setequal(as.character(unique(plot$data$id)), setdiff(unique(identities), NA))
+})
+
+test_that("the usual case is unchanged", {
+  plot <- DotPlot(pbmc_small, features = features)
+  expect_setequal(levels(plot$data$features.plot), features)
+  expect_setequal(as.character(unique(plot$data$id)), levels(Idents(pbmc_small)))
+})


### PR DESCRIPTION
Two ways `DotPlot()` fails on input it should handle. Both found by sweeping the plotting functions with degenerate but ordinary arguments; `VlnPlot()` and `FeaturePlot()` handle the same inputs.

## A feature named twice

```r
> DotPlot(object, features = c(markers, markers[1]))
Error in `levels<-`: factor level [4] is duplicated
```

From

```r
data.plot$features.plot <- factor(x = data.plot$features.plot, levels = features)
```

The features are there only to fix the order of the axis, so they are taken unique. This happens as soon as marker lists are combined, and with a named list (the grouped dot plot) it is unavoidable when a gene marks two groups.

## Cells with no identity

```r
> DotPlot(object, features = markers)
Error in `rbind`: duplicate 'row.names' are not allowed
```

`CellsByIdentities()` returns a group for `NA`, padded with `NA` cell names, and those reach `FetchData()`. The per-group frames then fail to bind. Such cells are now dropped, with

```
Warning: 3 cells have no identity and are not shown
```

Both the cell names and the identity column are filtered, so this holds whether or not the padding itself is fixed. With satijalab/seurat-object#302 (which fixes the padding) but without this change, the same call still fails, differently:

```
Error: replacement has 1 row, data has 0
```

so the two are complementary rather than duplicates.

## Tests

`tests/testthat/test_dotplot_features_idents.R`: a repeated feature plotted once, a feature repeated across named groups, cells with no identity warned about and excluded, and the ordinary case unchanged.

Three assertions fail without the change. Full suite `NOT_CRAN=true`: 1188 passing, the only 2 failures being the pre-existing `Read10X_Image` ones fixed in #10454.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
