### PR TITLE
Check what SCTransform is being given

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- `SCTransform` now says when cells have no counts for the features given, or when too few features are detected for a model to be fit, instead of failing inside `sctransform` with \dQuote{cell attribute "log_umi" contains NA, NaN, or infinite value} or \dQuote{need at least 2 data points} ([#8385](https://github.com/satijalab/seurat/issues/8385))
+
 - Fixed `AddModuleScore` (and `CellCycleScoring`) on v5 objects with on-disk (e.g. BPCells) assays, where each layer was fully densified to an in-memory `dgCMatrix` before scoring; scoring now operates directly on the on-disk matrix
 - Fixed bug in `PercentageFeatureSet` where layer data was incorrectly retrieved prior to finding features with requested pattern ([#10438](https://github.com/satijalab/seurat/pull/10438))
 - Updated `as.SingleCellExperiment` to address conversion case where an object has both original and sketched assay / reductions (differing numbers of cells) ([#10419](https://github.com/satijalab/seurat/pull/10419))

--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -3887,6 +3887,34 @@ SCTransform.default <- function(
   vst.args <- list(...)
   object <- as.sparse(x = object)
   umi <- object
+  # sctransform models log10 of the counts per cell, which is -Inf for a cell
+  # with none, and stops with 'cell attribute "log_umi" contains NA, NaN, or
+  # infinite value'. That happens as soon as features have been subset
+  empty.cells <- which(x = Matrix::colSums(x = umi) == 0)
+  if (length(x = empty.cells)) {
+    stop(
+      length(x = empty.cells), " of ", ncol(x = umi),
+      " cells have no counts for the features given",
+      if (!is.null(x = colnames(x = umi))) {
+        paste0(", such as ", paste(sQuote(x = head(x = colnames(x = umi)[empty.cells], n = 3L), q = FALSE), collapse = ", "))
+      },
+      ". Remove them first, for example with subset(object, subset = nCount_RNA > 0)",
+      call. = FALSE
+    )
+  }
+  # and it fits a density over the expressed features, which needs more than a
+  # couple of them: 'need at least 2 data points' out of bw.SJ() otherwise
+  min.cells <- vst.args[['min_cells']] %||% 5
+  expressed <- sum(Matrix::rowSums(x = umi > 0) >= min.cells)
+  if (expressed < 3L) {
+    stop(
+      "Only ", expressed, " features are detected in at least ", min.cells,
+      " cells, out of ", nrow(x = umi),
+      ". sctransform cannot fit a model to that; lower min_cells, or use ",
+      "NormalizeData() for an object this sparse",
+      call. = FALSE
+    )
+  }
   # check for batch_var in meta data
   if ('batch_var' %in% names(x = vst.args)) {
     if (!(vst.args[['batch_var']] %in% colnames(x = cell.attr))) {

--- a/tests/testthat/test_sctransform_input.R
+++ b/tests/testthat/test_sctransform_input.R
@@ -1,0 +1,41 @@
+set.seed(42)
+
+# sctransform models log10 of the counts per cell and fits a density over the
+# expressed features. Neither is defined for degenerate input, and both failed
+# from inside sctransform with messages that name neither the cells nor the
+# features involved
+data("pbmc_small", package = "SeuratObject", envir = environment())
+
+test_that("cells with no counts are named", {
+  skip_if_not_installed("sctransform")
+  # subsetting features leaves cells with nothing counted
+  few <- pbmc_small[1:8, ]
+  expect_gt(sum(Matrix::colSums(LayerData(few, layer = "counts")) == 0), 0)
+  expect_error(
+    suppressWarnings(SCTransform(few, verbose = FALSE)),
+    "cells have no counts for the features given"
+  )
+  expect_error(
+    suppressWarnings(SCTransform(few, verbose = FALSE)),
+    "nCount_RNA > 0"
+  )
+})
+
+test_that("too few detected features are reported", {
+  skip_if_not_installed("sctransform")
+  counts <- LayerData(pbmc_small, layer = "counts")
+  counts[, ] <- 0
+  counts[1:2, ] <- 3
+  object <- suppressWarnings(CreateSeuratObject(counts = counts))
+  expect_error(
+    suppressWarnings(SCTransform(object, verbose = FALSE)),
+    "features are detected in at least 5 cells"
+  )
+})
+
+test_that("an ordinary object still transforms", {
+  skip_if_not_installed("sctransform")
+  transformed <- suppressWarnings(SCTransform(pbmc_small, variable.features.n = 20, verbose = FALSE))
+  expect_true("SCT" %in% Assays(transformed))
+  expect_identical(ncol(transformed), ncol(pbmc_small))
+})


### PR DESCRIPTION
Two ways `SCTransform()` fails from inside `sctransform`, with messages that name neither the cells nor the features involved. Addresses #8385, and the recurring first one.

## A cell with no counts

`sctransform` models log10 of the counts per cell, which is `-Inf` for a cell that has none among the features given:

```
Error: cell attribute "log_umi" contains NA, NaN, or infinite value
```

This is one feature subset away at any time: `pbmc_small[1:8, ]` has 20 such cells out of 80. Nothing in the message says that cells are the problem, let alone which.

```
20 of 80 cells have no counts for the features given, such as 'GAACCTGATGAACC',
'TGACTGGATTCTCA', 'TGGTATCTAAACAG'. Remove them first, for example with
subset(object, subset = nCount_RNA > 0)
```

## Too few detected features

The variance stabilisation fits a density over the expressed features, and with too few of them:

```
Error in bw.SJ(genes_log_gmean_step1) : need at least 2 data points
```

which is what #8385 reports after merging and joining layers. The check here uses the `min_cells` that will be passed to `vst()`, so it agrees with what `sctransform` itself filters on:

```
Only 0 features are detected in at least 5 cells, out of 230. sctransform cannot fit a
model to that; lower min_cells, or use NormalizeData() for an object this sparse
```

## Scope

Both are checks on the input, before any work: an object that transforms today transforms identically, and an object that fails today still fails, with a message that says what to change.

## Tests

`tests/testthat/test_sctransform_input.R`: the cells message on a feature-subset object, the features message on a near-empty one, and an ordinary object still transforming.

Three assertions fail without the change. Full suite `NOT_CRAN=true`: 1185 passing, the only 2 failures being the pre-existing `Read10X_Image` ones fixed in #10454.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
