### PR TITLE
Rename the cells an SCT model still shares with its assay

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- Fixed `RenameCells` on an SCT assay failing with \dQuote{missing values in 'row.names' are not allowed} when a model records cells the assay no longer has, which is what `RunAzimuth` hits on a subset object ([#256](https://github.com/satijalab/seurat-object/issues/256))
+
 - Fixed `AddModuleScore` (and `CellCycleScoring`) on v5 objects with on-disk (e.g. BPCells) assays, where each layer was fully densified to an in-memory `dgCMatrix` before scoring; scoring now operates directly on the on-disk matrix
 - Fixed bug in `PercentageFeatureSet` where layer data was incorrectly retrieved prior to finding features with requested pattern ([#10438](https://github.com/satijalab/seurat/pull/10438))
 - Updated `as.SingleCellExperiment` to address conversion case where an object has both original and sketched assay / reductions (differing numbers of cells) ([#10419](https://github.com/satijalab/seurat/pull/10419))

--- a/R/objects.R
+++ b/R/objects.R
@@ -1892,19 +1892,21 @@ RenameCells.SCTAssay <- function(object, new.names = NULL, ...) {
   old.names <- Cells(x = object)
   names(x = new.names) <- old.names
   cell.attributes <- SCTResults(object = object, slot = "cell.attributes")
+  # A model records the cells it was fit on, and subsetting the object does not
+  # prune that record, so a model can name cells the assay no longer has. Those
+  # have no new name, and assigning NA leaves the frame with missing or
+  # duplicated row names
+  .RenameAttributes <- function(x) {
+    old <- rownames(x = x)
+    renamed <- unname(obj = new.names[old])
+    rownames(x = x) <- ifelse(test = is.na(x = renamed), yes = old, no = renamed)
+    return(x)
+  }
   if (length(x = cell.attributes) > 0) {
     if (is.data.frame(x = cell.attributes)) {
-      old.names <- rownames(x = cell.attributes)
-      rownames(x = cell.attributes) <- unname(obj = new.names[old.names])
+      cell.attributes <- .RenameAttributes(x = cell.attributes)
     } else {
-      cell.attributes <- lapply(
-        X = cell.attributes,
-        FUN = function(x) {
-          old.names <- rownames(x = x)
-          rownames(x = x) <- unname(obj = new.names[old.names])
-          return(x)
-        }
-      )
+      cell.attributes <- lapply(X = cell.attributes, FUN = .RenameAttributes)
     }
     SCTResults(object = object, slot = "cell.attributes") <- cell.attributes
   }

--- a/tests/testthat/test_rename_sct_cells.R
+++ b/tests/testthat/test_rename_sct_cells.R
@@ -1,0 +1,47 @@
+set.seed(42)
+
+# An SCT model records the cells it was fit on, and subsetting does not prune
+# that record, so a model can name cells the assay no longer has. Those have no
+# new name, and assigning NA left the frame with missing row names:
+#   Error in `.rowNamesDF<-`(x, value = value): missing values in 'row.names'
+build_sct <- function() {
+  data("pbmc_small", package = "SeuratObject", envir = environment())
+  suppressWarnings(SCTransform(
+    pbmc_small,
+    variable.features.n = 20,
+    vst.flavor = "v1",
+    verbose = FALSE
+  ))
+}
+
+add_ghost_cell <- function(object, model = 1L) {
+  attributes <- slot(slot(object[["SCT"]], name = "SCTModel.list")[[model]], name = "cell.attributes")
+  ghost <- attributes[1, , drop = FALSE]
+  rownames(ghost) <- "ghost_cell"
+  slot(slot(object[["SCT"]], name = "SCTModel.list")[[model]], name = "cell.attributes") <-
+    rbind(attributes, ghost)
+  object
+}
+
+cell_attributes <- function(object, model = 1L) {
+  slot(slot(object[["SCT"]], name = "SCTModel.list")[[model]], name = "cell.attributes")
+}
+
+test_that("renaming works when a model names a cell the assay lost", {
+  object <- add_ghost_cell(build_sct())
+  renamed <- expect_no_error(RenameCells(object, new.names = paste0(Cells(object), "_query")))
+  expect_identical(colnames(renamed), paste0(colnames(object), "_query"))
+
+  attributes <- cell_attributes(renamed)
+  expect_false(anyNA(rownames(attributes)))
+  # the cells the assay has are renamed, the one it does not is left alone
+  expect_true(all(paste0(colnames(object), "_query")[1:5] %in% rownames(attributes)))
+  expect_true("ghost_cell" %in% rownames(attributes))
+})
+
+test_that("ordinary renaming is unchanged", {
+  object <- build_sct()
+  renamed <- RenameCells(object, new.names = paste0(Cells(object), "_query"))
+  expect_identical(colnames(renamed), paste0(colnames(object), "_query"))
+  expect_setequal(rownames(cell_attributes(renamed)), colnames(renamed))
+})


### PR DESCRIPTION
Fixes the `RenameCells` half of satijalab/seurat-object#256, where `RunAzimuth()` fails renaming a query object.

## Cause

`RenameCells.SCTAssay()` builds the mapping from the **assay's** cells and applies it to each **model's** cell attributes:

```r
old.names <- Cells(x = object)
names(x = new.names) <- old.names
...
rownames(x = x) <- unname(obj = new.names[old.names])
```

A model records the cells it was fit on, and subsetting the object does not prune that record, so a model can name cells the assay no longer has. Those look up as `NA`:

```
Error in `.rowNamesDF<-`(x, value = value): missing values in 'row.names' are not allowed
```

which is exactly the traceback in that issue:

```
11: FUN(X[[i]], ...)
10: lapply(X = cell.attributes, FUN = function(x) { ... })
 9: RenameCells.SCTAssay(object = object[[i]], new.names = new.cell.names[colnames(x = object[[i]])])
```

It also explains why passing `make.unique(Cells(object))` did not help: uniqueness was never the problem.

## Fix

Rename the cells that are in the mapping and leave the rest as they are. Dropping them would discard the record; renaming them is impossible, since they have no new name.

## Related

The same model-versus-assay drift is behind #10469 (`PrepSCTFindMarkers` failing with `subscript out of bounds`), and this is the same shape of fix.

The other error in that issue, `duplicate 'row.names' are not allowed`, comes from renaming to names that are not unique, which is a SeuratObject-level check; I will send that separately.

## Tests

`tests/testthat/test_rename_sct_cells.R`: renaming an object whose model names a cell the assay lost, asserting the assay's cells are renamed, the stale one is left alone and no row name is `NA`; plus ordinary renaming unchanged.

Three assertions fail without the change. Full suite `NOT_CRAN=true`: 1186 passing, the only 2 failures being the pre-existing `Read10X_Image` ones fixed in #10454.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
