### PR TITLE
Ask for as many components as the data has

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- Fixed `LeverageScore`, and so `SketchData`, failing on any object with fewer than 50 features or cells: the number of components was computed from the object's size and then not used, so `irlba` was always asked for 50 and stopped with \dQuote{max(nu, nv) must be strictly less than min(nrow(A), ncol(A))}
+
 - Fixed `AddModuleScore` (and `CellCycleScoring`) on v5 objects with on-disk (e.g. BPCells) assays, where each layer was fully densified to an in-memory `dgCMatrix` before scoring; scoring now operates directly on the on-disk matrix
 - Fixed bug in `PercentageFeatureSet` where layer data was incorrectly retrieved prior to finding features with requested pattern ([#10438](https://github.com/satijalab/seurat/pull/10438))
 - Updated `as.SingleCellExperiment` to address conversion case where an object has both original and sketched assay / reductions (differing numbers of cells) ([#10419](https://github.com/satijalab/seurat/pull/10419))

--- a/R/sketching.R
+++ b/R/sketching.R
@@ -404,11 +404,20 @@ LeverageScore.default <- function(
   # Check the dimensions of the object, nsketch, and ndims
   ncells <- ncol(x = object)
   if (ncells < nsketch * 1.5) {
-    nv <- ifelse(nrow(x = object) < 50, nrow(x = object) - 1, 50)
+    # irlba needs nv below both dimensions, and nv was computed here but then
+    # not used, so anything smaller than 50 in either direction failed with
+    # "max(nu, nv) must be strictly less than min(nrow(A), ncol(A))"
+    nv <- min(50L, nrow(x = object) - 1L, ncells - 1L)
+    if (nv < 1L) {
+      abort(message = paste0(
+        "Cannot compute leverage scores from ", nrow(x = object),
+        " features and ", ncells, " cells: at least two of each are needed"
+      ))
+    }
     if (inherits(x = object, what = 'IterableMatrix')) {
       object <- as.sparse(x = object)
     }
-    Z <- irlba(A = object, nv = 50, nu = 0, verbose = FALSE)$v
+    Z <- irlba(A = object, nv = nv, nu = 0, verbose = FALSE)$v
     return(rowSums(x = Z ^ 2))
   }
   if (nrow(x = object) > 5000L) {

--- a/tests/testthat/test_leverage_score_small.R
+++ b/tests/testthat/test_leverage_score_small.R
@@ -1,0 +1,46 @@
+set.seed(42)
+
+# nv was computed from the object's size and then not used, so LeverageScore()
+# always asked irlba for 50 components and failed on anything smaller with
+# "max(nu, nv) must be strictly less than min(nrow(A), ncol(A))"
+data("pbmc_small", package = "SeuratObject", envir = environment())
+
+test_that("leverage scores can be computed on a small object", {
+  scored <- LeverageScore(pbmc_small, verbose = FALSE)
+  scores <- scored$leverage.score
+  expect_length(scores, ncol(pbmc_small))
+  expect_true(all(scores >= 0))
+  expect_false(anyNA(scores))
+})
+
+test_that("sketching works on a small object", {
+  sketched <- suppressWarnings(SketchData(
+    pbmc_small,
+    ncells = 40,
+    method = "LeverageScore",
+    sketched.assay = "sketch",
+    verbose = FALSE
+  ))
+  expect_true("sketch" %in% Assays(sketched))
+  expect_identical(ncol(sketched[["sketch"]]), 40L)
+  expect_true(all(colnames(sketched[["sketch"]]) %in% colnames(pbmc_small)))
+})
+
+test_that("asking for more cells than there are keeps them all", {
+  sketched <- suppressWarnings(SketchData(
+    pbmc_small,
+    ncells = ncol(pbmc_small) * 3,
+    method = "LeverageScore",
+    sketched.assay = "sketch",
+    verbose = FALSE
+  ))
+  expect_identical(ncol(sketched[["sketch"]]), ncol(pbmc_small))
+})
+
+test_that("a matrix with too few dimensions is reported", {
+  data <- as.sparse(LayerData(pbmc_small, layer = "data")[1, 1, drop = FALSE])
+  expect_error(
+    LeverageScore(data, verbose = FALSE),
+    "at least two of each are needed"
+  )
+})


### PR DESCRIPTION
`SketchData()` fails on any small object, at every size of sketch:

```r
> SketchData(pbmc_small, ncells = 40, method = "LeverageScore")
Error: max(nu, nv) must be strictly less than min(nrow(A), ncol(A))
```

## Cause

`LeverageScore.default()` sizes its decomposition to the object, and then does not use the value:

```r
nv <- ifelse(nrow(x = object) < 50, nrow(x = object) - 1, 50)
...
Z <- irlba(A = object, nv = 50, nu = 0, verbose = FALSE)$v
```

`nv` is computed and dropped; 50 components are always requested. Anything with fewer than 50 features or cells on the side being decomposed therefore stops inside `irlba`, and since `SketchData()` is how `LeverageScore()` is usually reached, that is where it surfaces.

## Fix

Use `nv`, bounded by both dimensions, and say so when there is nothing to decompose at all:

```
Cannot compute leverage scores from 1 features and 1 cells: at least two of each are needed
```

Behaviour is unchanged for objects with 50 or more of each, which is where the constant and the computed value agree.

## Tests

`tests/testthat/test_leverage_score_small.R`: leverage scores on `pbmc_small`, sketching to 40 cells, asking for more cells than exist (all of them are kept), and the message for a matrix with nothing to decompose.

Four assertions fail without the change. Full suite `NOT_CRAN=true`: 1187 passing, the only 2 failures being the pre-existing `Read10X_Image` ones fixed in #10454.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
