### PR TITLE
Say that a tree needs more than one identity

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- `BuildClusterTree` now says that at least two identities are needed, instead of `hclust` reporting \dQuote{must have n >= 2 objects to cluster}
+
 - Fixed `AddModuleScore` (and `CellCycleScoring`) on v5 objects with on-disk (e.g. BPCells) assays, where each layer was fully densified to an in-memory `dgCMatrix` before scoring; scoring now operates directly on the on-disk matrix
 - Fixed bug in `PercentageFeatureSet` where layer data was incorrectly retrieved prior to finding features with requested pattern ([#10438](https://github.com/satijalab/seurat/pull/10438))
 - Updated `as.SingleCellExperiment` to address conversion case where an object has both original and sketched assay / reductions (differing numbers of cells) ([#10419](https://github.com/satijalab/seurat/pull/10419))

--- a/R/tree.R
+++ b/R/tree.R
@@ -74,6 +74,16 @@ BuildClusterTree <- function(
     stop(cluster.ape, call. = FALSE)
   }
   assay <- assay %||% DefaultAssay(object = object)
+  # hclust() needs two things to join, and says so in its own terms:
+  # "must have n >= 2 objects to cluster"
+  if (length(x = levels(x = object)) < 2L) {
+    stop(
+      "Cannot build a tree from ", length(x = levels(x = object)),
+      " identity: at least two are needed. Set Idents() to a grouping with ",
+      "more than one level, or run FindClusters() first",
+      call. = FALSE
+    )
+  }
   if (!is.null(x = graph)) {
     idents <- levels(x = object)
     nclusters <- length(x = idents)

--- a/tests/testthat/test_cluster_tree.R
+++ b/tests/testthat/test_cluster_tree.R
@@ -1,0 +1,24 @@
+set.seed(42)
+
+# hclust() needs two things to join, and said so in its own terms:
+# "must have n >= 2 objects to cluster", which does not mention identities
+data("pbmc_small", package = "SeuratObject", envir = environment())
+
+test_that("one identity is reported as such", {
+  one <- subset(pbmc_small, idents = 0)
+  expect_error(
+    suppressWarnings(BuildClusterTree(one, verbose = FALSE)),
+    "Cannot build a tree from 1 identity"
+  )
+  expect_error(
+    suppressWarnings(BuildClusterTree(one, verbose = FALSE)),
+    "at least two are needed"
+  )
+})
+
+test_that("two identities still build a tree", {
+  skip_if_not_installed("ape")
+  two <- subset(pbmc_small, idents = c(0, 1))
+  built <- suppressWarnings(BuildClusterTree(two, verbose = FALSE))
+  expect_s3_class(Tool(built, slot = "BuildClusterTree"), "phylo")
+})


### PR DESCRIPTION
```r
> BuildClusterTree(subset(object, idents = 0))
Error in hclust(d = data.dist) : must have n >= 2 objects to cluster
```

Nothing in that mentions identities, and it comes from `hclust`, so the traceback does not help either. The object in this situation is usually a subset, where the identity count is precisely what the user needs to be told.

```
Cannot build a tree from 1 identity: at least two are needed. Set Idents() to a
grouping with more than one level, or run FindClusters() first
```

Found by sweeping with degenerate but ordinary arguments, not from an issue.

## Tests

`tests/testthat/test_cluster_tree.R`: the message on a one-identity subset, and two identities still building a `phylo` tree.

Two assertions fail without the change. Full suite `NOT_CRAN=true`: 1182 passing, the only 2 failures being the pre-existing `Read10X_Image` ones fixed in #10454.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
