### PR TITLE
Make dimnames unique before building a Seurat object from an SCE

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Fixed `as.Seurat` on a `SingleCellExperiment` with duplicated cell names or feature names, which failed with `subscript out of bounds` because only the first matrix had its names made unique ([#10498](https://github.com/satijalab/seurat/issues/10498))
 - Fixed `AddModuleScore` (and `CellCycleScoring`) on v5 objects with on-disk (e.g. BPCells) assays, where each layer was fully densified to an in-memory `dgCMatrix` before scoring; scoring now operates directly on the on-disk matrix ([#10448](https://github.com/satijalab/seurat/pull/10448))
 - Fixed `GetResidual()` to correctly handle multi-model SCT assays with partial feature overlap ([#10541](https://github.com/satijalab/seurat/pull/10451))
 - Fixed bug in `PercentageFeatureSet` where layer data was incorrectly retrieved prior to finding features with requested pattern ([#10438](https://github.com/satijalab/seurat/pull/10438))

--- a/R/objects.R
+++ b/R/objects.R
@@ -1181,6 +1181,27 @@ as.Seurat.SingleCellExperiment <- function(
       call. = FALSE
     )
   }
+  # `CreateAssayObject()` uniquifies duplicated dimnames on the first matrix
+  # alone, so the second one keeps the original names and no longer lines up
+  # with the assay: `SetAssayData()` then reindexes with names that are not
+  # there and fails with an opaque "subscript out of bounds". Uniquify once, up
+  # front, so every assay, `colData()` and reduction carries the same names.
+  if (anyDuplicated(x = rownames(x = x))) {
+    warning(
+      "Non-unique features (rownames) present in the SingleCellExperiment, making unique",
+      call. = FALSE,
+      immediate. = TRUE
+    )
+    rownames(x = x) <- make.unique(names = rownames(x = x))
+  }
+  if (anyDuplicated(x = colnames(x = x))) {
+    warning(
+      "Non-unique cell names (colnames) present in the SingleCellExperiment, making unique",
+      call. = FALSE,
+      immediate. = TRUE
+    )
+    colnames(x = x) <- make.unique(names = colnames(x = x))
+  }
   meta.data <- as.data.frame(x = SummarizedExperiment::colData(x = x))
   if (packageVersion(pkg = "SingleCellExperiment") >= "1.14.0") {
     orig.exp <- SingleCellExperiment::mainExpName(x = x) %||% "originalexp"

--- a/tests/testthat/test_objects.R
+++ b/tests/testthat/test_objects.R
@@ -23,3 +23,44 @@ test_that("as.SingleCellExperiment works", {
     # expect_equal(SingleCellExperiment::mainExpName(sce), 'RNA')
   }
 })
+
+test_that("as.Seurat handles a SingleCellExperiment with duplicated names", {
+  skip_on_cran()
+  skip_if_not_installed('SingleCellExperiment')
+  mat <- as.matrix(x = pbmc_small[["RNA"]]$counts[1:20, 1:6])
+  # a multi-sample aggregate repeats barcodes across samples
+  colnames(x = mat) <- rep(x = c('AAA', 'BBB', 'CCC'), times = 2)
+  rownames(x = mat) <- c(paste0('g', 1:19), 'g1')
+  mat <- as.sparse(x = mat)
+  sce <- SingleCellExperiment::SingleCellExperiment(
+    assays = list(counts = mat, logcounts = mat)
+  )
+
+  warns <- character(length = 0L)
+  obj <- withCallingHandlers(
+    expr = as.Seurat(x = sce),
+    warning = function(w) {
+      warns <<- c(warns, conditionMessage(c = w))
+      invokeRestart(r = 'muffleWarning')
+    }
+  )
+  expect_true(object = any(grepl(pattern = 'Non-unique features', x = warns)))
+  expect_true(object = any(grepl(pattern = 'Non-unique cell names', x = warns)))
+  expect_s4_class(object = obj, class = 'Seurat')
+  expect_equal(object = ncol(x = obj), expected = 6)
+  expect_equal(object = nrow(x = obj), expected = 20)
+  expect_equal(
+    object = colnames(x = obj),
+    expected = c('AAA', 'BBB', 'CCC', 'AAA.1', 'BBB.1', 'CCC.1')
+  )
+  expect_equal(
+    object = rownames(x = obj),
+    expected = c(paste0('g', 1:19), 'g1.1')
+  )
+  # the second matrix must survive the round trip, not just `counts`
+  expect_equal(
+    object = as.matrix(x = LayerData(object = obj, layer = 'data')),
+    expected = as.matrix(x = LayerData(object = obj, layer = 'counts'))
+  )
+  expect_equal(object = rownames(x = obj[[]]), expected = colnames(x = obj))
+})


### PR DESCRIPTION
Fixes the failure reported in #10498 (comment).

`as.Seurat()` on a `SingleCellExperiment` whose cells carry duplicated barcodes, the normal case for a multi-sample aggregate, fails with an opaque error:

```r
m <- abs(round(Matrix::rsparsematrix(20, 6, 0.3) * 10))
rownames(m) <- paste0("g", 1:20)
colnames(m) <- c("AAA", "BBB", "CCC", "AAA", "BBB", "CCC")
sce <- SingleCellExperiment(assays = list(counts = m, logcounts = m))

as.Seurat(sce)
#> Warning: Non-unique cell names (colnames) present in the input matrix, making unique
#> Error in .subscript.2ary(x, i, j, drop = drop) : subscript out of bounds
```

## Why

The assay is built from `counts` first, and `CreateAssayObject()` calls `make.unique()` on that matrix alone, turning the barcodes into `"AAA"` and `"AAA.1"`. `logcounts` is then added with `SetAssayData()`, which reindexes it as `new.data[new.features, colnames(object)]`. `colnames(object)` now holds `"AAA.1"`, a name that does not exist in `logcounts`, so the character subscript fails.

Duplicated feature names hit the same seam from the other side: `match(counts.names, rownames(new.data))` drops the renamed features and the call ends in `Attempting to add a different number of cells and/or features`.

Subsetting hides it, which is why the report showed `as.Seurat(all[, 1:1000])` working: the first 1000 barcodes of that object happen to be unique.

## The change

Uniquify once, up front, on the `SingleCellExperiment` itself, so every assay, `colData()` and reduction carries the same names before any of them is used. `as.data.frame(colData(x))` already uniquifies the same way, so the metadata rownames keep matching the cell names. Both axes warn, matching the wording `CreateAssayObject()` already uses.

## Verification

New test in `tests/testthat/test_objects.R` builds an SCE with both duplicated barcodes and a duplicated feature, and asserts the two warnings, the uniquified dimnames, the metadata rownames, and that `logcounts` survives the round trip rather than only `counts`. It fails on `main` at `.subscript.2ary` and passes with the change.

Independent of the #10494 series; it is not the `dgCMatrix` 2^31 limit, just a name-handling bug on the same code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
