### PR TITLE
Fix `FindSpatiallyVariableFeatures` cell lookup for `FOV` spatial images

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: Seurat
-Version: 5.5.1.9004
+Version: 5.5.1.9005
 Title: Tools for Single Cell Genomics
 Description: A toolkit for quality control, analysis, and exploration of single cell RNA sequencing data. 'Seurat' aims to enable users to identify and interpret sources of heterogeneity from single cell transcriptomic measurements, and to integrate diverse types of single cell data. See Satija R, Farrell J, Gennert D, et al (2015) <doi:10.1038/nbt.3192>, Macosko E, Basu A, Satija R, et al (2015) <doi:10.1016/j.cell.2015.05.002>, Stuart T, Butler A, et al (2019) <doi:10.1016/j.cell.2019.05.031>, and Hao, Hao, et al (2020) <doi:10.1101/2020.10.12.335331> for more details.
 Authors@R: c(

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,9 @@
 - Fixed naming of combined p-value column in output of `FindConservedMarkers` when a non-default `meta.method` is specified ([#10429](https://github.com/satijalab/seurat/pull/10429))
 - Updated minimum required `uwot` version to `0.2.1` ([#10447](https://github.com/satijalab/seurat/pull/10447))
 - Registered `Radius.VisiumV2` as an S3 method to fix `Radius` returning `NULL` for `VisiumV2` images ([#10454](https://github.com/satijalab/seurat/pull/10454))
+- Fixed `FindSpatiallyVariableFeatures()` to correctly match FOV coordinates to cells in the requested assay and handle various edge cases, including fewer than two matched cells, a single varying feature, or no varying requested features ([#10504](https://github.com/satijalab/seurat/pull/10504))
+- Updated argument handling in `FindSpatiallyVariableFeatures()` by resolving `selection.method` with `match.arg()` and restoring the `FindSpatiallyVariableFeatures.Assay()` default `nfeatures` value to `2000` ([#10504](https://github.com/satijalab/seurat/pull/10504))
+- Fixed `RunMarkVario()` to return one named mark variogram result per feature for single-feature inputs and parallel execution chunks ([#10505](https://github.com/satijalab/seurat/pull/10505))
 
 # Seurat 5.5.1
 

--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -3650,15 +3650,28 @@ RunMarkVario <- function(
       f = ceiling(x = seq_along(along.with = features) / (length(x = features) / chunks))
     )
     mv <- future_lapply(X = features, FUN = function(x) {
-      pp[["marks"]] <- as.data.frame(x = t(x = data[x, ]))
-      markvario(X = pp, normalise = TRUE, ...)
+      # drop = FALSE so that a chunk holding a single feature stays a matrix
+      # and t() keeps one row per cell
+      pp[["marks"]] <- as.data.frame(x = t(x = data[x, , drop = FALSE]))
+      chunk <- markvario(X = pp, normalise = TRUE, ...)
+      # markvario() hands back a bare 'fv' for a single mark and a named list
+      # of them for several. Keep every chunk a list, so that the unlist()
+      # below contributes one entry per feature rather than one per column of
+      # an 'fv' whenever a chunk holds a single feature.
+      if (inherits(x = chunk, what = 'fv')) {
+        chunk <- list(chunk)
+      }
+      return(chunk)
     })
     mv <- unlist(x = mv, recursive = FALSE)
-    names(x = mv) <- rownames(x = data)
   } else {
     pp[["marks"]] <- as.data.frame(x = t(x = data))
     mv <- markvario(X = pp, normalise = TRUE, ...)
+    if (inherits(x = mv, what = 'fv')) {
+      mv <- list(mv)
+    }
   }
+  names(x = mv) <- rownames(x = data)
   return(mv)
 }
 
@@ -4756,14 +4769,22 @@ FindSpatiallyVariableFeatures.Assay <- function(
   data <- LayerData(object, layer = layer, cells = cells, features = features)
   data <- as.matrix(x = data)
   # RowVar() is C++ and aborts the session on an empty matrix rather than
-  # raising an R error, so catch any remaining path that produces one.
-  if (!ncol(x = data)) {
+  # raising an R error, so catch any remaining path that produces one. One
+  # column is caught here too: RowVar() divides by 'ncol - 1', so a single
+  # cell yields NaN for every feature, and the NA subscript that follows
+  # fails further down with a message that says nothing about the cause.
+  if (ncol(x = data) < 2) {
     stop(
-      "No cells were returned from the '", layer, "' layer.",
+      "Fewer than two cells were returned from the '", layer, "' layer; ",
+      "spatial variability is measured across cells and needs at least two. ",
+      "Check that the row names of 'spatial.location' are cell names.",
       call. = FALSE
     )
   }
-  data <- data[RowVar(x = data) > 0, ]
+  # Keep a single surviving feature as a one-row matrix; without drop = FALSE
+  # it becomes a vector and the call fails on 'attempt to set colnames on an
+  # object with less than two dimensions'.
+  data <- data[RowVar(x = data) > 0, , drop = FALSE]
   if (nrow(x = data) != 0) {
     svf.info <- FindSpatiallyVariableFeatures(
       object = data,
@@ -4778,10 +4799,22 @@ FindSpatiallyVariableFeatures.Assay <- function(
   } else {
     svf.info <- c()
   }
+  if (selection.method == "markvariogram" &&
+      "markvariogram" %in% names(x = Misc(object = object))) {
+    svf.info <- c(svf.info, Misc(object = object, slot = "markvariogram"))
+  }
+  # Nothing was computed and nothing was cached: every requested feature had
+  # zero variance. The branches below index into 'svf.info', so return here
+  # rather than letting them fail on a NULL.
+  if (!length(x = svf.info)) {
+    warning(
+      "None of the requested features vary across the given cells in the '",
+      layer, "' layer; returning the object unchanged.",
+      call. = FALSE
+    )
+    return(object)
+  }
   if (selection.method == "markvariogram") {
-    if ("markvariogram" %in% names(x = Misc(object = object))) {
-      svf.info <- c(svf.info, Misc(object = object, slot = "markvariogram"))
-    }
     suppressWarnings(expr = Misc(object = object, slot = "markvariogram") <- svf.info)
     svf.info <- ComputeRMetric(mv = svf.info, r.metric)
     svf.info <- svf.info[order(svf.info[, 1]), , drop = FALSE]

--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -4759,7 +4759,8 @@ FindSpatiallyVariableFeatures.Assay <- function(
     features <- features[! features %in% features.computed]
   }
   cells <- rownames(spatial.location)
-  if (!any(cells %in% Cells(x = object, layer = layer))) {
+  cell.mismatch <- setdiff(cells, Cells(x = object, layer = layer))
+  if (length(cell.mismatch) > 0L) {
     stop(
       "None of the row names in 'spatial.location' match cells in the '",
       layer, "' layer. Row names must be cell names.",

--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -4726,7 +4726,7 @@ FindSpatiallyVariableFeatures.Assay <- function(
   r.metric = 5,
   x.cuts = NULL,
   y.cuts = NULL,
-  nfeatures = nfeatures,
+  nfeatures = 2000,
   verbose = TRUE,
   ...
 ) {

--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -4746,8 +4746,23 @@ FindSpatiallyVariableFeatures.Assay <- function(
     features <- features[! features %in% features.computed]
   }
   cells <- rownames(spatial.location)
+  if (!any(cells %in% Cells(x = object, layer = layer))) {
+    stop(
+      "None of the row names in 'spatial.location' match cells in the '",
+      layer, "' layer. Row names must be cell names.",
+      call. = FALSE
+    )
+  }
   data <- LayerData(object, layer = layer, cells = cells, features = features)
   data <- as.matrix(x = data)
+  # RowVar() is C++ and aborts the session on an empty matrix rather than
+  # raising an R error, so catch any remaining path that produces one.
+  if (!ncol(x = data)) {
+    stop(
+      "No cells were returned from the '", layer, "' layer.",
+      call. = FALSE
+    )
+  }
   data <- data[RowVar(x = data) > 0, ]
   if (nrow(x = data) != 0) {
     svf.info <- FindSpatiallyVariableFeatures(
@@ -4821,8 +4836,31 @@ FindSpatiallyVariableFeatures.Seurat <- function(
 
   assay <- assay %||% DefaultAssay(object = object)
   selection.method <- match.arg(arg = selection.method)
+  images <- Images(object = object, assay = assay)
+  if (is.null(x = image)) {
+    if (!length(x = images)) {
+      stop(
+        "No image is associated with assay ", sQuote(x = assay, q = FALSE),
+        call. = FALSE
+      )
+    }
+    image <- images[[1L]]
+  }
   features <- features %||% Features(object, assay = assay, layer = layer)
   tc <- GetTissueCoordinates(object = object[[image]])
+  if ('cell' %in% colnames(x = tc)) {
+    cell.names <- as.character(x = tc[['cell']])
+    if (anyNA(cell.names) || any(!nzchar(x = cell.names)) || anyDuplicated(x = cell.names)) {
+      stop(
+        "Spatial coordinates must contain exactly one row per cell. Use ",
+        "'DefaultBoundary()' to select a centroid-based boundary or provide ",
+        "'spatial.location'.",
+        call. = FALSE
+      )
+    }
+    rownames(x = tc) <- cell.names
+    tc <- tc[, setdiff(x = colnames(x = tc), y = 'cell'), drop = FALSE]
+  }
 
   object[[assay]] <- FindSpatiallyVariableFeatures(
     object = object[[assay]],

--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -4781,9 +4781,9 @@ FindSpatiallyVariableFeatures.Assay <- function(
       call. = FALSE
     )
   }
-  # Keep a single surviving feature as a one-row matrix; without drop = FALSE
-  # it becomes a vector and the call fails on 'attempt to set colnames on an
-  # object with less than two dimensions'.
+  # Keep a single surviving feature as a one-row matrix; without drop = FALSE it
+  # becomes a vector and `nrow()` returns NULL, triggering "argument is of length
+  # zero" in the `if (nrow(x = data) != 0)` check below.
   data <- data[RowVar(x = data) > 0, , drop = FALSE]
   if (nrow(x = data) != 0) {
     svf.info <- FindSpatiallyVariableFeatures(

--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -4762,8 +4762,8 @@ FindSpatiallyVariableFeatures.Assay <- function(
   cell.mismatch <- setdiff(cells, Cells(x = object, layer = layer))
   if (length(cell.mismatch) > 0L) {
     stop(
-      "None of the row names in 'spatial.location' match cells in the '",
-      layer, "' layer. Row names must be cell names.",
+      "At least some of the row names in 'spatial.location' do not match cells in the '",
+      layer, "' layer; check that the row names of 'spatial.location' are cell names.",
       call. = FALSE
     )
   }
@@ -4777,8 +4777,7 @@ FindSpatiallyVariableFeatures.Assay <- function(
   if (ncol(x = data) < 2) {
     stop(
       "Fewer than two cells were returned from the '", layer, "' layer; ",
-      "spatial variability is measured across cells and needs at least two. ",
-      "Check that the row names of 'spatial.location' are cell names.",
+      "finding spatially variable features requires at least two cells.",
       call. = FALSE
     )
   }

--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -4673,6 +4673,7 @@ FindSpatiallyVariableFeatures.default <- function(
   verbose = TRUE,
   ...
 ) {
+  selection.method <- match.arg(arg = selection.method)
   # error check dimensions
   if (ncol(x = object) != nrow(x = spatial.location)) {
     stop("Please provide the same number of observations as spatial locations.")
@@ -4739,6 +4740,7 @@ FindSpatiallyVariableFeatures.Assay <- function(
     layer <- slot %||% layer
   }
   features <- features %||% Features(object, layer = layer)
+  selection.method <- match.arg(selection.method)
   if (selection.method == "markvariogram" && "markvariogram" %in% names(x = Misc(object = object))) {
     features.computed <- names(x = Misc(object = object, slot = "markvariogram"))
     features <- features[! features %in% features.computed]
@@ -4818,7 +4820,7 @@ FindSpatiallyVariableFeatures.Seurat <- function(
   }
 
   assay <- assay %||% DefaultAssay(object = object)
-  image <- image %||% DefaultImage(object = object)
+  selection.method <- match.arg(arg = selection.method)
   features <- features %||% Features(object, assay = assay, layer = layer)
   tc <- GetTissueCoordinates(object = object[[image]])
 

--- a/man/FindSpatiallyVariableFeatures.Rd
+++ b/man/FindSpatiallyVariableFeatures.Rd
@@ -32,7 +32,7 @@ FindSpatiallyVariableFeatures(object, ...)
   r.metric = 5,
   x.cuts = NULL,
   y.cuts = NULL,
-  nfeatures = nfeatures,
+  nfeatures = 2000,
   verbose = TRUE,
   ...
 )
@@ -63,7 +63,7 @@ FindSpatiallyVariableFeatures(object, ...)
   r.metric = 5,
   x.cuts = NULL,
   y.cuts = NULL,
-  nfeatures = nfeatures,
+  nfeatures = 2000,
   verbose = TRUE,
   ...
 )

--- a/tests/testthat/test_spatial.R
+++ b/tests/testthat/test_spatial.R
@@ -418,3 +418,113 @@ test_that("FindSpatiallyVariableFeatures uses FOV cell names for the requested a
     "centroid-based boundary"
   )
 })
+
+# Degenerate inputs to FindSpatiallyVariableFeatures ---------------------------
+
+#' Returns a small assay plus matching coordinates for the tests below.
+build_svf_case <- function(counts) {
+  object <- suppressWarnings(CreateSeuratObject(counts = as.sparse(counts)))
+  object <- suppressWarnings(NormalizeData(object, verbose = FALSE))
+  list(
+    assay = object[["RNA"]],
+    coordinates = data.frame(
+      x = seq_len(ncol(counts)),
+      y = rev(seq_len(ncol(counts))),
+      row.names = colnames(counts)
+    )
+  )
+}
+
+svf_counts <- function(varying = 0L) {
+  cells <- paste0("cell", seq_len(12L))
+  counts <- matrix(
+    data = 3L,
+    nrow = 4L,
+    ncol = length(x = cells),
+    dimnames = list(paste0("gene", 1:4), cells)
+  )
+  for (i in seq_len(varying)) {
+    counts[i, ] <- sample(x = seq_along(cells))
+  }
+  return(counts)
+}
+
+test_that("FindSpatiallyVariableFeatures needs at least two cells", {
+  set.seed(42)
+  case <- build_svf_case(svf_counts(varying = 4L))
+  # Only the first row name is a real cell, which is enough to clear the check
+  # on 'spatial.location' but leaves a single column to compute variance over.
+  coordinates <- case$coordinates
+  rownames(x = coordinates) <- c(
+    rownames(x = coordinates)[1],
+    paste0("absent", seq_len(nrow(x = coordinates) - 1L))
+  )
+  expect_error(
+    FindSpatiallyVariableFeatures(
+      case$assay,
+      layer = "counts",
+      features = rownames(x = case$assay),
+      spatial.location = coordinates,
+      selection.method = "moransi",
+      verbose = FALSE
+    ),
+    "at least two"
+  )
+})
+
+test_that("FindSpatiallyVariableFeatures handles a single varying feature", {
+  for (method in c("moransi", "markvariogram")) {
+    set.seed(42)
+    case <- build_svf_case(svf_counts(varying = 1L))
+    result <- suppressWarnings(FindSpatiallyVariableFeatures(
+      case$assay,
+      layer = "counts",
+      features = rownames(x = case$assay),
+      spatial.location = case$coordinates,
+      selection.method = method,
+      nfeatures = 4L,
+      verbose = FALSE
+    ))
+    expect_equal(SpatiallyVariableFeatures(result, method = method), "gene1")
+  }
+})
+
+test_that("FindSpatiallyVariableFeatures warns when nothing varies", {
+  for (method in c("moransi", "markvariogram")) {
+    set.seed(42)
+    case <- build_svf_case(svf_counts(varying = 0L))
+    expect_warning(
+      result <- FindSpatiallyVariableFeatures(
+        case$assay,
+        layer = "counts",
+        features = rownames(x = case$assay),
+        spatial.location = case$coordinates,
+        selection.method = method,
+        verbose = FALSE
+      ),
+      "None of the requested features vary"
+    )
+    expect_identical(result, case$assay)
+  }
+})
+
+test_that("RunMarkVario returns one named entry per feature", {
+  set.seed(42)
+  n.cells <- 12L
+  positions <- data.frame(x = seq_len(n.cells), y = rev(seq_len(n.cells)))
+  # markvario() hands back a bare 'fv' for a single mark and a named list of
+  # them for several; the caller relies on always getting the list.
+  for (n.features in c(1L, 3L)) {
+    marks <- matrix(
+      data = rnorm(n = n.features * n.cells),
+      nrow = n.features,
+      dimnames = list(
+        paste0("gene", seq_len(n.features)),
+        paste0("cell", seq_len(n.cells))
+      )
+    )
+    mv <- RunMarkVario(spatial.location = positions, data = marks)
+    expect_named(mv, rownames(x = marks))
+    expect_true(all(vapply(mv, inherits, logical(1L), what = "fv")))
+  }
+})

--- a/tests/testthat/test_spatial.R
+++ b/tests/testthat/test_spatial.R
@@ -350,3 +350,71 @@ test_that("SpatialDimPlot works with multiple assays, layers, & images", {
   expect_true(equivalent_plots(plots[[1]], plot.2))
   expect_true(equivalent_plots(plots[[2]], plot.1))
 })
+
+test_that("FindSpatiallyVariableFeatures uses FOV cell names for the requested assay", {
+  set.seed(42)
+  test.case <- merge(test.data.1, test.data.3)
+  segment.cells <- colnames(x = test.case[["Spatial.A"]])
+  bin.cells <- colnames(x = test.case[["Spatial.B"]])
+  features <- rownames(x = test.case[["Spatial.B"]])[1:6]
+
+  test.case[["slice1.A"]] <- NULL
+  test.case[["slice2.B"]] <- NULL
+  test.case[["segmentation"]] <- CreateFOV(
+    CreateSegmentation(data.frame(
+      x = rep(c(0, 1, 1, 0), 2L) + rep(1:2, each = 4L),
+      y = rep(c(0, 0, 1, 1), 2L),
+      cell = rep(segment.cells[1:2], each = 4L)
+    )),
+    assay = "Spatial.A"
+  )
+  test.case[["bins"]] <- CreateFOV(
+    CreateCentroids(data.frame(
+      x = runif(length(x = bin.cells)) * 100,
+      y = runif(length(x = bin.cells)) * 100,
+      cell = bin.cells
+    )),
+    type = "centroids",
+    assay = "Spatial.B"
+  )
+  DefaultAssay(test.case) <- "Spatial.A"
+  test.case <- suppressWarnings(NormalizeData(test.case, assay = "Spatial.B", verbose = FALSE))
+
+  result <- suppressWarnings(FindSpatiallyVariableFeatures(
+    test.case,
+    assay = "Spatial.B",
+    layer = "data",
+    features = features,
+    selection.method = "markvariogram",
+    verbose = FALSE
+  ))
+  expect_length(SpatiallyVariableFeatures(result[["Spatial.B"]], method = "markvariogram"), 6L)
+
+  coords <- GetTissueCoordinates(test.case[["bins"]])[, c("x", "y")]
+  rownames(coords) <- seq_len(nrow(coords))
+  expect_error(
+    FindSpatiallyVariableFeatures(
+      test.case[["Spatial.B"]],
+      layer = "data",
+      features = features,
+      spatial.location = coords,
+      selection.method = "markvariogram",
+      nfeatures = length(x = features),
+      verbose = FALSE
+    ),
+    "Row names must be cell names"
+  )
+
+  expect_error(
+    suppressWarnings(FindSpatiallyVariableFeatures(
+      test.case,
+      assay = "Spatial.A",
+      layer = "counts",
+      image = "segmentation",
+      features = features,
+      selection.method = "markvariogram",
+      verbose = FALSE
+    )),
+    "centroid-based boundary"
+  )
+})

--- a/tests/testthat/test_spatial.R
+++ b/tests/testthat/test_spatial.R
@@ -402,7 +402,7 @@ test_that("FindSpatiallyVariableFeatures uses FOV cell names for the requested a
       nfeatures = length(x = features),
       verbose = FALSE
     ),
-    "Row names must be cell names"
+    "row names in 'spatial.location' do not match cells"
   )
 
   expect_error(
@@ -419,63 +419,46 @@ test_that("FindSpatiallyVariableFeatures uses FOV cell names for the requested a
   )
 })
 
-# Degenerate inputs to FindSpatiallyVariableFeatures ---------------------------
-
 #' Returns a small assay plus matching coordinates for the tests below.
-build_svf_case <- function(counts) {
+build_svf_case <- function(n_features_vary = 0L) {
+  cells <- paste0("cell", seq_len(12L))
+  counts <- matrix(3L, nrow = 4L, ncol = length(x = cells))
+  dimnames(x = counts) <- list(paste0("gene", 1:4), cells)
+  for (i in seq_len(n_features_vary)) {
+    counts[i, ] <- sample(x = seq_along(cells))
+  }
   object <- suppressWarnings(CreateSeuratObject(counts = as.sparse(counts)))
   object <- suppressWarnings(NormalizeData(object, verbose = FALSE))
   list(
     assay = object[["RNA"]],
     coordinates = data.frame(
-      x = seq_len(ncol(counts)),
-      y = rev(seq_len(ncol(counts))),
-      row.names = colnames(counts)
+      x = seq_len(length(x = cells)),
+      y = rev(seq_len(length(x = cells))),
+      row.names = cells
     )
   )
 }
 
-svf_counts <- function(varying = 0L) {
-  cells <- paste0("cell", seq_len(12L))
-  counts <- matrix(
-    data = 3L,
-    nrow = 4L,
-    ncol = length(x = cells),
-    dimnames = list(paste0("gene", 1:4), cells)
-  )
-  for (i in seq_len(varying)) {
-    counts[i, ] <- sample(x = seq_along(cells))
-  }
-  return(counts)
-}
-
-test_that("FindSpatiallyVariableFeatures needs at least two cells", {
+test_that("FindSpatiallyVariableFeatures handles bad inputs", {
   set.seed(42)
-  case <- build_svf_case(svf_counts(varying = 4L))
-  # Only the first row name is a real cell, which is enough to clear the check
-  # on 'spatial.location' but leaves a single column to compute variance over.
-  coordinates <- case$coordinates
-  rownames(x = coordinates) <- c(
-    rownames(x = coordinates)[1],
-    paste0("absent", seq_len(nrow(x = coordinates) - 1L))
-  )
+  case <- build_svf_case(n_features_vary = 4L)
+  # error when there are too few cells passed to spatial.location
   expect_error(
     FindSpatiallyVariableFeatures(
       case$assay,
       layer = "counts",
       features = rownames(x = case$assay),
-      spatial.location = coordinates,
+      spatial.location = case$coordinates[1, , drop = FALSE],
       selection.method = "moransi",
       verbose = FALSE
     ),
     "at least two"
   )
-})
 
-test_that("FindSpatiallyVariableFeatures handles a single varying feature", {
+  # test that no errors are thrown when identifying a single varying feature
   for (method in c("moransi", "markvariogram")) {
     set.seed(42)
-    case <- build_svf_case(svf_counts(varying = 1L))
+    case <- build_svf_case(n_features_vary = 1L)
     result <- suppressWarnings(FindSpatiallyVariableFeatures(
       case$assay,
       layer = "counts",
@@ -487,25 +470,21 @@ test_that("FindSpatiallyVariableFeatures handles a single varying feature", {
     ))
     expect_equal(SpatiallyVariableFeatures(result, method = method), "gene1")
   }
-})
 
-test_that("FindSpatiallyVariableFeatures warns when nothing varies", {
-  for (method in c("moransi", "markvariogram")) {
-    set.seed(42)
-    case <- build_svf_case(svf_counts(varying = 0L))
-    expect_warning(
-      result <- FindSpatiallyVariableFeatures(
-        case$assay,
-        layer = "counts",
-        features = rownames(x = case$assay),
-        spatial.location = case$coordinates,
-        selection.method = method,
-        verbose = FALSE
-      ),
-      "None of the requested features vary"
-    )
-    expect_identical(result, case$assay)
-  }
+  # warn when no features vary
+  case <- build_svf_case(n_features_vary = 0L)
+  expect_warning(
+    result <- FindSpatiallyVariableFeatures(
+      case$assay,
+      layer = "counts",
+      features = rownames(x = case$assay),
+      spatial.location = case$coordinates,
+      selection.method = "markvariogram",
+      verbose = FALSE
+    ),
+    "None of the requested features vary"
+  )
+  expect_identical(result, case$assay)
 })
 
 test_that("RunMarkVario returns one named entry per feature", {


### PR DESCRIPTION
This PR proposes changes based on https://github.com/satijalab/seurat/pull/10457, but with a narrower scope.

# Summary

`FindSpatiallyVariableFeatures()` assumed `rownames(spatial.location)` were cell names. For FOV-backed data such as CosMx/Xenium/Vizgen-style objects, GetTissueCoordinates() can return coordinates like:

|     | x   | y | cell |
|-----|-----|---|------|
| 1   | ... |   |      |
| 2   | ... |   |      |
| ... |     |   |      |

(That is, with integer row names and the real cell IDs in the cell column.) The `Assay`/`StdAssay` method then used row names like 1, 2, 3 to pull expression data, found no matching cells, produced a matrix with zero columns, and passed that to RowVar(), which could segfault.

Both this PR and 10457 address the core bug by using the cell column as coordinate row names before moving down the method dispatch. There are also two small fixes in both PRs that address other issues:  resolving the `selection.method` argument with `match.arg()` and fixing the wrong `nfeatures = nfeatures` default in `FindVariableFeatures.Assay/StdAssay` to `nfeatures = 2000`.

This branch proposes an additional safeguard on the cell column prior to using it as rownames: we check for duplicates, which occur when the default boundary for the selected image as segmentation-based. In that case, multiple coordinate rows can refer to the same cell (where each row represents coordinates for one vertex of the segmentation polygon). If this is true, users are directed to choose a centroid-based boundary or provide `spatial.location`.

The test added to `test_spatial.R` covers the assay-specific FOV case and also explicitly checks the segmentation boundary path.