### PR TITLE
Say when ctrl is larger than the bins it draws from

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- `AddModuleScore` (and `CellCycleScoring`) now says when `ctrl` is larger than the expression bins it draws control features from, instead of failing with \dQuote{cannot take a sample larger than the population}; this is what a small or heavily filtered object hits with the default `ctrl = 100`
+
 - Fixed `AddModuleScore` (and `CellCycleScoring`) on v5 objects with on-disk (e.g. BPCells) assays, where each layer was fully densified to an in-memory `dgCMatrix` before scoring; scoring now operates directly on the on-disk matrix
 - Fixed bug in `PercentageFeatureSet` where layer data was incorrectly retrieved prior to finding features with requested pattern ([#10438](https://github.com/satijalab/seurat/pull/10438))
 - Updated `as.SingleCellExperiment` to address conversion case where an object has both original and sketched assay / reductions (differing numbers of cells) ([#10419](https://github.com/satijalab/seurat/pull/10419))

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -407,6 +407,21 @@ AddModuleScore.Assay <- function(
   data.cut <- cut_number(x = data.avg + rnorm(n = length(data.avg))/1e30, n = nbin, labels = FALSE, right = FALSE)
   #data.cut <- as.numeric(x = Hmisc::cut2(x = data.avg, m = round(x = length(x = data.avg) / (nbin + 1))))
   names(x = data.cut) <- names(x = data.avg)
+  # sample() below draws ctrl features from the bin a feature sits in, so a bin
+  # smaller than ctrl fails with "cannot take a sample larger than the
+  # population", which says nothing about ctrl, nbin or the object's size
+  bins.used <- na.omit(object = data.cut[unlist(x = features, use.names = FALSE)])
+  bin.sizes <- table(data.cut)[as.character(x = unique(x = bins.used))]
+  if (length(x = bin.sizes) && ctrl > min(bin.sizes)) {
+    stop(
+      "Cannot sample ", ctrl, " control features: the smallest expression bin ",
+      "holding a feature of the set has ", min(bin.sizes), ". Lower ctrl to at ",
+      "most ", min(bin.sizes), ", or lower nbin (currently ", nbin,
+      ") so that the ", length(x = data.cut), " features are spread over ",
+      "larger bins",
+      call. = FALSE
+    )
+  }
   ctrl.use <- vector(mode = "list", length = cluster.length)
   for (i in 1:cluster.length) {
     features.use <- features[[i]]

--- a/tests/testthat/test_addmodulescore_ctrl.R
+++ b/tests/testthat/test_addmodulescore_ctrl.R
@@ -1,0 +1,41 @@
+set.seed(42)
+
+# The control features are drawn from the expression bin each feature sits in,
+# so ctrl larger than a bin failed with base R's "cannot take a sample larger
+# than the population", which names neither ctrl nor nbin
+data("pbmc_small", package = "SeuratObject", envir = environment())
+
+test_that("a ctrl larger than the bins is explained", {
+  # 230 features over 24 bins is about 9 per bin, against a default ctrl of 100
+  expect_error(
+    suppressWarnings(AddModuleScore(pbmc_small, features = list(rownames(pbmc_small)[1:20]))),
+    "Cannot sample 100 control features"
+  )
+  expect_error(
+    suppressWarnings(AddModuleScore(pbmc_small, features = list(rownames(pbmc_small)[1:20]))),
+    "Lower ctrl to at most"
+  )
+})
+
+test_that("a ctrl the bins can supply still scores", {
+  scored <- suppressWarnings(AddModuleScore(
+    pbmc_small,
+    features = list(rownames(pbmc_small)[1:20]),
+    ctrl = 5,
+    name = "module"
+  ))
+  expect_true("module1" %in% colnames(scored[[]]))
+  expect_length(scored$module1, ncol(pbmc_small))
+  expect_false(anyNA(scored$module1))
+})
+
+test_that("a smaller nbin makes the bins large enough", {
+  scored <- suppressWarnings(AddModuleScore(
+    pbmc_small,
+    features = list(rownames(pbmc_small)[1:20]),
+    nbin = 5,
+    ctrl = 40,
+    name = "module"
+  ))
+  expect_true("module1" %in% colnames(scored[[]]))
+})


### PR DESCRIPTION
`AddModuleScore()` on a small object fails with a message from base R:

```r
> AddModuleScore(pbmc_small, features = list(rownames(pbmc_small)[1:20]))
Error: cannot take a sample larger than the population when 'replace = FALSE'
```

## Cause

The control features are drawn from the expression bin each feature of the set sits in:

```r
sample(x = data.cut[which(x = data.cut == data.cut[features.use[j]])],
       size = ctrl, replace = FALSE)
```

so a bin smaller than `ctrl` cannot supply them. Roughly, any object with fewer than `nbin * ctrl` features hits this on the defaults. `pbmc_small` is 230 features over 24 bins, about 9 per bin against a default `ctrl = 100`, so **every** call with default arguments fails on it. Small panels, heavily filtered objects and targeted assays are all in that range.

The message names neither `ctrl`, nor `nbin`, nor the object's size, so there is nothing to act on.

## Change

Check the bins that will actually be drawn from, and say what to change:

```
Cannot sample 100 control features: the smallest expression bin holding a feature of
the set has 9. Lower ctrl to at most 9, or lower nbin (currently 24) so that the 230
features are spread over larger bins
```

Still an error rather than a silent adjustment: lowering `ctrl` or `nbin` changes what the score means, so it is the caller's decision. `CellCycleScoring()` goes through the same path and gains the same message.

## Tests

`tests/testthat/test_addmodulescore_ctrl.R`: the message on defaults, scoring with a `ctrl` the bins can supply, and scoring with a smaller `nbin`.

Two assertions fail without the change. Full suite `NOT_CRAN=true`: 1185 passing, the only 2 failures being the pre-existing `Read10X_Image` ones fixed in #10454.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
