### PR TITLE
Handle degenerate inputs to FindSpatiallyVariableFeatures

### DIFF
--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -3650,15 +3650,28 @@ RunMarkVario <- function(
       f = ceiling(x = seq_along(along.with = features) / (length(x = features) / chunks))
     )
     mv <- future_lapply(X = features, FUN = function(x) {
-      pp[["marks"]] <- as.data.frame(x = t(x = data[x, ]))
-      markvario(X = pp, normalise = TRUE, ...)
+      # drop = FALSE so that a chunk holding a single feature stays a matrix
+      # and t() keeps one row per cell
+      pp[["marks"]] <- as.data.frame(x = t(x = data[x, , drop = FALSE]))
+      chunk <- markvario(X = pp, normalise = TRUE, ...)
+      # markvario() hands back a bare 'fv' for a single mark and a named list
+      # of them for several. Keep every chunk a list, so that the unlist()
+      # below contributes one entry per feature rather than one per column of
+      # an 'fv' whenever a chunk holds a single feature.
+      if (inherits(x = chunk, what = 'fv')) {
+        chunk <- list(chunk)
+      }
+      return(chunk)
     })
     mv <- unlist(x = mv, recursive = FALSE)
-    names(x = mv) <- rownames(x = data)
   } else {
     pp[["marks"]] <- as.data.frame(x = t(x = data))
     mv <- markvario(X = pp, normalise = TRUE, ...)
+    if (inherits(x = mv, what = 'fv')) {
+      mv <- list(mv)
+    }
   }
+  names(x = mv) <- rownames(x = data)
   return(mv)
 }
 
@@ -4756,14 +4769,22 @@ FindSpatiallyVariableFeatures.Assay <- function(
   data <- LayerData(object, layer = layer, cells = cells, features = features)
   data <- as.matrix(x = data)
   # RowVar() is C++ and aborts the session on an empty matrix rather than
-  # raising an R error, so catch any remaining path that produces one.
-  if (!ncol(x = data)) {
+  # raising an R error, so catch any remaining path that produces one. One
+  # column is caught here too: RowVar() divides by 'ncol - 1', so a single
+  # cell yields NaN for every feature, and the NA subscript that follows
+  # fails further down with a message that says nothing about the cause.
+  if (ncol(x = data) < 2) {
     stop(
-      "No cells were returned from the '", layer, "' layer.",
+      "Fewer than two cells were returned from the '", layer, "' layer; ",
+      "spatial variability is measured across cells and needs at least two. ",
+      "Check that the row names of 'spatial.location' are cell names.",
       call. = FALSE
     )
   }
-  data <- data[RowVar(x = data) > 0, ]
+  # Keep a single surviving feature as a one-row matrix; without drop = FALSE
+  # it becomes a vector and the call fails on 'attempt to set colnames on an
+  # object with less than two dimensions'.
+  data <- data[RowVar(x = data) > 0, , drop = FALSE]
   if (nrow(x = data) != 0) {
     svf.info <- FindSpatiallyVariableFeatures(
       object = data,
@@ -4778,10 +4799,22 @@ FindSpatiallyVariableFeatures.Assay <- function(
   } else {
     svf.info <- c()
   }
+  if (selection.method == "markvariogram" &&
+      "markvariogram" %in% names(x = Misc(object = object))) {
+    svf.info <- c(svf.info, Misc(object = object, slot = "markvariogram"))
+  }
+  # Nothing was computed and nothing was cached: every requested feature had
+  # zero variance. The branches below index into 'svf.info', so return here
+  # rather than letting them fail on a NULL.
+  if (!length(x = svf.info)) {
+    warning(
+      "None of the requested features vary across the given cells in the '",
+      layer, "' layer; returning the object unchanged.",
+      call. = FALSE
+    )
+    return(object)
+  }
   if (selection.method == "markvariogram") {
-    if ("markvariogram" %in% names(x = Misc(object = object))) {
-      svf.info <- c(svf.info, Misc(object = object, slot = "markvariogram"))
-    }
     suppressWarnings(expr = Misc(object = object, slot = "markvariogram") <- svf.info)
     svf.info <- ComputeRMetric(mv = svf.info, r.metric)
     svf.info <- svf.info[order(svf.info[, 1]), , drop = FALSE]

--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -4781,9 +4781,9 @@ FindSpatiallyVariableFeatures.Assay <- function(
       call. = FALSE
     )
   }
-  # Keep a single surviving feature as a one-row matrix; without drop = FALSE
-  # it becomes a vector and the call fails on 'attempt to set colnames on an
-  # object with less than two dimensions'.
+  # Keep a single surviving feature as a one-row matrix; without drop = FALSE it
+  # becomes a vector and `nrow()` returns NULL, triggering "argument is of length
+  # zero" in the `if (nrow(x = data) != 0)` check below.
   data <- data[RowVar(x = data) > 0, , drop = FALSE]
   if (nrow(x = data) != 0) {
     svf.info <- FindSpatiallyVariableFeatures(

--- a/tests/testthat/test_spatial.R
+++ b/tests/testthat/test_spatial.R
@@ -418,3 +418,113 @@ test_that("FindSpatiallyVariableFeatures uses FOV cell names for the requested a
     "centroid-based boundary"
   )
 })
+
+# Degenerate inputs to FindSpatiallyVariableFeatures ---------------------------
+
+#' Returns a small assay plus matching coordinates for the tests below.
+build_svf_case <- function(counts) {
+  object <- suppressWarnings(CreateSeuratObject(counts = as.sparse(counts)))
+  object <- suppressWarnings(NormalizeData(object, verbose = FALSE))
+  list(
+    assay = object[["RNA"]],
+    coordinates = data.frame(
+      x = seq_len(ncol(counts)),
+      y = rev(seq_len(ncol(counts))),
+      row.names = colnames(counts)
+    )
+  )
+}
+
+svf_counts <- function(varying = 0L) {
+  cells <- paste0("cell", seq_len(12L))
+  counts <- matrix(
+    data = 3L,
+    nrow = 4L,
+    ncol = length(x = cells),
+    dimnames = list(paste0("gene", 1:4), cells)
+  )
+  for (i in seq_len(varying)) {
+    counts[i, ] <- sample(x = seq_along(cells))
+  }
+  return(counts)
+}
+
+test_that("FindSpatiallyVariableFeatures needs at least two cells", {
+  set.seed(42)
+  case <- build_svf_case(svf_counts(varying = 4L))
+  # Only the first row name is a real cell, which is enough to clear the check
+  # on 'spatial.location' but leaves a single column to compute variance over.
+  coordinates <- case$coordinates
+  rownames(x = coordinates) <- c(
+    rownames(x = coordinates)[1],
+    paste0("absent", seq_len(nrow(x = coordinates) - 1L))
+  )
+  expect_error(
+    FindSpatiallyVariableFeatures(
+      case$assay,
+      layer = "counts",
+      features = rownames(x = case$assay),
+      spatial.location = coordinates,
+      selection.method = "moransi",
+      verbose = FALSE
+    ),
+    "at least two"
+  )
+})
+
+test_that("FindSpatiallyVariableFeatures handles a single varying feature", {
+  for (method in c("moransi", "markvariogram")) {
+    set.seed(42)
+    case <- build_svf_case(svf_counts(varying = 1L))
+    result <- suppressWarnings(FindSpatiallyVariableFeatures(
+      case$assay,
+      layer = "counts",
+      features = rownames(x = case$assay),
+      spatial.location = case$coordinates,
+      selection.method = method,
+      nfeatures = 4L,
+      verbose = FALSE
+    ))
+    expect_equal(SpatiallyVariableFeatures(result, method = method), "gene1")
+  }
+})
+
+test_that("FindSpatiallyVariableFeatures warns when nothing varies", {
+  for (method in c("moransi", "markvariogram")) {
+    set.seed(42)
+    case <- build_svf_case(svf_counts(varying = 0L))
+    expect_warning(
+      result <- FindSpatiallyVariableFeatures(
+        case$assay,
+        layer = "counts",
+        features = rownames(x = case$assay),
+        spatial.location = case$coordinates,
+        selection.method = method,
+        verbose = FALSE
+      ),
+      "None of the requested features vary"
+    )
+    expect_identical(result, case$assay)
+  }
+})
+
+test_that("RunMarkVario returns one named entry per feature", {
+  set.seed(42)
+  n.cells <- 12L
+  positions <- data.frame(x = seq_len(n.cells), y = rev(seq_len(n.cells)))
+  # markvario() hands back a bare 'fv' for a single mark and a named list of
+  # them for several; the caller relies on always getting the list.
+  for (n.features in c(1L, 3L)) {
+    marks <- matrix(
+      data = rnorm(n = n.features * n.cells),
+      nrow = n.features,
+      dimnames = list(
+        paste0("gene", seq_len(n.features)),
+        paste0("cell", seq_len(n.cells))
+      )
+    )
+    mv <- RunMarkVario(spatial.location = positions, data = marks)
+    expect_named(mv, rownames(x = marks))
+    expect_true(all(vapply(mv, inherits, logical(1L), what = "fv")))
+  }
+})


### PR DESCRIPTION
The follow-up I offered in [my review of #10504](https://github.com/satijalab/seurat/pull/10504#pullrequestreview-5170058348), targeting `fix/findspvariable-fov` so it can be merged into that branch or ignored, whichever suits you.

One correction up front: I called the second finding "one word on the line just below the new guard." That was wrong. `drop = FALSE` is necessary but not sufficient, and writing the reproduction turned up two more shapes that reach the same code. Five in total, each ending in a message that says nothing about the cause.

## What breaks

| Input | Today | Cause |
|---|---|---|
| `spatial.location` with one matching row name | `argument is of length zero` | `RowVar()` divides by `ncol - 1` |
| Exactly one feature survives the variance filter | `argument is of length zero` | subset drops to a vector |
| ... with `selection.method = "markvariogram"` | `$ operator is invalid for atomic vectors` | `markvario()` returns a bare `fv` |
| `RunMarkVario()` under a parallel plan | silently wrong result | same, per chunk |
| No feature survives the variance filter | `attempt to set 'colnames' on an object with less than two dimensions` | `svf.info` is `c()` |

## The five

**1. The `!ncol(data)` guard lets a one-column matrix through.** `!any(cells %in% ...)` only needs a single match, so a `spatial.location` holding one real cell name and eleven that match nothing clears both new checks. `RowVar()` divides by `ncol - 1`, so every feature comes back `NaN`, `NaN > 0` is `NA`, and the subset degenerates before `nrow()` is reached. Widened to `ncol(data) < 2`, with a message that names the reason.

**2. `data[RowVar(data) > 0, ]` needs `drop = FALSE`.** With exactly one surviving feature it becomes a vector, `nrow()` returns NULL, and the line below raises the same `argument is of length zero`.

**3. `markvariogram` needs more than that.** `markvario()` returns a bare `fv` for a single mark and a named list of them for several. `ComputeRMetric()` iterates over its argument, so one surviving feature hit `$ operator is invalid for atomic vectors`. The single-mark case is now normalized to a list, the shape the caller already assumes.

**4. The same variable shape corrupts `RunMarkVario()` under a parallel plan, silently.** Features are split into one chunk per worker, and a chunk holding a single feature contributes its four `fv` columns to `unlist()` instead of one entry, so the names assigned afterwards run off the end:

```r
plan("multisession", workers = 2)
marks <- matrix(rnorm(36), nrow = 3, dimnames = list(paste0("g", 1:3), paste0("c", 1:12)))
RunMarkVario(spatial.location = pos, data = marks)
#> length 6, names g1, g2, g3, NA, NA, NA
```

Five features over two workers split 3 and 2, so neither chunk is size one and the result is fine, which is presumably why this went unnoticed. Each chunk is normalized the same way now, and subset with `drop = FALSE` so a one-feature chunk stays a matrix and `t()` keeps one row per cell.

**5. Nothing survives the variance filter.** `svf.info` is set to `c()` and both selection branches index into it. The empty branch reads as deliberate, so it now warns and returns the object unchanged rather than falling through.

## Scope

All five are reachable on `main`. Only the first sits downstream of the guard this branch adds; the rest are independent of your change but live in the same function, and the single-feature ones are on the path your new test exercises. Happy to split 4 out into its own PR against `main` if you would rather keep this branch tight, or drop any of it.

I did not touch the third point from my review, the "provide `spatial.location`" half of the segmentation message pointing at an argument `FindSpatiallyVariableFeatures.Seurat` does not have. That is wording on your new code, so it seemed yours to decide.

Nor did I add a test for 4: nothing in `tests/testthat` currently sets a `future` plan, and introducing `multisession` there is a convention change plus a CI cost. There is a direct shape test for `RunMarkVario` with one feature instead, which covers the sequential half. The reproduction above is there if you would rather have the parallel case tested.

## Tests

Four new blocks in `test_spatial.R`: the two-cell minimum, a single varying feature under both selection methods, the warn-and-return path under both, and `RunMarkVario` shape for one and three features. Each fails on this branch without the corresponding fix.

Full suite with `NOT_CRAN=true`, R 4.6.1, macOS arm64: 17 files, 1209 expectations, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
